### PR TITLE
Normalize values for fiducial_alignment_status

### DIFF
--- a/ingestion_tools/dataset_configs/10002.yaml
+++ b/ingestion_tools/dataset_configs/10002.yaml
@@ -91,7 +91,7 @@ tiltseries:
   alignment_binning_factor: ~ # We may need to calculate this for each tilt if we can identify aligned & unaligned files in the bucket.
 tomograms:
   ctf_corrected: false
-  fiducial_alignment_status: false
+  fiducial_alignment_status: NON_FIDUCIAL
   offset:
     x: 0
     y: 0

--- a/ingestion_tools/dataset_configs/10004.yaml
+++ b/ingestion_tools/dataset_configs/10004.yaml
@@ -166,7 +166,6 @@ standardization_config:
     - '{run_name}/{run_name}.mdoc-dose_filt.xf'
     - '{run_name}/{run_name}.mdoc'
   tiltseries_glob: '{run_name}/*.st'
-  rawtlt_files: ~
   tomo_format: mrc
   tomo_glob: '{run_name}/*.rec'
   tomo_regex: .*\.rec

--- a/ingestion_tools/dataset_configs/10010.yaml
+++ b/ingestion_tools/dataset_configs/10010.yaml
@@ -78,7 +78,7 @@ tiltseries:
   alignment_binning_factor: ~
 tomograms:
   voxel_spacing: 'float {tomograms_voxel_spacing}'
-  fiducial_alignment_status: false
+  fiducial_alignment_status: NON_FIDUCIAL
   offset:
     x: 0
     y: 0

--- a/ingestion_tools/scripts/common/normalize_fields.py
+++ b/ingestion_tools/scripts/common/normalize_fields.py
@@ -1,0 +1,11 @@
+def normalize_fiducial_alignment(status):
+    # Grant jensen configs use true/false
+    if status == True:
+        return "FIDUCIAL"
+    if status == False:
+        return "NON_FIDUCIAL"
+    # Everybody else uses proper values
+    if status.upper() in ["FIDUCIAL", "NON_FIDUCIAL"]:
+        return status.upper()
+    # Any other values are not allowed.
+    raise Exception("Fiducial alignment status must be FIDUCIAL or NON_FIDUCIAL")

--- a/ingestion_tools/scripts/gjensen_config.py
+++ b/ingestion_tools/scripts/gjensen_config.py
@@ -10,6 +10,7 @@ from typing import Any, Callable
 import click
 import yaml
 
+from common.normalize_fields import normalize_fiducial_alignment
 from common.fs import LocalFilesystem
 from functools import partial
 
@@ -243,6 +244,7 @@ def to_tomogram(
         print(f'{data["run_name"]} has {len(data["tomograms"].values())} tomograms: '
               f'{",".join(set(data["tomograms"].keys()))}')
 
+    tomogram["fiducial_alignment_status"] = normalize_fiducial_alignment(tomogram["fiducial_alignment_status"])
     tomogram["offset"] = {"x": 0, "y": 0, "z": 0}
     tomogram["affine_transformation_matrix"] = [
         [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]

--- a/ingestion_tools/scripts/importers/tomogram.py
+++ b/ingestion_tools/scripts/importers/tomogram.py
@@ -4,6 +4,8 @@ from common.metadata import TomoMetadata
 
 from importers.base_importer import VolumeImporter
 from importers.key_image import KeyImageImporter
+from common.normalize_fields import normalize_fiducial_alignment
+
 
 if TYPE_CHECKING:
     from importers.run import RunImporter
@@ -14,6 +16,7 @@ else:
 class TomogramImporter(VolumeImporter):
     type_key = "tomogram"
     cached_find_results: dict[str, Any] = {}
+
 
     def get_voxel_spacing(self):
         if self.config.tomo_format != "mrc":
@@ -40,6 +43,10 @@ class TomogramImporter(VolumeImporter):
             base_metadata["voxel_spacing"] = float(base_metadata["voxel_spacing"])
         else:
             merge_data["voxel_spacing"] = round(self.get_voxel_spacing(), 3)
+        # Enforce our schema for these values.
+        base_metadata["fiducial_alignment_status"] = normalize_fiducial_alignment(
+            base_metadata.get("fiducial_alignment_status")
+        )
 
         metadata = TomoMetadata(self.config.fs, base_metadata)
         if write:


### PR DESCRIPTION
This should prevent us from winding up with `true/false/FIDUCIAL/NON_FIDUCIAL` values in our db when our metadata schema specifically calls for the only valid values to be `FIDUCIAL` and `NON_FIDUCIAL`.

Once this is merged I'll update the DB as well.