### PR TITLE
Fix ingestion of segmentation masks

### DIFF
--- a/ingestion_tools/scripts/common/image.py
+++ b/ingestion_tools/scripts/common/image.py
@@ -217,6 +217,7 @@ def scale_maskfile(
     label: int,
     scale_z_axis: bool = True,
     write: bool = True,
+    voxel_spacing=None,
 ):
     mc = MaskConverter(fs, tomo_filename, label)
     pyramid = mc.make_pyramid(scale_z_axis=scale_z_axis)
@@ -226,6 +227,7 @@ def scale_maskfile(
         pyramid,
         f"{output_prefix}.mrc",
         write,
+        voxel_spacing=voxel_spacing,
     )
 
 

--- a/ingestion_tools/scripts/common/image.py
+++ b/ingestion_tools/scripts/common/image.py
@@ -71,7 +71,7 @@ class TomoConverter:
         mrcfiles.append(os.path.basename(filename))
 
         if write:
-            newfile = mrcfile.new(filename, self.data, overwrite=True)
+            newfile = mrcfile.new(filename, pyramid[0], overwrite=True)
             self.update_headers(newfile, header_mapper, voxel_spacing)
             newfile.flush()
             newfile.close()

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -120,8 +120,9 @@ class SemanticSegmentationMaskFile(VolumeAnnotationSource):
 
     def convert(self, fs: FileSystemApi, input_prefix: str, output_prefix: str, voxel_spacing: float = None):
         input_file = self.get_source_file(fs, input_prefix)
-        return scale_maskfile(fs, self.get_output_filename(output_prefix), input_file, self.label, write=True,
-                              voxel_spacing=voxel_spacing)
+        return scale_maskfile(
+            fs, self.get_output_filename(output_prefix), input_file, self.label, write=True, voxel_spacing=voxel_spacing
+        )
 
     def is_valid(self, fs: FileSystemApi, input_prefix: str) -> bool:
         try:

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -85,12 +85,12 @@ class SegmentationMaskFile(VolumeAnnotationSource):
         glob_string: str,
         glob_vars: dict[str, str],
         file_format: str,
-        is_viz_default: bool = False,
+        is_visualization_default: bool = False,
     ):
         self.glob_string = glob_string.format(**glob_vars)
         self.file_format = file_format
         self.shape = shape
-        self.is_viz_default = is_viz_default
+        self.is_viz_default = is_visualization_default
         if self.file_format not in ["mrc"]:
             raise NotImplementedError("We only support MRC files for segmentation masks")
 
@@ -107,13 +107,13 @@ class SemanticSegmentationMaskFile(VolumeAnnotationSource):
         glob_vars: dict[str, str],
         file_format: str,
         mask_label: int = 1,  # No explicit label means we are dealing with a binary mask already
-        is_viz_default: bool = False,
+        is_visualization_default: bool = False,
     ):
         self.glob_string = glob_string.format(**glob_vars)
         self.file_format = file_format
         self.shape = "SegmentationMask"  # Don't expose SemanticSegmentationMask to the public portal.
         self.label = mask_label
-        self.is_viz_default = is_viz_default
+        self.is_viz_default = is_visualization_default
 
         if self.file_format not in ["mrc"]:
             raise NotImplementedError("We only support MRC files for segmentation masks")
@@ -138,7 +138,7 @@ class PointFile(BaseAnnotationSource):
         glob_vars: dict[str, str],
         file_format: str,
         columns: str,
-        is_viz_default: bool = False,
+        is_visualization_default: bool = False,
         delimiter: str = ",",
     ):
         self.glob_string = glob_string.format(**glob_vars)
@@ -146,7 +146,7 @@ class PointFile(BaseAnnotationSource):
         self.columns = columns
         self.shape = shape
         self.delimiter = delimiter
-        self.is_viz_default = is_viz_default
+        self.is_viz_default = is_visualization_default
         if self.file_format not in ["csv", "csv_with_header"]:
             raise NotImplementedError("We only support CSV files for Point files")
 
@@ -170,16 +170,16 @@ class PointFile(BaseAnnotationSource):
         annotation_set = []
         with fs.open(csvfilename, "r") as data:
             points = csv.reader(data, delimiter=self.delimiter)
-        if skip_header:
-            next(points)
-        for coord in points:
-            annotation_set.append(
-                self.point(
-                    float(coord[coord_order[0]]),
-                    float(coord[coord_order[1]]),
-                    float(coord[coord_order[2]]),
-                ),
-            )
+            if skip_header:
+                next(points)
+            for coord in points:
+                annotation_set.append(
+                    self.point(
+                        float(coord[coord_order[0]]),
+                        float(coord[coord_order[1]]),
+                        float(coord[coord_order[2]]),
+                    ),
+                )
         return annotation_set
 
     def get_metadata(self, output_prefix: str):
@@ -227,7 +227,7 @@ class OrientedPointFile(PointFile):
         file_format: str,
         binning: int,
         glob_string: str,
-        is_viz_default: bool = False,
+        is_visualization_default: bool = False,
         order: str | None = None,
         filter_value: str | None = None,
     ):
@@ -239,7 +239,7 @@ class OrientedPointFile(PointFile):
         self.glob_string = glob_string.format(**glob_vars)
         self.order = order
         self.filter_value = ""
-        self.is_viz_default = is_viz_default
+        self.is_viz_default = is_visualization_default
         if filter_value:
             self.filter_value = filter_value.format(**glob_vars)
         valid_formats = self.map_functions.keys()

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -39,7 +39,7 @@ class AnnotationMap(TypedDict):
 
 
 class BaseAnnotationSource:
