### PR TITLE
Updaing ingestor image to arm platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
     environment:
       HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:postgres@db:5432/cryoet
   ingestor:
-    platform: linux/amd64
+    platform: linux/arm64
     profiles: ["ingestor"]
     image: ingestor
     build:


### PR DESCRIPTION
### Description
These fixes build errors for the GitHub workflow as we are using `ARM64` for it. 

### Todo:

Update infra for batch workflow to also use `arm64`.