-    is_viz_default: bool
+    is_visualization_default: bool
 
     def get_source_file(self, fs: FileSystemApi, input_prefix: str):
         source_path = os.path.join(input_prefix, self.glob_string)
@@ -71,7 +71,7 @@ class VolumeAnnotationSource(BaseAnnotationSource):
                 "format": fmt,
                 "path": self.get_output_filename(output_prefix, fmt),
                 "shape": self.shape,
-                "is_visualization_default": self.is_viz_default,
+                "is_visualization_default": self.is_visualization_default,
             }
             for fmt in ["zarr", "mrc"]
         ]
@@ -90,7 +90,7 @@ class SegmentationMaskFile(VolumeAnnotationSource):
         self.glob_string = glob_string.format(**glob_vars)
         self.file_format = file_format
         self.shape = shape
-        self.is_viz_default = is_visualization_default
+        self.is_visualization_default = is_visualization_default
         if self.file_format not in ["mrc"]:
             raise NotImplementedError("We only support MRC files for segmentation masks")
 
@@ -113,7 +113,7 @@ class SemanticSegmentationMaskFile(VolumeAnnotationSource):
         self.file_format = file_format
         self.shape = "SegmentationMask"  # Don't expose SemanticSegmentationMask to the public portal.
         self.label = mask_label
-        self.is_viz_default = is_visualization_default
+        self.is_visualization_default = is_visualization_default
 
         if self.file_format not in ["mrc"]:
             raise NotImplementedError("We only support MRC files for segmentation masks")
@@ -121,7 +121,12 @@ class SemanticSegmentationMaskFile(VolumeAnnotationSource):
     def convert(self, fs: FileSystemApi, input_prefix: str, output_prefix: str, voxel_spacing: float = None):
         input_file = self.get_source_file(fs, input_prefix)
         return scale_maskfile(
-            fs, self.get_output_filename(output_prefix), input_file, self.label, write=True, voxel_spacing=voxel_spacing,
+            fs,
+            self.get_output_filename(output_prefix),
+            input_file,
+            self.label,
+            write=True,
+            voxel_spacing=voxel_spacing,
         )
 
     def is_valid(self, fs: FileSystemApi, input_prefix: str) -> bool:
@@ -148,7 +153,7 @@ class PointFile(BaseAnnotationSource):
         self.columns = columns
         self.shape = shape
         self.delimiter = delimiter
-        self.is_viz_default = is_visualization_default
+        self.is_visualization_default = is_visualization_default
         if self.file_format not in ["csv", "csv_with_header"]:
             raise NotImplementedError("We only support CSV files for Point files")
 
@@ -190,7 +195,7 @@ class PointFile(BaseAnnotationSource):
                 "format": "ndjson",
                 "path": self.get_output_filename(output_prefix),
                 "shape": self.shape,
-                "is_visualization_default": self.is_viz_default,
+                "is_visualization_default": self.is_visualization_default,
             },
         ]
         return metadata
@@ -241,7 +246,7 @@ class OrientedPointFile(PointFile):
         self.glob_string = glob_string.format(**glob_vars)
         self.order = order
         self.filter_value = ""
-        self.is_viz_default = is_visualization_default
+        self.is_visualization_default = is_visualization_default
         if filter_value:
             self.filter_value = filter_value.format(**glob_vars)
         valid_formats = self.map_functions.keys()

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -121,7 +121,7 @@ class SemanticSegmentationMaskFile(VolumeAnnotationSource):
     def convert(self, fs: FileSystemApi, input_prefix: str, output_prefix: str, voxel_spacing: float = None):
         input_file = self.get_source_file(fs, input_prefix)
         return scale_maskfile(
-            fs, self.get_output_filename(output_prefix), input_file, self.label, write=True, voxel_spacing=voxel_spacing
+            fs, self.get_output_filename(output_prefix), input_file, self.label, write=True, voxel_spacing=voxel_spacing,
         )
 
     def is_valid(self, fs: FileSystemApi, input_prefix: str) -> bool:

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -120,7 +120,8 @@ class SemanticSegmentationMaskFile(VolumeAnnotationSource):
 
     def convert(self, fs: FileSystemApi, input_prefix: str, output_prefix: str, voxel_spacing: float = None):
         input_file = self.get_source_file(fs, input_prefix)
-        return scale_maskfile(fs, self.get_output_filename(output_prefix), input_file, self.label, write=True)
+        return scale_maskfile(fs, self.get_output_filename(output_prefix), input_file, self.label, write=True,
+                              voxel_spacing=voxel_spacing)
 
     def is_valid(self, fs: FileSystemApi, input_prefix: str) -> bool:
         try:


### PR DESCRIPTION
Fixing https://github.com/chanzuckerberg/cryoet-data-portal/issues/502

1. The labels in segmentation masks were not correctly separated because `pyramid_to_mrc` in `common/image.py` took the original data, not the one from the pyramid (only the pyramid data is processed)

2. AnnotationSource classes in `importers/annotation.py` expected the keyword argument `is_viz_default`, but the YAML dict has `is_visualization_default`

3.  Import of `Point` annotations failed due to faulty indenting in `Point.load` in `importers/annotation.py`

4. Voxel spacing of the ingested segmentation masks was not correct, because `scale_maskfile` in `common/image.py` was not yet using the new override mechanism for the `voxel_spacing` (the correct `voxel_spacing` was actually passed inside `AnnotationImporter.import_annotations`, but not taken into account in the `SemanticSegmentationMaskFile.convert` method.