### PR TITLE
Add LinkML schema for metadata files and the ability to generate docs and pydantic classes from the schema.

### DIFF
--- a/schema/v1.1.0/Makefile
+++ b/schema/v1.1.0/Makefile
@@ -1,0 +1,13 @@
+.DEFAULT_GOAL := build
+
+.PHONY: clean
+clean:
+	rm -rf metadata-docs
+	rm -rf metadata_materialized.yaml
+	rm -rf metadata_models.py
+
+.PHONY: build
+build:
+	python schema.py materialize metadata.yaml common.yaml metadata_materialized.yaml
+	gen-doc -d metadata-docs --no-mergeimports  --hierarchical-class-view --stacktrace metadata_materialized.yaml
+	gen-pydantic --pydantic-version 2 metadata_materialized.yaml > metadata_models.py

--- a/schema/v1.1.0/Makefile
+++ b/schema/v1.1.0/Makefile
@@ -11,3 +11,4 @@ build:
 	python schema.py materialize metadata.yaml common.yaml metadata_materialized.yaml
 	gen-doc -d metadata-docs --no-mergeimports  --hierarchical-class-view --stacktrace metadata_materialized.yaml
 	gen-pydantic --pydantic-version 2 metadata_materialized.yaml > metadata_models.py
+	black -l 88 metadata_models.py

--- a/schema/v1.1.0/README.md
+++ b/schema/v1.1.0/README.md
@@ -1,0 +1,50 @@
+# cryoET data portal metadata schema
+
+This directory contains the metadata schema for the cryoET data portal. Browse contained classes [here](metadata-docs/index.md).
+
+Metadata file and directory layout specs:
+
+<pre>
+[dataset_identifier]/
+|-- <a href="metadata-docs/Dataset.md">dataset_metadata.json</a>
+|-- [run_name]/
+|   |-- run_metadata.json
+|   |-- Frames/
+|   |   |-- [tiff|eer|mrc]
+|   |   |-- Gain_reference.mrc|dm4
+|   |   |-- frame_acquisition_order.json
+|   |-- TiltSeries/
+|   |   |-- <a href="metadata-docs/TiltSeries.md">tiltseries_metadata.json</a>
+|   |   |-- [run_name].mrc
+|   |   |-- [run_name].zarr/
+|   |   |   |-- [subdirectories according to <a href="https://ngff.openmicroscopy.org/latest/">OME-NGFF spec</a> at 100%, 50% and 25% scale]
+|   |   |-- [run_name].mdoc [optional, sometimes]
+|   |   |-- [run_name].rawtlt [optional, sometimes]
+|   |   |-- [run_name].tlt [optional, sometimes]
+|   |-- Tomograms/
+|   |   |-- VoxelSpacing[xx.yyy]
+|   |   |   |-- CanonicalTomogram
+|   |   |   |   |-- <a href="metadata-docs/Tomogram.md">tomogram_metadata.json</a>
+|   |   |   |   |-- neuroglancer_config.json
+|   |   |   |   |-- [run_name].mrc
+|   |   |   |   |-- [run_name].xf [optional, sometimes]
+|   |   |   |   |-- [run_name].zarr/
+|   |   |   |   |   |-- [subdirectories according to <a href="https://ngff.openmicroscopy.org/latest/">OME-NGFF spec</a> at 100%, 50% and 25% scale]
+|   |   |   |-- Annotations/
+|   |   |   |   |-- XXX_[object_name]_[version]_point.ndjson
+|   |   |   |   |-- <a href="metadata-docs/Annotation.md">XXX_[object_name]_[version].json</a>
+|   |   |   |   |-- YYY_[object_name]_[version]_segmentationmask.mrc
+|   |   |   |   |-- YYY_[object_name]_[version]_segmentationmask.zarr
+|   |   |   |   |   |-- [subdirectories according to <a href="https://ngff.openmicroscopy.org/latest/">OME-NGFF spec</a> at 100%, 50% and 25% scale]
+|   |   |   |   |-- <a href="metadata-docs/Annotation.md">YYY_[object_name]_[version].json</a>
+
+</pre>
+
+## Building the schema and docs
+
+To build the schema, markdown docs and pydantic classes:
+
+```bash
+cd schema/v1.1.0
+make build
+```

--- a/schema/v1.1.0/common.yaml
+++ b/schema/v1.1.0/common.yaml
@@ -1,0 +1,697 @@
+id: https://cryoetdataportal.czscience.com/schema-docs/common
+name: cdp-common
+version: 1.1.0
+prefixes:
+  linkml: https://w3id.org/linkml/
+  cdp-common: https://cryoetdataportal.czscience.com/schema/common/
+  ROR: https://ror.org/
+  UBERON: http://purl.obolibrary.org/obo/UBERON_
+  CL: http://purl.obolibrary.org/obo/CL_
+  GO: http://purl.obolibrary.org/obo/GO_
+  IAO: http://purl.obolibrary.org/obo/IAO_
+  FOAF: http://xmlns.com/foaf/0.1/
+imports:
+  - linkml:types
+default_prefix: cdp-common
+default_range: string
+
+
+slots:
+  # ============================================================================
+  # Common Identifiers
+  # ============================================================================
+  orcid:
+    description: >-
+      A unique, persistent identifier for researchers, provided by ORCID.
+    range: string
+    pattern: '[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$'
+    exact_mappings:
+      - IAO:0000708
+
+  affiliation_identifier:
+    description: >-
+      A Research Organization Registry (ROR) identifier.
+    range: string
+    pattern: '^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$'
+  # ============================================================================
+
+  # ============================================================================
+  # Dates (re-used in Dataset, Tomogram, Tiltseries, Annotation)
+  # ============================================================================
+  deposition_date:
+    range: date
+    required: true
+    description: >-
+      The date a data item was received by the cryoET data portal.
+
+  release_date:
+    range: date
+    required: true
+    description: >-
+      The date a data item was received by the cryoET data portal.
+
+  last_modified_date:
+    range: date
+    required: true
+    description: >-
+      The date a piece of data was last modified on the cryoET data portal.
+  # ============================================================================
+
+  # ============================================================================
+  # Author slots
+  # ============================================================================
+  author_name:
+    range: string
+    required: true
+    description: >-
+      The full name of the author.
+    close_mappings:
+      - FOAF:name
+
+  author_email:
+    range: string
+    description: >-
+      The email address of the author.
+    close_mappings:
+      - FOAF:mbox
+
+  author_affiliation_name:
+    range: string
+    description: >-
+      The name of the author's affiliation.
+
+  author_affiliation_address:
+    range: string
+    description: >-
+      The address of the author's affiliation.
+
+  author_corresponding_author_status:
+    range: boolean
+    description: >-
+      Whether the author is a corresponding author.
+
+  author_primary_author_status:
+    range: boolean
+    description: >-
+      Whether the author is a primary author.
+
+  author_primary_annotator_status:
+    range: boolean
+    description: >-
+      Whether the author is a primary annotator.
+
+  author_list_order:
+    range: integer
+    required: true
+    description: >-
+      The position of the author in the author list.
+  # ============================================================================
+
+  # ============================================================================
+  # Dataset slots
+  # ============================================================================
+  dataset_identifier:
+    identifier: true
+    range: integer
+    required: true
+    description: >-
+      An identifier for a CryoET dataset, assigned by the Data Portal. Used to identify the dataset as the directory 
+      name in data tree.
+  dataset_title:
+    range: string
+    required: true
+    description: >-
+      Title of a CryoET dataset.
+  dataset_description:
+    range: string
+    required: true
+    description: >-
+      A short description of a CryoET dataset, similar to an abstract for a journal article or dataset.
+
+  dataset_key_photo_url:
+    range: string
+    description: >-
+      URL for the dataset preview image.
+  dataset_key_photo_thumbnail_url:
+    range: string
+    description: >- 
+      URL for the thumbnail of preview image.
+  dataset_s3_prefix:
+    range: string
+    description: >-
+      The S3 public bucket path where this dataset is contained.
+  dataset_https_prefix:
+    range: string
+    description: >-
+      The HTTPS directory path where this dataset is contained.
+  # ============================================================================
+
+  # ============================================================================
+  # Funding information slots
+  # ============================================================================
+  funding_agency_name:
+    range: string
+    recommended: true
+    description: The name of the funding source.
+  funding_grant_id:
+    range: string
+    recommended: true
+    description: Grant identifier provided by the funding agency
+  # ============================================================================
+
+  # ============================================================================
+  # Experimental metadata slots
+  # ============================================================================
+  # Organism/Species
+  organism_name:
+    range: string
+    recommended: true
+    description: >-
+      Name of the organism from which a biological sample used in a CryoET study is derived from, e.g. homo sapiens.
+  organism_taxid:
+    range: string
+    recommended: true
+    description: >-
+      NCBI taxonomy identifier for the organism, e.g. 9606
+
+  # Tissue
+  tissue_name:
+    range: string
+    recommended: true
+    description: >-
+      Name of the tissue from which a biological sample used in a CryoET study is derived from.
+  tissue_id:
+    range: string
+    recommended: true
+    description: >-
+      The UBERON identifier for the tissue.
+
+  # Cell Type
+  cell_name:
+    range: string
+    recommended: true
+    description: >-
+      Name of the cell type from which a biological sample used in a CryoET study is derived from.
+  cell_type_id:
+    range: string
+    recommended: true
+    description: >-
+      Cell Ontology identifier for the cell type
+
+  # Cell Strain
+  cell_strain_name:
+    range: string
+    recommended: true
+    description: >-
+      Cell line or strain for the sample.
+  cell_strain_id:
+    range: string
+    recommended: true
+    description: >-
+      Link to more information about the cell strain.
+
+  # Cell Component
+  cell_component_name:
+    range: string
+    recommended: true
+    description: >-
+      Name of the cellular component.
+  cell_component_id:
+    range: string
+    recommended: true
+    description: >-
+      The GO identifier for the cellular component.
+
+  # Preparation
+  preparation_sample_type:
+    range: sample_type_enum
+    required: true
+    description: >-
+      Type of sample imaged in a CryoET study.
+  sample_preparation:
+    range: string
+    recommended: true
+    description: >-
+      Describes how the sample was prepared.
+  grid_preparation:
+    range: string
+    recommended: true
+    description: >-
+      Describes Cryo-ET grid preparation.
+  preparation_other_setup:
+    range: string
+    recommended: true
+    description: >-
+      Describes other setup not covered by sample preparation or grid preparation that may make this dataset unique in  
+      the same publication.
+  # ============================================================================
+
+  # ============================================================================
+  # Run slots
+  # ============================================================================
+
+  # ============================================================================
+
+  # ============================================================================
+  # TomogramVoxelSpacing slots
+  # ============================================================================
+
+  # ============================================================================
+
+  # ============================================================================
+  # TiltSeries slots
+  # ============================================================================
+  #  id:
+  #    range: integer
+  #    description: Numeric identifier for this tilt series (this may change!)
+  #run (Run): An object relationship with the run this tiltseries is a part of
+  tiltseries_run_id:
+    range: integer
+    description: Reference to the run this tiltseries is a part of
+  tiltseries_acceleration_voltage:
+    range: integer
+    description: Electron Microscope Accelerator voltage in volts
+    unit:
+      descriptive_name: volts
+      symbol: V
+  tiltseries_aligned_tiltseries_binning:
+    range: integer
+    description: Binning factor of the aligned tilt series
+  tiltseries_binning_from_frames:
+    range: float
+    description: Describes the binning factor from frames to tilt series file
+  tiltseries_camera_manufacturer:
+    range: string
+    description: Name of the camera manufacturer
+  tiltseries_camera_model:
+    range: string
+    description: Camera model name
+  tiltseries_data_acquisition_software:
+    range: string
+    description: Software used to collect data
+  tiltseries_frames_count:
+    range: integer
+    description: Number of frames associated with this tiltseries
+  tiltseries_https_alignment_file:
+    range: string
+    description: HTTPS path to the alignment file for this tiltseries
+  tiltseries_https_angle_list:
+    range: string
+    description: HTTPS path to the angle list file for this tiltseries
+  tiltseries_https_collection_metadata:
+    range: string
+    description: HTTPS path to the collection metadata file for this tiltseries
+  tiltseries_https_mrc_bin1:
+    range: string
+    description: HTTPS path to this tiltseries in MRC format (no scaling)
+  tiltseries_https_omezarr_dir:
+    range: string
+    description: HTTPS path to this tiltseries in multiscale OME-Zarr format
+  tiltseries_microscope_additional_info:
+    range: string
+    description: Other microscope optical setup information, in addition to energy filter, phase plate and image corrector
+  tiltseries_microscope_energy_filter:
+    range: string
+    description: Energy filter setup used
+  tiltseries_microscope_image_corrector:
+    range: string
+    description: Image corrector setup
+  tiltseries_microscope_manufacturer:
+    range: string
+    description: Name of the microscope manufacturer
+  tiltseries_microscope_model:
+    range: string
+    description: Microscope model name
+  tiltseries_microscope_phase_plate:
+    range: string
+    description: Phase plate configuration
+  tiltseries_pixel_spacing:
+    range: float
+    description: Pixel spacing for the tilt series
+    unit:
+      descriptive_name: Angstroms per pixel
+      symbol: Å/px
+  tiltseries_related_empiar_entry:
+    range: string
+    description: If a tilt series is deposited into EMPIAR, enter the EMPIAR dataset identifier
+  tiltseries_s3_alignment_file:
+    range: string
+    description: S3 path to the alignment file for this tiltseries
+  tiltseries_s3_angle_list:
+    range: string
+    description: S3 path to the angle list file for this tiltseries
+  tiltseries_s3_collection_metadata:
+    range: string
+    description: S3 path to the collection metadata file for this tiltseries
+  tiltseries_s3_mrc_bin1:
+    range: string
+    description: S3 path to this tiltseries in MRC format (no scaling)
+  tiltseries_s3_omezarr_dir:
+    range: string
+    description: S3 path to this tiltseries in multiscale OME-Zarr format
+  tiltseries_spherical_aberration_constant:
+    range: float
+    description: Spherical Aberration Constant of the objective lens in millimeters
+    unit:
+      descriptive_name: millimeters
+      symbol: mm
+  tiltseries_tilt_axis:
+    range: float
+    description: Rotation angle in degrees
+    unit:
+      descriptive_name: degrees
+      symbol: °
+  tiltseries_tilt_max:
+    range: float
+    description: Maximal tilt angle in degrees
+    unit:
+      descriptive_name: degrees
+      symbol: °
+  tiltseries_tilt_min:
+    range: float
+    description: Minimal tilt angle in degrees
+    unit:
+      descriptive_name: degrees
+      symbol: °
+  tiltseries_tilt_range:
+    range: float
+    description: Total tilt range in degrees
+    unit:
+      descriptive_name: degrees
+      symbol: °
+  tiltseries_tilt_series_quality:
+    range: integer
+    description: Author assessment of tilt series quality within the dataset (1-5, 5 is best)
+  tiltseries_tilt_step:
+    range: float
+    description: Tilt step in degrees
+    unit:
+      descriptive_name: degrees
+      symbol: °
+  tiltseries_tilting_scheme:
+    range: string
+    description: The order of stage tilting during acquisition of the data
+  tiltseries_total_flux:
+    range: float
+    description: Number of Electrons reaching the specimen in a square Angstrom area for the entire tilt series
+    unit:
+      descriptive_name: electrons per square Angstrom
+      symbol: e^-/Å^2
+  # ============================================================================
+
+
+  # ============================================================================
+  # Tomogram slots
+  # ============================================================================
+  tomogram_affine_transformation_matrix:
+    range: string
+    description: The flip or rotation transformation of this author submitted tomogram is indicated here
+  tomogram_ctf_corrected:
+    range: boolean
+    description: Whether this tomogram is CTF corrected
+  #dataset (Dataset): An object relationship with the dataset this tomogram is a part of
+  tomogram_dataset_id:
+    range: integer
+    description: Reference to the dataset this tomogram is a part of
+  tomogram_fiducial_alignment_status:
+    range: fiducial_alignment_status_enum
+    description: Whether the tomographic alignment was computed based on fiducial markers.
+  tomogram_https_mrc_scale0:
+    range: string
+    description: HTTPS path to this tomogram in MRC format (no scaling)
+  tomogram_https_omezarr_dir:
+    range: string
+    description: HTTPS path to this tomogram in multiscale OME-Zarr format
+  tomogram_is_canonical:
+    range: boolean
+    description: Is this tomogram considered the canonical tomogram for the run experiment?
+  tomogram_key_photo_thumbnail_url:
+    range: string
+    description: URL for the thumbnail of key photo
+  tomogram_key_photo_url:
+    range: string
+    description: URL for the key photo
+  tomogram_name:
+    range: string
+    description: Short name for this tomogram
+  tomogram_neuroglancer_config:
+    range: string
+    description: the compact json of neuroglancer config
+  tomogram_offset_x:
+    range: integer
+    description: x offset data relative to the canonical tomogram in pixels
+    unit:
+      descriptive_name: pixels
+      symbol: px
+  tomogram_offset_y:
+    range: integer
+    description: y offset data relative to the canonical tomogram in pixels
+    unit:
+      descriptive_name: pixels
+      symbol: px
+  tomogram_offset_z:
+    range: integer
+    description: z offset data relative to the canonical tomogram in pixels
+    unit:
+      descriptive_name: pixels
+      symbol: px
+  tomogram_processing:
+    range: string
+    description: Describe additional processing used to derive the tomogram
+  tomogram_processing_software:
+    range: string
+    description: Processing software used to derive the tomogram
+  tomogram_reconstruction_method:
+    range: string
+    description: Describe reconstruction method (Weighted back-projection, SART, SIRT)
+  tomogram_reconstruction_software:
+    range: string
+    description: Name of software used for reconstruction
+  tomogram_s3_mrc_scale0:
+    range: string
+    description: S3 path to this tomogram in MRC format (no scaling)
+  tomogram_s3_omezarr_dir:
+    range: string
+    description: S3 path to this tomogram in multiscale OME-Zarr format
+  tomogram_scale0_dimensions:
+    range: string
+    description: comma separated x,y,z dimensions of the unscaled tomogram
+  tomogram_scale1_dimensions:
+    range: string
+    description: comma separated x,y,z dimensions of the scale1 tomogram
+  tomogram_scale2_dimensions:
+    range: string
+    description: comma separated x,y,z dimensions of the scale2 tomogram
+  tomogram_size_x:
+    range: integer
+    description: Number of pixels in the 3D data fast axis
+  tomogram_size_y:
+    range: integer
+    description: Number of pixels in the 3D data medium axis
+  tomogram_size_z:
+    range: integer
+    description: Number of pixels in the 3D data slow axis.  This is the image projection direction at zero stage tilt
+  tomogram_version:
+    range: string
+    description: Version of tomogram using the same software and post-processing. Version of tomogram using the same software and post-processing. This will be presented as the latest version
+  #tomogram_voxel_spacing (TomogramVoxelSpacing): An object relationship with a specific voxel spacing for this experiment run
+  tomogram_type:
+    range: string
+    description: "Tomogram purpose (ex: CANONICAL)"
+  tomogram_voxel_spacing:
+    range: float
+    description: Voxel spacing equal in all three axes in angstroms
+    unit:
+      descriptive_name: Angstroms per voxel
+      symbol: Å/voxel
+  # ============================================================================
+
+  # ============================================================================
+  # Annotation slots
+  # ============================================================================
+  #id (int): Numeric identifier (May change!)
+  annotation_method:
+    range: string
+    description: Describe how the annotation is made (e.g. Manual, crYoLO, Positive Unlabeled Learning, template matching)
+  annotation_method_type:
+    range: annotation_method_type_enum
+    description: Classification of the annotation method based on supervision.
+  annotation_publication:
+    range: string
+    description: DOIs for publications that describe the dataset. Use a comma to separate multiple DOIs.
+  annotation_software:
+    range: string
+    description: Software used for generating this annotation
+  #authors (list[Author]): An array relationship with the authors of this annotation
+  annotation_confidence_precision:
+    range: float
+    description: Describe the confidence level of the annotation. Precision is defined as the % of annotation objects being true positive
+  annotation_confidence_recall:
+    range: float
+    description: Describe the confidence level of the annotation. Recall is defined as the % of true positives being annotated correctly
+  #deposition_date (date): Date when an annotation set is initially received by the Data Portal.
+  annotation_ground_truth_status:
+    range: boolean
+    description: Whether an annotation is considered ground truth, as determined by the annotator.
+  annotation_ground_truth_used:
+    range: string
+    description: Annotation filename used as ground truth for precision and recall
+  https_metadata_path:
+    range: string
+    description: HTTPS path for the metadata json file for this annotation
+  #last_modified_date (date): Date when an annotation was last modified in the Data Portal
+  annotation_object_count:
+    range: integer
+    description: Number of objects identified
+  annotation_object_description:
+    range: string
+    description: A textual description of the annotation object, can be a longer description to include additional information not covered by the Annotation object name and state.
+  annotation_object_id:
+    range: string
+    description: Gene Ontology Cellular Component identifier for the annotation object
+  annotation_object_name:
+    range: string
+    description: Name of the object being annotated (e.g. ribosome, nuclear pore complex, actin filament, membrane)
+  annotation_object_state:
+    range: string
+    description: Molecule state annotated (e.g. open, closed)
+  #release_date (date): Date when annotation data is made public by the Data Portal.
+  #tomogram_voxel_spacing (TomogramVoxelSpacing): An object relationship with a specific voxel spacing for this annotation
+  tomogram_voxel_spacing_id:
+    range: integer
+    description: Reference to the tomogram voxel spacing group this annotation applies to
+  s3_metadata_path:
+    range: string
+    description: S3 path for the metadata json file for this annotation
+  annotation_is_curator_recommended:
+    range: boolean
+    description: This annotation is recommended by the curator to be preferred for this object type.
+
+  # ============================================================================
+  # Annotation File slots
+  # ============================================================================
+  #id (int): Numeric identifier (May change!)
+  annotation_file_format:
+    range: string
+    description: File format for this file
+  annotation_file_https_path:
+    range: string
+    description: HTTPS url for the annotation file
+  annotation_file_s3_path:
+    range: string
+    description: S3 path for the annotation file
+  annotation_file_shape_type:
+    range: string
+    description: Describe whether this is a Point, OrientedPoint, or SegmentationMask file
+  annotation_file_annotation_id:
+    range: integer
+    description: Reference to the annotation this file applies to
+  annotation_file_path:
+    range: string
+    description: Path to the annotation file relative to the dataset root.
+  annotation_file_is_visualization_default:
+    range: boolean
+    description: This annotation will be rendered in neuroglancer by default.
+  #Annotation (Annotation): The annotation this file is a part of
+
+enums:
+  # ============================================================================
+  # Controlled vocabularies
+  # ============================================================================
+  sample_type_enum:
+    description: Type of sample imaged in a CryoET study.
+    permissible_values:
+      cell:
+        description: Tomographic data of whole cells or cell sections.
+      tissue:
+        description: Tomographic data of tissue sections.
+      organism:
+        description: Tomographic data of sections through multicellular organisms.
+      organelle:
+        description: Tomographic data of purified organelles.
+      virus:
+        description: Tomographic data of purified viruses or VLPs.
+      in_vitro:
+        description: Tomographic data of in vitro reconstituted systems or mixtures of proteins.
+      in_silico:
+        description: Simulated tomographic data.
+      other:
+        description: Other type of sample.
+
+  fiducial_alignment_status_enum:
+    description: Fiducial Alignment method
+    permissible_values:
+      FIDUCIAL:
+        description: Alignment computed based on fiducial markers
+      NON_FIDUCIAL:
+        description: Alignment computed without fiducial markers
+
+  tomogram_type_enum:
+    description: Tomogram type
+    permissible_values:
+      CANONICAL:
+        description: Canonical tomogram (basis geometry for all annotations)
+
+  annotation_method_type_enum:
+    description: Describes how the annotations were generated.
+    permissible_values:
+      manual:
+        description: Annotations were generated manually.
+      automated:
+        description: Annotations were generated semi-automatically.
+      hybrid:
+        description: Annotations were generated automatically.
+
+  annotation_shape_enum:
+    description: Annotation shape types available on the data portal.
+    permissible_values:
+      Point:
+        description: Annotations were generated manually.
+      OrientedPoint:
+        description: Annotations were generated semi-automatically.
+      SegmentationMask:
+        description: Annotations were generated automatically.
+
+
+classes:
+  # ============================================================================
+  # Deposition, release and last modified dates
+  # ============================================================================
+  DateStamp:
+    abstract: true
+    description: A set of dates at which a data item was deposited, published and last modified.
+    slots:
+      - deposition_date
+      - release_date
+      - last_modified_date
+    slot_usage:
+      deposition_date:
+        required: true
+      release_date:
+        recommended: true
+      last_modified_date:
+        recommended: true
+
+  # ============================================================================
+  # Cross-references to other databases and publications
+  # ============================================================================
+  CrossReferences:
+    description: A set of cross-references to other databases and publications.
+    attributes:
+      dataset_publications:
+        range: string
+        recommended: true
+        description: Comma-separated list of DOIs for publications associated with the dataset.
+      related_database_entries:
+        range: string
+        recommended: true
+        description: Comma-separated list of related database entries for the dataset.
+      related_database_links:
+        range: string
+        description: Comma-separated list of related database links for the dataset.
+      dataset_citations:
+        range: string
+        description: Comma-separated list of DOIs for publications citing the dataset.
+
+
+

--- a/schema/v1.1.0/common.yaml
+++ b/schema/v1.1.0/common.yaml
@@ -1,9 +1,9 @@
-id: https://cryoetdataportal.czscience.com/schema-docs/common
+id: common
 name: cdp-common
 version: 1.1.0
 prefixes:
   linkml: https://w3id.org/linkml/
-  cdp-common: https://cryoetdataportal.czscience.com/schema/common/
+  cdp-common: common
   ROR: https://ror.org/
   UBERON: http://purl.obolibrary.org/obo/UBERON_
   CL: http://purl.obolibrary.org/obo/CL_

--- a/schema/v1.1.0/metadata-docs/Annotation.md
+++ b/schema/v1.1.0/metadata-docs/Annotation.md
@@ -7,7 +7,7 @@ _Metadata describing an annotation._
 
 
 
-URI: [cdp-meta:Annotation](https://cryoetdataportal.czscience.com/schema/metadata/Annotation)
+URI: [cdp-meta:Annotation](metadataAnnotation)
 
 
 
@@ -114,7 +114,7 @@ URI: [cdp-meta:Annotation](https://cryoetdataportal.czscience.com/schema/metadat
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -141,7 +141,7 @@ URI: [cdp-meta:Annotation](https://cryoetdataportal.czscience.com/schema/metadat
 ```yaml
 name: Annotation
 description: Metadata describing an annotation.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 mixins:
 - DatestampedEntity
 - AnnotatoredEntity
@@ -150,7 +150,7 @@ attributes:
     name: annotation_method
     description: Describe how the annotation is made (e.g. Manual, crYoLO, Positive
       Unlabeled Learning, template matching)
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_method
     rank: 1000
@@ -164,7 +164,7 @@ attributes:
   annotation_method_type:
     name: annotation_method_type
     description: Classification of the annotation method based on supervision.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_method_type
     rank: 1000
@@ -179,7 +179,7 @@ attributes:
     name: annotation_publications
     description: DOIs for publications that describe the dataset. Use a comma to separate
       multiple DOIs.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_publication
     rank: 1000
@@ -193,7 +193,7 @@ attributes:
   annotation_software:
     name: annotation_software
     description: Software used for generating this annotation
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_software
     rank: 1000
@@ -208,7 +208,7 @@ attributes:
     name: ground_truth_status
     description: Whether an annotation is considered ground truth, as determined by
       the annotator.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_ground_truth_status
     rank: 1000
@@ -222,7 +222,7 @@ attributes:
   object_count:
     name: object_count
     description: Number of objects identified
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_object_count
     rank: 1000
@@ -237,7 +237,7 @@ attributes:
     name: is_curator_recommended
     description: This annotation is recommended by the curator to be preferred for
       this object type.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_is_curator_recommended
     rank: 1000
@@ -251,7 +251,7 @@ attributes:
   files:
     name: files
     description: Metadata describing a file containing an annotation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     multivalued: true
     list_elements_ordered: true
@@ -265,7 +265,7 @@ attributes:
   confidence:
     name: confidence
     description: Metadata describing the confidence of an annotation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: confidence
     owner: Annotation
@@ -277,7 +277,7 @@ attributes:
   annotation_object:
     name: annotation_object
     description: Metadata describing the object being annotated.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: annotation_object
     owner: Annotation
@@ -290,7 +290,7 @@ attributes:
     name: dates
     description: A set of dates at which a data item was deposited, published and
       last modified.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: dates
     owner: Annotation
     domain_of:
@@ -304,7 +304,7 @@ attributes:
   authors:
     name: authors
     description: Annotator of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     multivalued: true
     list_elements_ordered: true
     alias: authors
@@ -329,7 +329,7 @@ attributes:
 ```yaml
 name: Annotation
 description: Metadata describing an annotation.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 mixins:
 - DatestampedEntity
 - AnnotatoredEntity
@@ -338,7 +338,7 @@ attributes:
     name: annotation_method
     description: Describe how the annotation is made (e.g. Manual, crYoLO, Positive
       Unlabeled Learning, template matching)
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_method
     rank: 1000
@@ -352,7 +352,7 @@ attributes:
   annotation_method_type:
     name: annotation_method_type
     description: Classification of the annotation method based on supervision.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_method_type
     rank: 1000
@@ -367,7 +367,7 @@ attributes:
     name: annotation_publications
     description: DOIs for publications that describe the dataset. Use a comma to separate
       multiple DOIs.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_publication
     rank: 1000
@@ -381,7 +381,7 @@ attributes:
   annotation_software:
     name: annotation_software
     description: Software used for generating this annotation
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_software
     rank: 1000
@@ -396,7 +396,7 @@ attributes:
     name: ground_truth_status
     description: Whether an annotation is considered ground truth, as determined by
       the annotator.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_ground_truth_status
     rank: 1000
@@ -410,7 +410,7 @@ attributes:
   object_count:
     name: object_count
     description: Number of objects identified
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_object_count
     rank: 1000
@@ -425,7 +425,7 @@ attributes:
     name: is_curator_recommended
     description: This annotation is recommended by the curator to be preferred for
       this object type.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_is_curator_recommended
     rank: 1000
@@ -439,7 +439,7 @@ attributes:
   files:
     name: files
     description: Metadata describing a file containing an annotation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     multivalued: true
     list_elements_ordered: true
@@ -453,7 +453,7 @@ attributes:
   confidence:
     name: confidence
     description: Metadata describing the confidence of an annotation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: confidence
     owner: Annotation
@@ -465,7 +465,7 @@ attributes:
   annotation_object:
     name: annotation_object
     description: Metadata describing the object being annotated.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: annotation_object
     owner: Annotation
@@ -478,7 +478,7 @@ attributes:
     name: dates
     description: A set of dates at which a data item was deposited, published and
       last modified.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: dates
     owner: Annotation
     domain_of:
@@ -492,7 +492,7 @@ attributes:
   authors:
     name: authors
     description: Annotator of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     multivalued: true
     list_elements_ordered: true
     alias: authors

--- a/schema/v1.1.0/metadata-docs/Annotation.md
+++ b/schema/v1.1.0/metadata-docs/Annotation.md
@@ -1,0 +1,512 @@
+# Class: Annotation
+
+
+_Metadata describing an annotation._
+
+
+
+
+
+URI: [cdp-meta:Annotation](https://cryoetdataportal.czscience.com/schema/metadata/Annotation)
+
+
+
+
+```mermaid
+ classDiagram
+    class Annotation
+      DatestampedEntity <|-- Annotation
+      AnnotatoredEntity <|-- Annotation
+      
+      Annotation : annotation_method
+        
+          Annotation --> string : annotation_method
+        
+      Annotation : annotation_method_type
+        
+          Annotation --> annotation_method_type_enum : annotation_method_type
+        
+      Annotation : annotation_object
+        
+          Annotation --> AnnotationObject : annotation_object
+        
+      Annotation : annotation_publications
+        
+          Annotation --> string : annotation_publications
+        
+      Annotation : annotation_software
+        
+          Annotation --> string : annotation_software
+        
+      Annotation : authors
+        
+          Annotation --> Annotator : authors
+        
+      Annotation : confidence
+        
+          Annotation --> AnnotationConfidence : confidence
+        
+      Annotation : dates
+        
+          Annotation --> DateStamp : dates
+        
+      Annotation : files
+        
+          Annotation --> AnnotationFile : files
+        
+      Annotation : ground_truth_status
+        
+          Annotation --> boolean : ground_truth_status
+        
+      Annotation : is_curator_recommended
+        
+          Annotation --> boolean : is_curator_recommended
+        
+      Annotation : object_count
+        
+          Annotation --> integer : object_count
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* **Annotation** [ [DatestampedEntity](DatestampedEntity.md) [AnnotatoredEntity](AnnotatoredEntity.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [annotation_method](annotation_method.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Describe how the annotation is made (e | direct |
+| [annotation_method_type](annotation_method_type.md) | 0..1 <br/> [AnnotationMethodTypeEnum](AnnotationMethodTypeEnum.md) | Classification of the annotation method based on supervision | direct |
+| [annotation_publications](annotation_publications.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | DOIs for publications that describe the dataset | direct |
+| [annotation_software](annotation_software.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Software used for generating this annotation | direct |
+| [ground_truth_status](ground_truth_status.md) | 0..1 <br/> [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean) | Whether an annotation is considered ground truth, as determined by the annota... | direct |
+| [object_count](object_count.md) | 0..1 <br/> [xsd:integer](http://www.w3.org/2001/XMLSchema#integer) | Number of objects identified | direct |
+| [is_curator_recommended](is_curator_recommended.md) | 0..1 <br/> [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean) | This annotation is recommended by the curator to be preferred for this object... | direct |
+| [files](files.md) | 0..* <br/> [AnnotationFile](AnnotationFile.md) | Metadata describing a file containing an annotation | direct |
+| [confidence](confidence.md) | 0..1 <br/> [AnnotationConfidence](AnnotationConfidence.md) | Metadata describing the confidence of an annotation | direct |
+| [annotation_object](annotation_object.md) | 0..1 <br/> [AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated | direct |
+| [dates](dates.md) | 1..1 <br/> [DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... | direct |
+| [authors](authors.md) | 1..* <br/> [Annotator](Annotator.md) | Annotator of a scientific data entity | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:Annotation |
+| native | cdp-meta:Annotation |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Annotation
+description: Metadata describing an annotation.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+mixins:
+- DatestampedEntity
+- AnnotatoredEntity
+attributes:
+  annotation_method:
+    name: annotation_method
+    description: Describe how the annotation is made (e.g. Manual, crYoLO, Positive
+      Unlabeled Learning, template matching)
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_method
+    rank: 1000
+    alias: annotation_method
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: string
+    inlined: true
+    inlined_as_list: true
+  annotation_method_type:
+    name: annotation_method_type
+    description: Classification of the annotation method based on supervision.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_method_type
+    rank: 1000
+    alias: annotation_method_type
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: annotation_method_type_enum
+    inlined: true
+    inlined_as_list: true
+  annotation_publications:
+    name: annotation_publications
+    description: DOIs for publications that describe the dataset. Use a comma to separate
+      multiple DOIs.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_publication
+    rank: 1000
+    alias: annotation_publications
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: string
+    inlined: true
+    inlined_as_list: true
+  annotation_software:
+    name: annotation_software
+    description: Software used for generating this annotation
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_software
+    rank: 1000
+    alias: annotation_software
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: string
+    inlined: true
+    inlined_as_list: true
+  ground_truth_status:
+    name: ground_truth_status
+    description: Whether an annotation is considered ground truth, as determined by
+      the annotator.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_ground_truth_status
+    rank: 1000
+    alias: ground_truth_status
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  object_count:
+    name: object_count
+    description: Number of objects identified
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_object_count
+    rank: 1000
+    alias: object_count
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  is_curator_recommended:
+    name: is_curator_recommended
+    description: This annotation is recommended by the curator to be preferred for
+      this object type.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_is_curator_recommended
+    rank: 1000
+    alias: is_curator_recommended
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  files:
+    name: files
+    description: Metadata describing a file containing an annotation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    multivalued: true
+    list_elements_ordered: true
+    alias: files
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: AnnotationFile
+    inlined: true
+    inlined_as_list: true
+  confidence:
+    name: confidence
+    description: Metadata describing the confidence of an annotation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: confidence
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: AnnotationConfidence
+    inlined: true
+    inlined_as_list: true
+  annotation_object:
+    name: annotation_object
+    description: Metadata describing the object being annotated.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: annotation_object
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: AnnotationObject
+    inlined: true
+    inlined_as_list: true
+  dates:
+    name: dates
+    description: A set of dates at which a data item was deposited, published and
+      last modified.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: dates
+    owner: Annotation
+    domain_of:
+    - DatestampedEntity
+    - Dataset
+    - Annotation
+    range: DateStamp
+    required: true
+    inlined: true
+    inlined_as_list: true
+  authors:
+    name: authors
+    description: Annotator of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    multivalued: true
+    list_elements_ordered: true
+    alias: authors
+    owner: Annotation
+    domain_of:
+    - AuthoredEntity
+    - AnnotatoredEntity
+    - Dataset
+    - Tomogram
+    - Annotation
+    range: Annotator
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Annotation
+description: Metadata describing an annotation.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+mixins:
+- DatestampedEntity
+- AnnotatoredEntity
+attributes:
+  annotation_method:
+    name: annotation_method
+    description: Describe how the annotation is made (e.g. Manual, crYoLO, Positive
+      Unlabeled Learning, template matching)
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_method
+    rank: 1000
+    alias: annotation_method
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: string
+    inlined: true
+    inlined_as_list: true
+  annotation_method_type:
+    name: annotation_method_type
+    description: Classification of the annotation method based on supervision.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_method_type
+    rank: 1000
+    alias: annotation_method_type
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: annotation_method_type_enum
+    inlined: true
+    inlined_as_list: true
+  annotation_publications:
+    name: annotation_publications
+    description: DOIs for publications that describe the dataset. Use a comma to separate
+      multiple DOIs.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_publication
+    rank: 1000
+    alias: annotation_publications
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: string
+    inlined: true
+    inlined_as_list: true
+  annotation_software:
+    name: annotation_software
+    description: Software used for generating this annotation
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_software
+    rank: 1000
+    alias: annotation_software
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: string
+    inlined: true
+    inlined_as_list: true
+  ground_truth_status:
+    name: ground_truth_status
+    description: Whether an annotation is considered ground truth, as determined by
+      the annotator.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_ground_truth_status
+    rank: 1000
+    alias: ground_truth_status
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  object_count:
+    name: object_count
+    description: Number of objects identified
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_object_count
+    rank: 1000
+    alias: object_count
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  is_curator_recommended:
+    name: is_curator_recommended
+    description: This annotation is recommended by the curator to be preferred for
+      this object type.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_is_curator_recommended
+    rank: 1000
+    alias: is_curator_recommended
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  files:
+    name: files
+    description: Metadata describing a file containing an annotation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    multivalued: true
+    list_elements_ordered: true
+    alias: files
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: AnnotationFile
+    inlined: true
+    inlined_as_list: true
+  confidence:
+    name: confidence
+    description: Metadata describing the confidence of an annotation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: confidence
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: AnnotationConfidence
+    inlined: true
+    inlined_as_list: true
+  annotation_object:
+    name: annotation_object
+    description: Metadata describing the object being annotated.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: annotation_object
+    owner: Annotation
+    domain_of:
+    - Annotation
+    range: AnnotationObject
+    inlined: true
+    inlined_as_list: true
+  dates:
+    name: dates
+    description: A set of dates at which a data item was deposited, published and
+      last modified.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: dates
+    owner: Annotation
+    domain_of:
+    - DatestampedEntity
+    - Dataset
+    - Annotation
+    range: DateStamp
+    required: true
+    inlined: true
+    inlined_as_list: true
+  authors:
+    name: authors
+    description: Annotator of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    multivalued: true
+    list_elements_ordered: true
+    alias: authors
+    owner: Annotation
+    domain_of:
+    - AuthoredEntity
+    - AnnotatoredEntity
+    - Dataset
+    - Tomogram
+    - Annotation
+    range: Annotator
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/AnnotationConfidence.md
+++ b/schema/v1.1.0/metadata-docs/AnnotationConfidence.md
@@ -7,7 +7,7 @@ _Metadata describing the confidence of an annotation._
 
 
 
-URI: [cdp-meta:AnnotationConfidence](https://cryoetdataportal.czscience.com/schema/metadata/AnnotationConfidence)
+URI: [cdp-meta:AnnotationConfidence](metadataAnnotationConfidence)
 
 
 
@@ -70,7 +70,7 @@ URI: [cdp-meta:AnnotationConfidence](https://cryoetdataportal.czscience.com/sche
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -97,13 +97,13 @@ URI: [cdp-meta:AnnotationConfidence](https://cryoetdataportal.czscience.com/sche
 ```yaml
 name: AnnotationConfidence
 description: Metadata describing the confidence of an annotation.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   precision:
     name: precision
     description: Describe the confidence level of the annotation. Precision is defined
       as the % of annotation objects being true positive
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_confidence_precision
     rank: 1000
@@ -118,7 +118,7 @@ attributes:
     name: recall
     description: Describe the confidence level of the annotation. Recall is defined
       as the % of true positives being annotated correctly
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_confidence_recall
     rank: 1000
@@ -132,7 +132,7 @@ attributes:
   ground_truth_used:
     name: ground_truth_used
     description: Annotation filename used as ground truth for precision and recall
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_ground_truth_used
     rank: 1000
@@ -153,13 +153,13 @@ attributes:
 ```yaml
 name: AnnotationConfidence
 description: Metadata describing the confidence of an annotation.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   precision:
     name: precision
     description: Describe the confidence level of the annotation. Precision is defined
       as the % of annotation objects being true positive
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_confidence_precision
     rank: 1000
@@ -174,7 +174,7 @@ attributes:
     name: recall
     description: Describe the confidence level of the annotation. Recall is defined
       as the % of true positives being annotated correctly
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_confidence_recall
     rank: 1000
@@ -188,7 +188,7 @@ attributes:
   ground_truth_used:
     name: ground_truth_used
     description: Annotation filename used as ground truth for precision and recall
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_ground_truth_used
     rank: 1000

--- a/schema/v1.1.0/metadata-docs/AnnotationConfidence.md
+++ b/schema/v1.1.0/metadata-docs/AnnotationConfidence.md
@@ -1,0 +1,204 @@
+# Class: AnnotationConfidence
+
+
+_Metadata describing the confidence of an annotation._
+
+
+
+
+
+URI: [cdp-meta:AnnotationConfidence](https://cryoetdataportal.czscience.com/schema/metadata/AnnotationConfidence)
+
+
+
+
+```mermaid
+ classDiagram
+    class AnnotationConfidence
+      AnnotationConfidence : ground_truth_used
+        
+          AnnotationConfidence --> string : ground_truth_used
+        
+      AnnotationConfidence : precision
+        
+          AnnotationConfidence --> float : precision
+        
+      AnnotationConfidence : recall
+        
+          AnnotationConfidence --> float : recall
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [precision](precision.md) | 0..1 <br/> [xsd:float](http://www.w3.org/2001/XMLSchema#float) | Describe the confidence level of the annotation | direct |
+| [recall](recall.md) | 0..1 <br/> [xsd:float](http://www.w3.org/2001/XMLSchema#float) | Describe the confidence level of the annotation | direct |
+| [ground_truth_used](ground_truth_used.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Annotation filename used as ground truth for precision and recall | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Annotation](Annotation.md) | [confidence](confidence.md) | range | [AnnotationConfidence](AnnotationConfidence.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:AnnotationConfidence |
+| native | cdp-meta:AnnotationConfidence |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: AnnotationConfidence
+description: Metadata describing the confidence of an annotation.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  precision:
+    name: precision
+    description: Describe the confidence level of the annotation. Precision is defined
+      as the % of annotation objects being true positive
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_confidence_precision
+    rank: 1000
+    alias: precision
+    owner: AnnotationConfidence
+    domain_of:
+    - AnnotationConfidence
+    range: float
+    inlined: true
+    inlined_as_list: true
+  recall:
+    name: recall
+    description: Describe the confidence level of the annotation. Recall is defined
+      as the % of true positives being annotated correctly
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_confidence_recall
+    rank: 1000
+    alias: recall
+    owner: AnnotationConfidence
+    domain_of:
+    - AnnotationConfidence
+    range: float
+    inlined: true
+    inlined_as_list: true
+  ground_truth_used:
+    name: ground_truth_used
+    description: Annotation filename used as ground truth for precision and recall
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_ground_truth_used
+    rank: 1000
+    alias: ground_truth_used
+    owner: AnnotationConfidence
+    domain_of:
+    - AnnotationConfidence
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: AnnotationConfidence
+description: Metadata describing the confidence of an annotation.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  precision:
+    name: precision
+    description: Describe the confidence level of the annotation. Precision is defined
+      as the % of annotation objects being true positive
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_confidence_precision
+    rank: 1000
+    alias: precision
+    owner: AnnotationConfidence
+    domain_of:
+    - AnnotationConfidence
+    range: float
+    inlined: true
+    inlined_as_list: true
+  recall:
+    name: recall
+    description: Describe the confidence level of the annotation. Recall is defined
+      as the % of true positives being annotated correctly
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_confidence_recall
+    rank: 1000
+    alias: recall
+    owner: AnnotationConfidence
+    domain_of:
+    - AnnotationConfidence
+    range: float
+    inlined: true
+    inlined_as_list: true
+  ground_truth_used:
+    name: ground_truth_used
+    description: Annotation filename used as ground truth for precision and recall
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_ground_truth_used
+    rank: 1000
+    alias: ground_truth_used
+    owner: AnnotationConfidence
+    domain_of:
+    - AnnotationConfidence
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/AnnotationFile.md
+++ b/schema/v1.1.0/metadata-docs/AnnotationFile.md
@@ -1,0 +1,235 @@
+# Class: AnnotationFile
+
+
+_Metadata describing a file containing an annotation._
+
+
+
+
+
+URI: [cdp-meta:AnnotationFile](https://cryoetdataportal.czscience.com/schema/metadata/AnnotationFile)
+
+
+
+
+```mermaid
+ classDiagram
+    class AnnotationFile
+      AnnotationFile : format
+        
+          AnnotationFile --> string : format
+        
+      AnnotationFile : is_visualization_default
+        
+          AnnotationFile --> boolean : is_visualization_default
+        
+      AnnotationFile : path
+        
+          AnnotationFile --> string : path
+        
+      AnnotationFile : shape
+        
+          AnnotationFile --> string : shape
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [format](format.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | File format for this file | direct |
+| [shape](shape.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Describe whether this is a Point, OrientedPoint, or SegmentationMask file | direct |
+| [path](path.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Path to the annotation file relative to the dataset root | direct |
+| [is_visualization_default](is_visualization_default.md) | 0..1 <br/> [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean) | This annotation will be rendered in neuroglancer by default | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Annotation](Annotation.md) | [files](files.md) | range | [AnnotationFile](AnnotationFile.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:AnnotationFile |
+| native | cdp-meta:AnnotationFile |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: AnnotationFile
+description: Metadata describing a file containing an annotation.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  format:
+    name: format
+    description: File format for this file
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_file_format
+    rank: 1000
+    alias: format
+    owner: AnnotationFile
+    domain_of:
+    - AnnotationFile
+    range: string
+    inlined: true
+    inlined_as_list: true
+  shape:
+    name: shape
+    description: Describe whether this is a Point, OrientedPoint, or SegmentationMask
+      file
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_file_shape_type
+    rank: 1000
+    alias: shape
+    owner: AnnotationFile
+    domain_of:
+    - AnnotationFile
+    range: string
+    inlined: true
+    inlined_as_list: true
+  path:
+    name: path
+    description: Path to the annotation file relative to the dataset root.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_file_path
+    rank: 1000
+    alias: path
+    owner: AnnotationFile
+    domain_of:
+    - AnnotationFile
+    range: string
+    inlined: true
+    inlined_as_list: true
+  is_visualization_default:
+    name: is_visualization_default
+    description: This annotation will be rendered in neuroglancer by default.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_file_is_visualization_default
+    rank: 1000
+    alias: is_visualization_default
+    owner: AnnotationFile
+    domain_of:
+    - AnnotationFile
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: AnnotationFile
+description: Metadata describing a file containing an annotation.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  format:
+    name: format
+    description: File format for this file
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_file_format
+    rank: 1000
+    alias: format
+    owner: AnnotationFile
+    domain_of:
+    - AnnotationFile
+    range: string
+    inlined: true
+    inlined_as_list: true
+  shape:
+    name: shape
+    description: Describe whether this is a Point, OrientedPoint, or SegmentationMask
+      file
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_file_shape_type
+    rank: 1000
+    alias: shape
+    owner: AnnotationFile
+    domain_of:
+    - AnnotationFile
+    range: string
+    inlined: true
+    inlined_as_list: true
+  path:
+    name: path
+    description: Path to the annotation file relative to the dataset root.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_file_path
+    rank: 1000
+    alias: path
+    owner: AnnotationFile
+    domain_of:
+    - AnnotationFile
+    range: string
+    inlined: true
+    inlined_as_list: true
+  is_visualization_default:
+    name: is_visualization_default
+    description: This annotation will be rendered in neuroglancer by default.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_file_is_visualization_default
+    rank: 1000
+    alias: is_visualization_default
+    owner: AnnotationFile
+    domain_of:
+    - AnnotationFile
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/AnnotationFile.md
+++ b/schema/v1.1.0/metadata-docs/AnnotationFile.md
@@ -7,7 +7,7 @@ _Metadata describing a file containing an annotation._
 
 
 
-URI: [cdp-meta:AnnotationFile](https://cryoetdataportal.czscience.com/schema/metadata/AnnotationFile)
+URI: [cdp-meta:AnnotationFile](metadataAnnotationFile)
 
 
 
@@ -75,7 +75,7 @@ URI: [cdp-meta:AnnotationFile](https://cryoetdataportal.czscience.com/schema/met
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -102,12 +102,12 @@ URI: [cdp-meta:AnnotationFile](https://cryoetdataportal.czscience.com/schema/met
 ```yaml
 name: AnnotationFile
 description: Metadata describing a file containing an annotation.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   format:
     name: format
     description: File format for this file
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_file_format
     rank: 1000
@@ -122,7 +122,7 @@ attributes:
     name: shape
     description: Describe whether this is a Point, OrientedPoint, or SegmentationMask
       file
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_file_shape_type
     rank: 1000
@@ -136,7 +136,7 @@ attributes:
   path:
     name: path
     description: Path to the annotation file relative to the dataset root.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_file_path
     rank: 1000
@@ -150,7 +150,7 @@ attributes:
   is_visualization_default:
     name: is_visualization_default
     description: This annotation will be rendered in neuroglancer by default.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_file_is_visualization_default
     rank: 1000
@@ -171,12 +171,12 @@ attributes:
 ```yaml
 name: AnnotationFile
 description: Metadata describing a file containing an annotation.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   format:
     name: format
     description: File format for this file
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_file_format
     rank: 1000
@@ -191,7 +191,7 @@ attributes:
     name: shape
     description: Describe whether this is a Point, OrientedPoint, or SegmentationMask
       file
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_file_shape_type
     rank: 1000
@@ -205,7 +205,7 @@ attributes:
   path:
     name: path
     description: Path to the annotation file relative to the dataset root.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_file_path
     rank: 1000
@@ -219,7 +219,7 @@ attributes:
   is_visualization_default:
     name: is_visualization_default
     description: This annotation will be rendered in neuroglancer by default.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_file_is_visualization_default
     rank: 1000

--- a/schema/v1.1.0/metadata-docs/AnnotationMethodTypeEnum.md
+++ b/schema/v1.1.0/metadata-docs/AnnotationMethodTypeEnum.md
@@ -42,7 +42,7 @@ URI: [AnnotationMethodTypeEnum](AnnotationMethodTypeEnum.md)
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -53,7 +53,7 @@ URI: [AnnotationMethodTypeEnum](AnnotationMethodTypeEnum.md)
 ```yaml
 name: annotation_method_type_enum
 description: Describes how the annotations were generated.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 permissible_values:
   manual:

--- a/schema/v1.1.0/metadata-docs/AnnotationMethodTypeEnum.md
+++ b/schema/v1.1.0/metadata-docs/AnnotationMethodTypeEnum.md
@@ -1,0 +1,70 @@
+# Enum: AnnotationMethodTypeEnum
+
+
+
+
+_Describes how the annotations were generated._
+
+
+
+URI: [AnnotationMethodTypeEnum](AnnotationMethodTypeEnum.md)
+
+## Permissible Values
+
+| Value | Meaning | Description |
+| --- | --- | --- |
+| manual | None | Annotations were generated manually |
+| automated | None | Annotations were generated semi-automatically |
+| hybrid | None | Annotations were generated automatically |
+
+
+
+
+## Slots
+
+| Name | Description |
+| ---  | --- |
+| [annotation_method_type](annotation_method_type.md) | Classification of the annotation method based on supervision |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: annotation_method_type_enum
+description: Describes how the annotations were generated.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+permissible_values:
+  manual:
+    text: manual
+    description: Annotations were generated manually.
+  automated:
+    text: automated
+    description: Annotations were generated semi-automatically.
+  hybrid:
+    text: hybrid
+    description: Annotations were generated automatically.
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/AnnotationObject.md
+++ b/schema/v1.1.0/metadata-docs/AnnotationObject.md
@@ -7,7 +7,7 @@ _Metadata describing the object being annotated._
 
 
 
-URI: [cdp-meta:AnnotationObject](https://cryoetdataportal.czscience.com/schema/metadata/AnnotationObject)
+URI: [cdp-meta:AnnotationObject](metadataAnnotationObject)
 
 
 
@@ -75,7 +75,7 @@ URI: [cdp-meta:AnnotationObject](https://cryoetdataportal.czscience.com/schema/m
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -102,11 +102,11 @@ URI: [cdp-meta:AnnotationObject](https://cryoetdataportal.czscience.com/schema/m
 ```yaml
 name: AnnotationObject
 description: Metadata describing the object being annotated.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   id:
     name: id
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_object_id
     alias: id
@@ -122,7 +122,7 @@ attributes:
     inlined_as_list: true
   name:
     name: name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_object_name
     alias: name
@@ -144,7 +144,7 @@ attributes:
     description: A textual description of the annotation object, can be a longer description
       to include additional information not covered by the Annotation object name
       and state.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_object_description
     rank: 1000
@@ -158,7 +158,7 @@ attributes:
   state:
     name: state
     description: Molecule state annotated (e.g. open, closed)
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_object_state
     rank: 1000
@@ -179,11 +179,11 @@ attributes:
 ```yaml
 name: AnnotationObject
 description: Metadata describing the object being annotated.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   id:
     name: id
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_object_id
     alias: id
@@ -199,7 +199,7 @@ attributes:
     inlined_as_list: true
   name:
     name: name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_object_name
     alias: name
@@ -221,7 +221,7 @@ attributes:
     description: A textual description of the annotation object, can be a longer description
       to include additional information not covered by the Annotation object name
       and state.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_object_description
     rank: 1000
@@ -235,7 +235,7 @@ attributes:
   state:
     name: state
     description: Molecule state annotated (e.g. open, closed)
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:annotation_object_state
     rank: 1000

--- a/schema/v1.1.0/metadata-docs/AnnotationObject.md
+++ b/schema/v1.1.0/metadata-docs/AnnotationObject.md
@@ -1,0 +1,251 @@
+# Class: AnnotationObject
+
+
+_Metadata describing the object being annotated._
+
+
+
+
+
+URI: [cdp-meta:AnnotationObject](https://cryoetdataportal.czscience.com/schema/metadata/AnnotationObject)
+
+
+
+
+```mermaid
+ classDiagram
+    class AnnotationObject
+      AnnotationObject : description
+        
+          AnnotationObject --> string : description
+        
+      AnnotationObject : id
+        
+          AnnotationObject --> string : id
+        
+      AnnotationObject : name
+        
+          AnnotationObject --> string : name
+        
+      AnnotationObject : state
+        
+          AnnotationObject --> string : state
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [id](id.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [name](name.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [description](description.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | A textual description of the annotation object, can be a longer description t... | direct |
+| [state](state.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Molecule state annotated (e | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Annotation](Annotation.md) | [annotation_object](annotation_object.md) | range | [AnnotationObject](AnnotationObject.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:AnnotationObject |
+| native | cdp-meta:AnnotationObject |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: AnnotationObject
+description: Metadata describing the object being annotated.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  id:
+    name: id
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_object_id
+    alias: id
+    owner: AnnotationObject
+    domain_of:
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  name:
+    name: name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_object_name
+    alias: name
+    owner: AnnotationObject
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  description:
+    name: description
+    description: A textual description of the annotation object, can be a longer description
+      to include additional information not covered by the Annotation object name
+      and state.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_object_description
+    rank: 1000
+    alias: description
+    owner: AnnotationObject
+    domain_of:
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  state:
+    name: state
+    description: Molecule state annotated (e.g. open, closed)
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_object_state
+    rank: 1000
+    alias: state
+    owner: AnnotationObject
+    domain_of:
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: AnnotationObject
+description: Metadata describing the object being annotated.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  id:
+    name: id
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_object_id
+    alias: id
+    owner: AnnotationObject
+    domain_of:
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  name:
+    name: name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_object_name
+    alias: name
+    owner: AnnotationObject
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  description:
+    name: description
+    description: A textual description of the annotation object, can be a longer description
+      to include additional information not covered by the Annotation object name
+      and state.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_object_description
+    rank: 1000
+    alias: description
+    owner: AnnotationObject
+    domain_of:
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  state:
+    name: state
+    description: Molecule state annotated (e.g. open, closed)
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:annotation_object_state
+    rank: 1000
+    alias: state
+    owner: AnnotationObject
+    domain_of:
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/AnnotationShapeEnum.md
+++ b/schema/v1.1.0/metadata-docs/AnnotationShapeEnum.md
@@ -1,0 +1,64 @@
+# Enum: AnnotationShapeEnum
+
+
+
+
+_Annotation shape types available on the data portal._
+
+
+
+URI: [AnnotationShapeEnum](AnnotationShapeEnum.md)
+
+## Permissible Values
+
+| Value | Meaning | Description |
+| --- | --- | --- |
+| Point | None | Annotations were generated manually |
+| OrientedPoint | None | Annotations were generated semi-automatically |
+| SegmentationMask | None | Annotations were generated automatically |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: annotation_shape_enum
+description: Annotation shape types available on the data portal.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+permissible_values:
+  Point:
+    text: Point
+    description: Annotations were generated manually.
+  OrientedPoint:
+    text: OrientedPoint
+    description: Annotations were generated semi-automatically.
+  SegmentationMask:
+    text: SegmentationMask
+    description: Annotations were generated automatically.
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/AnnotationShapeEnum.md
+++ b/schema/v1.1.0/metadata-docs/AnnotationShapeEnum.md
@@ -36,7 +36,7 @@ URI: [AnnotationShapeEnum](AnnotationShapeEnum.md)
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -47,7 +47,7 @@ URI: [AnnotationShapeEnum](AnnotationShapeEnum.md)
 ```yaml
 name: annotation_shape_enum
 description: Annotation shape types available on the data portal.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 permissible_values:
   Point:

--- a/schema/v1.1.0/metadata-docs/Annotator.md
+++ b/schema/v1.1.0/metadata-docs/Annotator.md
@@ -7,7 +7,7 @@ _Annotator of a scientific data entity._
 
 
 
-URI: [cdp-meta:Annotator](https://cryoetdataportal.czscience.com/schema/metadata/Annotator)
+URI: [cdp-meta:Annotator](metadataAnnotator)
 
 
 
@@ -96,7 +96,7 @@ URI: [cdp-meta:Annotator](https://cryoetdataportal.czscience.com/schema/metadata
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -123,11 +123,11 @@ URI: [cdp-meta:Annotator](https://cryoetdataportal.czscience.com/schema/metadata
 ```yaml
 name: Annotator
 description: Annotator of a scientific data entity.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   name:
     name: name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_name
     alias: name
@@ -146,7 +146,7 @@ attributes:
     inlined_as_list: true
   email:
     name: email
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_email
     alias: email
@@ -159,7 +159,7 @@ attributes:
     inlined_as_list: true
   affiliation_name:
     name: affiliation_name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_affiliation_name
     alias: affiliation_name
@@ -172,7 +172,7 @@ attributes:
     inlined_as_list: true
   affiliation_address:
     name: affiliation_address
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_affiliation_address
     alias: affiliation_address
@@ -185,7 +185,7 @@ attributes:
     inlined_as_list: true
   affiliation_identifier:
     name: affiliation_identifier
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:affiliation_identifier
     alias: affiliation_identifier
@@ -199,7 +199,7 @@ attributes:
     inlined_as_list: true
   is_corresponding:
     name: is_corresponding
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_corresponding_author_status
     alias: is_corresponding
@@ -213,7 +213,7 @@ attributes:
   is_primary_annotator:
     name: is_primary_annotator
     description: Whether the author is a primary author.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_primary_author_status
     rank: 1000
@@ -226,7 +226,7 @@ attributes:
     inlined_as_list: true
   ORCID:
     name: ORCID
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:orcid
     alias: ORCID
@@ -248,11 +248,11 @@ attributes:
 ```yaml
 name: Annotator
 description: Annotator of a scientific data entity.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   name:
     name: name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_name
     alias: name
@@ -271,7 +271,7 @@ attributes:
     inlined_as_list: true
   email:
     name: email
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_email
     alias: email
@@ -284,7 +284,7 @@ attributes:
     inlined_as_list: true
   affiliation_name:
     name: affiliation_name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_affiliation_name
     alias: affiliation_name
@@ -297,7 +297,7 @@ attributes:
     inlined_as_list: true
   affiliation_address:
     name: affiliation_address
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_affiliation_address
     alias: affiliation_address
@@ -310,7 +310,7 @@ attributes:
     inlined_as_list: true
   affiliation_identifier:
     name: affiliation_identifier
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:affiliation_identifier
     alias: affiliation_identifier
@@ -324,7 +324,7 @@ attributes:
     inlined_as_list: true
   is_corresponding:
     name: is_corresponding
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_corresponding_author_status
     alias: is_corresponding
@@ -338,7 +338,7 @@ attributes:
   is_primary_annotator:
     name: is_primary_annotator
     description: Whether the author is a primary author.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_primary_author_status
     rank: 1000
@@ -351,7 +351,7 @@ attributes:
     inlined_as_list: true
   ORCID:
     name: ORCID
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:orcid
     alias: ORCID

--- a/schema/v1.1.0/metadata-docs/Annotator.md
+++ b/schema/v1.1.0/metadata-docs/Annotator.md
@@ -1,0 +1,368 @@
+# Class: Annotator
+
+
+_Annotator of a scientific data entity._
+
+
+
+
+
+URI: [cdp-meta:Annotator](https://cryoetdataportal.czscience.com/schema/metadata/Annotator)
+
+
+
+
+```mermaid
+ classDiagram
+    class Annotator
+      Annotator : affiliation_address
+        
+          Annotator --> string : affiliation_address
+        
+      Annotator : affiliation_identifier
+        
+          Annotator --> string : affiliation_identifier
+        
+      Annotator : affiliation_name
+        
+          Annotator --> string : affiliation_name
+        
+      Annotator : email
+        
+          Annotator --> string : email
+        
+      Annotator : is_corresponding
+        
+          Annotator --> string : is_corresponding
+        
+      Annotator : is_primary_annotator
+        
+          Annotator --> boolean : is_primary_annotator
+        
+      Annotator : name
+        
+          Annotator --> string : name
+        
+      Annotator : ORCID
+        
+          Annotator --> string : ORCID
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [name](name.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [email](email.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [affiliation_name](affiliation_name.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [affiliation_address](affiliation_address.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [affiliation_identifier](affiliation_identifier.md) | 0..1 _recommended_ <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [is_corresponding](is_corresponding.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [is_primary_annotator](is_primary_annotator.md) | 0..1 <br/> [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean) | Whether the author is a primary author | direct |
+| [ORCID](ORCID.md) | 0..1 _recommended_ <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [AnnotatoredEntity](AnnotatoredEntity.md) | [authors](authors.md) | range | [Annotator](Annotator.md) |
+| [Annotation](Annotation.md) | [authors](authors.md) | range | [Annotator](Annotator.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:Annotator |
+| native | cdp-meta:Annotator |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Annotator
+description: Annotator of a scientific data entity.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  name:
+    name: name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_name
+    alias: name
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  email:
+    name: email
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_email
+    alias: email
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_name:
+    name: affiliation_name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_affiliation_name
+    alias: affiliation_name
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_address:
+    name: affiliation_address
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_affiliation_address
+    alias: affiliation_address
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_identifier:
+    name: affiliation_identifier
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:affiliation_identifier
+    alias: affiliation_identifier
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+  is_corresponding:
+    name: is_corresponding
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_corresponding_author_status
+    alias: is_corresponding
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  is_primary_annotator:
+    name: is_primary_annotator
+    description: Whether the author is a primary author.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_primary_author_status
+    rank: 1000
+    alias: is_primary_annotator
+    owner: Annotator
+    domain_of:
+    - Annotator
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  ORCID:
+    name: ORCID
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:orcid
+    alias: ORCID
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Annotator
+description: Annotator of a scientific data entity.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  name:
+    name: name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_name
+    alias: name
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  email:
+    name: email
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_email
+    alias: email
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_name:
+    name: affiliation_name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_affiliation_name
+    alias: affiliation_name
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_address:
+    name: affiliation_address
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_affiliation_address
+    alias: affiliation_address
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_identifier:
+    name: affiliation_identifier
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:affiliation_identifier
+    alias: affiliation_identifier
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+  is_corresponding:
+    name: is_corresponding
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_corresponding_author_status
+    alias: is_corresponding
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  is_primary_annotator:
+    name: is_primary_annotator
+    description: Whether the author is a primary author.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_primary_author_status
+    rank: 1000
+    alias: is_primary_annotator
+    owner: Annotator
+    domain_of:
+    - Annotator
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  ORCID:
+    name: ORCID
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:orcid
+    alias: ORCID
+    owner: Annotator
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/AnnotatoredEntity.md
+++ b/schema/v1.1.0/metadata-docs/AnnotatoredEntity.md
@@ -9,7 +9,7 @@ _An entity with associated annotation authors._
 * __NOTE__: this is an abstract class and should not be instantiated directly
 
 
-URI: [cdp-meta:AnnotatoredEntity](https://cryoetdataportal.czscience.com/schema/metadata/AnnotatoredEntity)
+URI: [cdp-meta:AnnotatoredEntity](metadataAnnotatoredEntity)
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:AnnotatoredEntity](https://cryoetdataportal.czscience.com/schema/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -84,13 +84,13 @@ URI: [cdp-meta:AnnotatoredEntity](https://cryoetdataportal.czscience.com/schema/
 ```yaml
 name: AnnotatoredEntity
 description: An entity with associated annotation authors.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   authors:
     name: authors
     description: Annotator of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     multivalued: true
     list_elements_ordered: true
     alias: authors
@@ -115,13 +115,13 @@ attributes:
 ```yaml
 name: AnnotatoredEntity
 description: An entity with associated annotation authors.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   authors:
     name: authors
     description: Annotator of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     multivalued: true
     list_elements_ordered: true
     alias: authors

--- a/schema/v1.1.0/metadata-docs/AnnotatoredEntity.md
+++ b/schema/v1.1.0/metadata-docs/AnnotatoredEntity.md
@@ -1,0 +1,141 @@
+# Class: AnnotatoredEntity
+
+
+_An entity with associated annotation authors._
+
+
+
+
+* __NOTE__: this is an abstract class and should not be instantiated directly
+
+
+URI: [cdp-meta:AnnotatoredEntity](https://cryoetdataportal.czscience.com/schema/metadata/AnnotatoredEntity)
+
+
+
+
+```mermaid
+ classDiagram
+    class AnnotatoredEntity
+      AnnotatoredEntity <|-- Annotation
+      
+      AnnotatoredEntity : authors
+        
+          AnnotatoredEntity --> Annotator : authors
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [authors](authors.md) | 1..* <br/> [Annotator](Annotator.md) | Annotator of a scientific data entity | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:AnnotatoredEntity |
+| native | cdp-meta:AnnotatoredEntity |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: AnnotatoredEntity
+description: An entity with associated annotation authors.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  authors:
+    name: authors
+    description: Annotator of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    multivalued: true
+    list_elements_ordered: true
+    alias: authors
+    owner: AnnotatoredEntity
+    domain_of:
+    - AuthoredEntity
+    - AnnotatoredEntity
+    - Dataset
+    - Tomogram
+    - Annotation
+    range: Annotator
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: AnnotatoredEntity
+description: An entity with associated annotation authors.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  authors:
+    name: authors
+    description: Annotator of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    multivalued: true
+    list_elements_ordered: true
+    alias: authors
+    owner: AnnotatoredEntity
+    domain_of:
+    - AuthoredEntity
+    - AnnotatoredEntity
+    - Dataset
+    - Tomogram
+    - Annotation
+    range: Annotator
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/Author.md
+++ b/schema/v1.1.0/metadata-docs/Author.md
@@ -1,0 +1,401 @@
+# Class: Author
+
+
+_Author of a scientific data entity._
+
+
+
+
+
+URI: [cdp-meta:Author](https://cryoetdataportal.czscience.com/schema/metadata/Author)
+
+
+
+
+```mermaid
+ classDiagram
+    class Author
+      Author : affiliation_address
+        
+          Author --> string : affiliation_address
+        
+      Author : affiliation_identifier
+        
+          Author --> string : affiliation_identifier
+        
+      Author : affiliation_name
+        
+          Author --> string : affiliation_name
+        
+      Author : email
+        
+          Author --> string : email
+        
+      Author : is_corresponding
+        
+          Author --> boolean : is_corresponding
+        
+      Author : is_primary_author
+        
+          Author --> boolean : is_primary_author
+        
+      Author : name
+        
+          Author --> string : name
+        
+      Author : ORCID
+        
+          Author --> string : ORCID
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [name](name.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | The full name of the author | direct |
+| [email](email.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | The email address of the author | direct |
+| [affiliation_name](affiliation_name.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | The name of the author's affiliation | direct |
+| [affiliation_address](affiliation_address.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | The address of the author's affiliation | direct |
+| [affiliation_identifier](affiliation_identifier.md) | 0..1 _recommended_ <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | A Research Organization Registry (ROR) identifier | direct |
+| [is_corresponding](is_corresponding.md) | 0..1 <br/> [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean) | Whether the author is a corresponding author | direct |
+| [is_primary_author](is_primary_author.md) | 0..1 <br/> [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean) | Whether the author is a primary author | direct |
+| [ORCID](ORCID.md) | 0..1 _recommended_ <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | A unique, persistent identifier for researchers, provided by ORCID | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [AuthoredEntity](AuthoredEntity.md) | [authors](authors.md) | range | [Author](Author.md) |
+| [Dataset](Dataset.md) | [authors](authors.md) | range | [Author](Author.md) |
+| [Tomogram](Tomogram.md) | [authors](authors.md) | range | [Author](Author.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:Author |
+| native | cdp-meta:Author |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Author
+description: Author of a scientific data entity.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  name:
+    name: name
+    description: The full name of the author.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_name
+    rank: 1000
+    alias: name
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  email:
+    name: email
+    description: The email address of the author.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_email
+    rank: 1000
+    alias: email
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_name:
+    name: affiliation_name
+    description: The name of the author's affiliation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_affiliation_name
+    rank: 1000
+    alias: affiliation_name
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_address:
+    name: affiliation_address
+    description: The address of the author's affiliation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_affiliation_address
+    rank: 1000
+    alias: affiliation_address
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_identifier:
+    name: affiliation_identifier
+    description: A Research Organization Registry (ROR) identifier.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:affiliation_identifier
+    rank: 1000
+    alias: affiliation_identifier
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+    pattern: ^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$
+  is_corresponding:
+    name: is_corresponding
+    description: Whether the author is a corresponding author.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_corresponding_author_status
+    rank: 1000
+    alias: is_corresponding
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  is_primary_author:
+    name: is_primary_author
+    description: Whether the author is a primary author.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_primary_author_status
+    rank: 1000
+    alias: is_primary_author
+    owner: Author
+    domain_of:
+    - Author
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  ORCID:
+    name: ORCID
+    description: A unique, persistent identifier for researchers, provided by ORCID.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:orcid
+    rank: 1000
+    alias: ORCID
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+    pattern: '[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$'
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Author
+description: Author of a scientific data entity.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  name:
+    name: name
+    description: The full name of the author.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_name
+    rank: 1000
+    alias: name
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  email:
+    name: email
+    description: The email address of the author.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_email
+    rank: 1000
+    alias: email
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_name:
+    name: affiliation_name
+    description: The name of the author's affiliation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_affiliation_name
+    rank: 1000
+    alias: affiliation_name
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_address:
+    name: affiliation_address
+    description: The address of the author's affiliation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_affiliation_address
+    rank: 1000
+    alias: affiliation_address
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affiliation_identifier:
+    name: affiliation_identifier
+    description: A Research Organization Registry (ROR) identifier.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:affiliation_identifier
+    rank: 1000
+    alias: affiliation_identifier
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+    pattern: ^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$
+  is_corresponding:
+    name: is_corresponding
+    description: Whether the author is a corresponding author.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_corresponding_author_status
+    rank: 1000
+    alias: is_corresponding
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  is_primary_author:
+    name: is_primary_author
+    description: Whether the author is a primary author.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:author_primary_author_status
+    rank: 1000
+    alias: is_primary_author
+    owner: Author
+    domain_of:
+    - Author
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  ORCID:
+    name: ORCID
+    description: A unique, persistent identifier for researchers, provided by ORCID.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:orcid
+    rank: 1000
+    alias: ORCID
+    owner: Author
+    domain_of:
+    - Author
+    - Annotator
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+    pattern: '[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$'
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/Author.md
+++ b/schema/v1.1.0/metadata-docs/Author.md
@@ -7,7 +7,7 @@ _Author of a scientific data entity._
 
 
 
-URI: [cdp-meta:Author](https://cryoetdataportal.czscience.com/schema/metadata/Author)
+URI: [cdp-meta:Author](metadataAuthor)
 
 
 
@@ -97,7 +97,7 @@ URI: [cdp-meta:Author](https://cryoetdataportal.czscience.com/schema/metadata/Au
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -124,12 +124,12 @@ URI: [cdp-meta:Author](https://cryoetdataportal.czscience.com/schema/metadata/Au
 ```yaml
 name: Author
 description: Author of a scientific data entity.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   name:
     name: name
     description: The full name of the author.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_name
     rank: 1000
@@ -150,7 +150,7 @@ attributes:
   email:
     name: email
     description: The email address of the author.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_email
     rank: 1000
@@ -165,7 +165,7 @@ attributes:
   affiliation_name:
     name: affiliation_name
     description: The name of the author's affiliation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_affiliation_name
     rank: 1000
@@ -180,7 +180,7 @@ attributes:
   affiliation_address:
     name: affiliation_address
     description: The address of the author's affiliation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_affiliation_address
     rank: 1000
@@ -195,7 +195,7 @@ attributes:
   affiliation_identifier:
     name: affiliation_identifier
     description: A Research Organization Registry (ROR) identifier.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:affiliation_identifier
     rank: 1000
@@ -212,7 +212,7 @@ attributes:
   is_corresponding:
     name: is_corresponding
     description: Whether the author is a corresponding author.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_corresponding_author_status
     rank: 1000
@@ -227,7 +227,7 @@ attributes:
   is_primary_author:
     name: is_primary_author
     description: Whether the author is a primary author.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_primary_author_status
     rank: 1000
@@ -241,7 +241,7 @@ attributes:
   ORCID:
     name: ORCID
     description: A unique, persistent identifier for researchers, provided by ORCID.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:orcid
     rank: 1000
@@ -265,12 +265,12 @@ attributes:
 ```yaml
 name: Author
 description: Author of a scientific data entity.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   name:
     name: name
     description: The full name of the author.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_name
     rank: 1000
@@ -291,7 +291,7 @@ attributes:
   email:
     name: email
     description: The email address of the author.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_email
     rank: 1000
@@ -306,7 +306,7 @@ attributes:
   affiliation_name:
     name: affiliation_name
     description: The name of the author's affiliation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_affiliation_name
     rank: 1000
@@ -321,7 +321,7 @@ attributes:
   affiliation_address:
     name: affiliation_address
     description: The address of the author's affiliation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_affiliation_address
     rank: 1000
@@ -336,7 +336,7 @@ attributes:
   affiliation_identifier:
     name: affiliation_identifier
     description: A Research Organization Registry (ROR) identifier.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:affiliation_identifier
     rank: 1000
@@ -353,7 +353,7 @@ attributes:
   is_corresponding:
     name: is_corresponding
     description: Whether the author is a corresponding author.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_corresponding_author_status
     rank: 1000
@@ -368,7 +368,7 @@ attributes:
   is_primary_author:
     name: is_primary_author
     description: Whether the author is a primary author.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:author_primary_author_status
     rank: 1000
@@ -382,7 +382,7 @@ attributes:
   ORCID:
     name: ORCID
     description: A unique, persistent identifier for researchers, provided by ORCID.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:orcid
     rank: 1000

--- a/schema/v1.1.0/metadata-docs/AuthoredEntity.md
+++ b/schema/v1.1.0/metadata-docs/AuthoredEntity.md
@@ -1,0 +1,144 @@
+# Class: AuthoredEntity
+
+
+_An entity with associated authors._
+
+
+
+
+* __NOTE__: this is an abstract class and should not be instantiated directly
+
+
+URI: [cdp-meta:AuthoredEntity](https://cryoetdataportal.czscience.com/schema/metadata/AuthoredEntity)
+
+
+
+
+```mermaid
+ classDiagram
+    class AuthoredEntity
+      AuthoredEntity <|-- Dataset
+      AuthoredEntity <|-- Tomogram
+      
+      AuthoredEntity : authors
+        
+          AuthoredEntity --> Author : authors
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [authors](authors.md) | 1..* <br/> [Author](Author.md) | Author of a scientific data entity | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:AuthoredEntity |
+| native | cdp-meta:AuthoredEntity |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: AuthoredEntity
+description: An entity with associated authors.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  authors:
+    name: authors
+    description: Author of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    multivalued: true
+    list_elements_ordered: true
+    alias: authors
+    owner: AuthoredEntity
+    domain_of:
+    - AuthoredEntity
+    - AnnotatoredEntity
+    - Dataset
+    - Tomogram
+    - Annotation
+    range: Author
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: AuthoredEntity
+description: An entity with associated authors.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  authors:
+    name: authors
+    description: Author of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    multivalued: true
+    list_elements_ordered: true
+    alias: authors
+    owner: AuthoredEntity
+    domain_of:
+    - AuthoredEntity
+    - AnnotatoredEntity
+    - Dataset
+    - Tomogram
+    - Annotation
+    range: Author
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/AuthoredEntity.md
+++ b/schema/v1.1.0/metadata-docs/AuthoredEntity.md
@@ -9,7 +9,7 @@ _An entity with associated authors._
 * __NOTE__: this is an abstract class and should not be instantiated directly
 
 
-URI: [cdp-meta:AuthoredEntity](https://cryoetdataportal.czscience.com/schema/metadata/AuthoredEntity)
+URI: [cdp-meta:AuthoredEntity](metadataAuthoredEntity)
 
 
 
@@ -58,7 +58,7 @@ URI: [cdp-meta:AuthoredEntity](https://cryoetdataportal.czscience.com/schema/met
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -85,13 +85,13 @@ URI: [cdp-meta:AuthoredEntity](https://cryoetdataportal.czscience.com/schema/met
 ```yaml
 name: AuthoredEntity
 description: An entity with associated authors.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   authors:
     name: authors
     description: Author of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     multivalued: true
     list_elements_ordered: true
@@ -117,13 +117,13 @@ attributes:
 ```yaml
 name: AuthoredEntity
 description: An entity with associated authors.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   authors:
     name: authors
     description: Author of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     multivalued: true
     list_elements_ordered: true

--- a/schema/v1.1.0/metadata-docs/Camera.md
+++ b/schema/v1.1.0/metadata-docs/Camera.md
@@ -1,0 +1,70 @@
+# Slot: camera
+
+
+_The camera used to collect the tilt series._
+
+
+
+URI: [cdp-meta:camera](https://cryoetdataportal.czscience.com/schema/metadata/camera)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Camera](Camera.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: camera
+description: The camera used to collect the tilt series.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: camera
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: Camera
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/Camera.md
+++ b/schema/v1.1.0/metadata-docs/Camera.md
@@ -5,7 +5,7 @@ _The camera used to collect the tilt series._
 
 
 
-URI: [cdp-meta:camera](https://cryoetdataportal.czscience.com/schema/metadata/camera)
+URI: [cdp-meta:camera](metadatacamera)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:camera](https://cryoetdataportal.czscience.com/schema/metadata/ca
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:camera](https://cryoetdataportal.czscience.com/schema/metadata/ca
 ```yaml
 name: camera
 description: The camera used to collect the tilt series.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: camera
 owner: TiltSeries

--- a/schema/v1.1.0/metadata-docs/CellComponent.md
+++ b/schema/v1.1.0/metadata-docs/CellComponent.md
@@ -1,0 +1,182 @@
+# Class: CellComponent
+
+
+_The cellular component from which the sample was derived._
+
+
+
+
+
+URI: [cdp-meta:CellComponent](https://cryoetdataportal.czscience.com/schema/metadata/CellComponent)
+
+
+
+
+```mermaid
+ classDiagram
+    class CellComponent
+      CellComponent : id
+        
+          CellComponent --> string : id
+        
+      CellComponent : name
+        
+          CellComponent --> string : name
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [name](name.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [id](id.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | [cell_component](cell_component.md) | range | [CellComponent](CellComponent.md) |
+| [Dataset](Dataset.md) | [cell_component](cell_component.md) | range | [CellComponent](CellComponent.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:CellComponent |
+| native | cdp-meta:CellComponent |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: CellComponent
+description: The cellular component from which the sample was derived.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  name:
+    name: name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_component_name
+    alias: name
+    owner: CellComponent
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  id:
+    name: id
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_component_id
+    alias: id
+    owner: CellComponent
+    domain_of:
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: CellComponent
+description: The cellular component from which the sample was derived.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  name:
+    name: name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_component_name
+    alias: name
+    owner: CellComponent
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  id:
+    name: id
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_component_id
+    alias: id
+    owner: CellComponent
+    domain_of:
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/CellComponent.md
+++ b/schema/v1.1.0/metadata-docs/CellComponent.md
@@ -7,7 +7,7 @@ _The cellular component from which the sample was derived._
 
 
 
-URI: [cdp-meta:CellComponent](https://cryoetdataportal.czscience.com/schema/metadata/CellComponent)
+URI: [cdp-meta:CellComponent](metadataCellComponent)
 
 
 
@@ -66,7 +66,7 @@ URI: [cdp-meta:CellComponent](https://cryoetdataportal.czscience.com/schema/meta
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -93,11 +93,11 @@ URI: [cdp-meta:CellComponent](https://cryoetdataportal.czscience.com/schema/meta
 ```yaml
 name: CellComponent
 description: The cellular component from which the sample was derived.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   name:
     name: name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_component_name
     alias: name
@@ -116,7 +116,7 @@ attributes:
     inlined_as_list: true
   id:
     name: id
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_component_id
     alias: id
@@ -140,11 +140,11 @@ attributes:
 ```yaml
 name: CellComponent
 description: The cellular component from which the sample was derived.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   name:
     name: name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_component_name
     alias: name
@@ -163,7 +163,7 @@ attributes:
     inlined_as_list: true
   id:
     name: id
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_component_id
     alias: id

--- a/schema/v1.1.0/metadata-docs/CellStrain.md
+++ b/schema/v1.1.0/metadata-docs/CellStrain.md
@@ -1,0 +1,182 @@
+# Class: CellStrain
+
+
+_The strain or cell line from which the sample was derived._
+
+
+
+
+
+URI: [cdp-meta:CellStrain](https://cryoetdataportal.czscience.com/schema/metadata/CellStrain)
+
+
+
+
+```mermaid
+ classDiagram
+    class CellStrain
+      CellStrain : id
+        
+          CellStrain --> string : id
+        
+      CellStrain : name
+        
+          CellStrain --> string : name
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [name](name.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [id](id.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | [cell_strain](cell_strain.md) | range | [CellStrain](CellStrain.md) |
+| [Dataset](Dataset.md) | [cell_strain](cell_strain.md) | range | [CellStrain](CellStrain.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:CellStrain |
+| native | cdp-meta:CellStrain |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: CellStrain
+description: The strain or cell line from which the sample was derived.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  name:
+    name: name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_strain_name
+    alias: name
+    owner: CellStrain
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  id:
+    name: id
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_strain_id
+    alias: id
+    owner: CellStrain
+    domain_of:
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: CellStrain
+description: The strain or cell line from which the sample was derived.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  name:
+    name: name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_strain_name
+    alias: name
+    owner: CellStrain
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  id:
+    name: id
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_strain_id
+    alias: id
+    owner: CellStrain
+    domain_of:
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/CellStrain.md
+++ b/schema/v1.1.0/metadata-docs/CellStrain.md
@@ -7,7 +7,7 @@ _The strain or cell line from which the sample was derived._
 
 
 
-URI: [cdp-meta:CellStrain](https://cryoetdataportal.czscience.com/schema/metadata/CellStrain)
+URI: [cdp-meta:CellStrain](metadataCellStrain)
 
 
 
@@ -66,7 +66,7 @@ URI: [cdp-meta:CellStrain](https://cryoetdataportal.czscience.com/schema/metadat
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -93,11 +93,11 @@ URI: [cdp-meta:CellStrain](https://cryoetdataportal.czscience.com/schema/metadat
 ```yaml
 name: CellStrain
 description: The strain or cell line from which the sample was derived.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   name:
     name: name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_strain_name
     alias: name
@@ -116,7 +116,7 @@ attributes:
     inlined_as_list: true
   id:
     name: id
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_strain_id
     alias: id
@@ -140,11 +140,11 @@ attributes:
 ```yaml
 name: CellStrain
 description: The strain or cell line from which the sample was derived.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   name:
     name: name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_strain_name
     alias: name
@@ -163,7 +163,7 @@ attributes:
     inlined_as_list: true
   id:
     name: id
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_strain_id
     alias: id

--- a/schema/v1.1.0/metadata-docs/CellType.md
+++ b/schema/v1.1.0/metadata-docs/CellType.md
@@ -7,7 +7,7 @@ _The cell type from which the sample was derived._
 
 
 
-URI: [cdp-meta:CellType](https://cryoetdataportal.czscience.com/schema/metadata/CellType)
+URI: [cdp-meta:CellType](metadataCellType)
 
 
 
@@ -66,7 +66,7 @@ URI: [cdp-meta:CellType](https://cryoetdataportal.czscience.com/schema/metadata/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -93,11 +93,11 @@ URI: [cdp-meta:CellType](https://cryoetdataportal.czscience.com/schema/metadata/
 ```yaml
 name: CellType
 description: The cell type from which the sample was derived.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   name:
     name: name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_name
     alias: name
@@ -116,7 +116,7 @@ attributes:
     inlined_as_list: true
   id:
     name: id
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_type_id
     alias: id
@@ -140,11 +140,11 @@ attributes:
 ```yaml
 name: CellType
 description: The cell type from which the sample was derived.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   name:
     name: name
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_name
     alias: name
@@ -163,7 +163,7 @@ attributes:
     inlined_as_list: true
   id:
     name: id
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:cell_type_id
     alias: id

--- a/schema/v1.1.0/metadata-docs/CellType.md
+++ b/schema/v1.1.0/metadata-docs/CellType.md
@@ -1,0 +1,182 @@
+# Class: CellType
+
+
+_The cell type from which the sample was derived._
+
+
+
+
+
+URI: [cdp-meta:CellType](https://cryoetdataportal.czscience.com/schema/metadata/CellType)
+
+
+
+
+```mermaid
+ classDiagram
+    class CellType
+      CellType : id
+        
+          CellType --> string : id
+        
+      CellType : name
+        
+          CellType --> string : name
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [name](name.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [id](id.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | [cell_type](cell_type.md) | range | [CellType](CellType.md) |
+| [Dataset](Dataset.md) | [cell_type](cell_type.md) | range | [CellType](CellType.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:CellType |
+| native | cdp-meta:CellType |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: CellType
+description: The cell type from which the sample was derived.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  name:
+    name: name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_name
+    alias: name
+    owner: CellType
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  id:
+    name: id
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_type_id
+    alias: id
+    owner: CellType
+    domain_of:
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: CellType
+description: The cell type from which the sample was derived.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  name:
+    name: name
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_name
+    alias: name
+    owner: CellType
+    domain_of:
+    - Author
+    - Annotator
+    - Organism
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+  id:
+    name: id
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:cell_type_id
+    alias: id
+    owner: CellType
+    domain_of:
+    - Tissue
+    - CellType
+    - CellStrain
+    - CellComponent
+    - AnnotationObject
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/CrossReferencedEntity.md
+++ b/schema/v1.1.0/metadata-docs/CrossReferencedEntity.md
@@ -1,0 +1,131 @@
+# Class: CrossReferencedEntity
+
+
+_An entity with associated cross-references to other databases and publications._
+
+
+
+
+* __NOTE__: this is an abstract class and should not be instantiated directly
+
+
+URI: [cdp-meta:CrossReferencedEntity](https://cryoetdataportal.czscience.com/schema/metadata/CrossReferencedEntity)
+
+
+
+
+```mermaid
+ classDiagram
+    class CrossReferencedEntity
+      CrossReferencedEntity <|-- Dataset
+      
+      CrossReferencedEntity : cross_references
+        
+          CrossReferencedEntity --> CrossReferences : cross_references
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [cross_references](cross_references.md) | 0..1 <br/> [CrossReferences](CrossReferences.md) | A set of cross-references to other databases and publications | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:CrossReferencedEntity |
+| native | cdp-meta:CrossReferencedEntity |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: CrossReferencedEntity
+description: An entity with associated cross-references to other databases and publications.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  cross_references:
+    name: cross_references
+    description: A set of cross-references to other databases and publications.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: cross_references
+    owner: CrossReferencedEntity
+    domain_of:
+    - CrossReferencedEntity
+    - Dataset
+    range: CrossReferences
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: CrossReferencedEntity
+description: An entity with associated cross-references to other databases and publications.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  cross_references:
+    name: cross_references
+    description: A set of cross-references to other databases and publications.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: cross_references
+    owner: CrossReferencedEntity
+    domain_of:
+    - CrossReferencedEntity
+    - Dataset
+    range: CrossReferences
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/CrossReferencedEntity.md
+++ b/schema/v1.1.0/metadata-docs/CrossReferencedEntity.md
@@ -9,7 +9,7 @@ _An entity with associated cross-references to other databases and publications.
 * __NOTE__: this is an abstract class and should not be instantiated directly
 
 
-URI: [cdp-meta:CrossReferencedEntity](https://cryoetdataportal.czscience.com/schema/metadata/CrossReferencedEntity)
+URI: [cdp-meta:CrossReferencedEntity](metadataCrossReferencedEntity)
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:CrossReferencedEntity](https://cryoetdataportal.czscience.com/sch
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -84,13 +84,13 @@ URI: [cdp-meta:CrossReferencedEntity](https://cryoetdataportal.czscience.com/sch
 ```yaml
 name: CrossReferencedEntity
 description: An entity with associated cross-references to other databases and publications.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   cross_references:
     name: cross_references
     description: A set of cross-references to other databases and publications.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: cross_references
     owner: CrossReferencedEntity
@@ -110,13 +110,13 @@ attributes:
 ```yaml
 name: CrossReferencedEntity
 description: An entity with associated cross-references to other databases and publications.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   cross_references:
     name: cross_references
     description: A set of cross-references to other databases and publications.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: cross_references
     owner: CrossReferencedEntity

--- a/schema/v1.1.0/metadata-docs/CrossReferences.md
+++ b/schema/v1.1.0/metadata-docs/CrossReferences.md
@@ -1,0 +1,224 @@
+# Class: CrossReferences
+
+
+_A set of cross-references to other databases and publications._
+
+
+
+
+
+URI: [cdp-meta:CrossReferences](https://cryoetdataportal.czscience.com/schema/metadata/CrossReferences)
+
+
+
+
+```mermaid
+ classDiagram
+    class CrossReferences
+      CrossReferences : dataset_citations
+        
+          CrossReferences --> string : dataset_citations
+        
+      CrossReferences : dataset_publications
+        
+          CrossReferences --> string : dataset_publications
+        
+      CrossReferences : related_database_entries
+        
+          CrossReferences --> string : related_database_entries
+        
+      CrossReferences : related_database_links
+        
+          CrossReferences --> string : related_database_links
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [dataset_publications](dataset_publications.md) | 0..1 _recommended_ <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Comma-separated list of DOIs for publications associated with the dataset | direct |
+| [related_database_entries](related_database_entries.md) | 0..1 _recommended_ <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Comma-separated list of related database entries for the dataset | direct |
+| [related_database_links](related_database_links.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Comma-separated list of related database links for the dataset | direct |
+| [dataset_citations](dataset_citations.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Comma-separated list of DOIs for publications citing the dataset | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [CrossReferencedEntity](CrossReferencedEntity.md) | [cross_references](cross_references.md) | range | [CrossReferences](CrossReferences.md) |
+| [Dataset](Dataset.md) | [cross_references](cross_references.md) | range | [CrossReferences](CrossReferences.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:CrossReferences |
+| native | cdp-meta:CrossReferences |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: CrossReferences
+description: A set of cross-references to other databases and publications.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  dataset_publications:
+    name: dataset_publications
+    description: Comma-separated list of DOIs for publications associated with the
+      dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: dataset_publications
+    owner: CrossReferences
+    domain_of:
+    - CrossReferences
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+  related_database_entries:
+    name: related_database_entries
+    description: Comma-separated list of related database entries for the dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: related_database_entries
+    owner: CrossReferences
+    domain_of:
+    - CrossReferences
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+  related_database_links:
+    name: related_database_links
+    description: Comma-separated list of related database links for the dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: related_database_links
+    owner: CrossReferences
+    domain_of:
+    - CrossReferences
+    range: string
+    inlined: true
+    inlined_as_list: true
+  dataset_citations:
+    name: dataset_citations
+    description: Comma-separated list of DOIs for publications citing the dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: dataset_citations
+    owner: CrossReferences
+    domain_of:
+    - CrossReferences
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: CrossReferences
+description: A set of cross-references to other databases and publications.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  dataset_publications:
+    name: dataset_publications
+    description: Comma-separated list of DOIs for publications associated with the
+      dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: dataset_publications
+    owner: CrossReferences
+    domain_of:
+    - CrossReferences
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+  related_database_entries:
+    name: related_database_entries
+    description: Comma-separated list of related database entries for the dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: related_database_entries
+    owner: CrossReferences
+    domain_of:
+    - CrossReferences
+    range: string
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+  related_database_links:
+    name: related_database_links
+    description: Comma-separated list of related database links for the dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: related_database_links
+    owner: CrossReferences
+    domain_of:
+    - CrossReferences
+    range: string
+    inlined: true
+    inlined_as_list: true
+  dataset_citations:
+    name: dataset_citations
+    description: Comma-separated list of DOIs for publications citing the dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: dataset_citations
+    owner: CrossReferences
+    domain_of:
+    - CrossReferences
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/CrossReferences.md
+++ b/schema/v1.1.0/metadata-docs/CrossReferences.md
@@ -7,7 +7,7 @@ _A set of cross-references to other databases and publications._
 
 
 
-URI: [cdp-meta:CrossReferences](https://cryoetdataportal.czscience.com/schema/metadata/CrossReferences)
+URI: [cdp-meta:CrossReferences](metadataCrossReferences)
 
 
 
@@ -76,7 +76,7 @@ URI: [cdp-meta:CrossReferences](https://cryoetdataportal.czscience.com/schema/me
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -103,13 +103,13 @@ URI: [cdp-meta:CrossReferences](https://cryoetdataportal.czscience.com/schema/me
 ```yaml
 name: CrossReferences
 description: A set of cross-references to other databases and publications.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   dataset_publications:
     name: dataset_publications
     description: Comma-separated list of DOIs for publications associated with the
       dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: dataset_publications
     owner: CrossReferences
@@ -122,7 +122,7 @@ attributes:
   related_database_entries:
     name: related_database_entries
     description: Comma-separated list of related database entries for the dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: related_database_entries
     owner: CrossReferences
@@ -135,7 +135,7 @@ attributes:
   related_database_links:
     name: related_database_links
     description: Comma-separated list of related database links for the dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: related_database_links
     owner: CrossReferences
@@ -147,7 +147,7 @@ attributes:
   dataset_citations:
     name: dataset_citations
     description: Comma-separated list of DOIs for publications citing the dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: dataset_citations
     owner: CrossReferences
@@ -166,13 +166,13 @@ attributes:
 ```yaml
 name: CrossReferences
 description: A set of cross-references to other databases and publications.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   dataset_publications:
     name: dataset_publications
     description: Comma-separated list of DOIs for publications associated with the
       dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: dataset_publications
     owner: CrossReferences
@@ -185,7 +185,7 @@ attributes:
   related_database_entries:
     name: related_database_entries
     description: Comma-separated list of related database entries for the dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: related_database_entries
     owner: CrossReferences
@@ -198,7 +198,7 @@ attributes:
   related_database_links:
     name: related_database_links
     description: Comma-separated list of related database links for the dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: related_database_links
     owner: CrossReferences
@@ -210,7 +210,7 @@ attributes:
   dataset_citations:
     name: dataset_citations
     description: Comma-separated list of DOIs for publications citing the dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: dataset_citations
     owner: CrossReferences

--- a/schema/v1.1.0/metadata-docs/Dataset.md
+++ b/schema/v1.1.0/metadata-docs/Dataset.md
@@ -1,0 +1,675 @@
+# Class: Dataset
+
+
+_High-level description of a cryoET dataset._
+
+
+
+
+
+URI: [cdp-meta:Dataset](https://cryoetdataportal.czscience.com/schema/metadata/Dataset)
+
+
+
+
+```mermaid
+ classDiagram
+    class Dataset
+      DatestampedEntity <|-- Dataset
+      AuthoredEntity <|-- Dataset
+      FundedEntity <|-- Dataset
+      PicturedEntity <|-- Dataset
+      CrossReferencedEntity <|-- Dataset
+      ExperimentalMetadata <|-- Dataset
+      
+      Dataset : authors
+        
+          Dataset --> Author : authors
+        
+      Dataset : cell_component
+        
+          Dataset --> CellComponent : cell_component
+        
+      Dataset : cell_strain
+        
+          Dataset --> CellStrain : cell_strain
+        
+      Dataset : cell_type
+        
+          Dataset --> CellType : cell_type
+        
+      Dataset : cross_references
+        
+          Dataset --> CrossReferences : cross_references
+        
+      Dataset : dataset_description
+        
+          Dataset --> string : dataset_description
+        
+      Dataset : dataset_identifier
+        
+          Dataset --> integer : dataset_identifier
+        
+      Dataset : dataset_title
+        
+          Dataset --> string : dataset_title
+        
+      Dataset : dates
+        
+          Dataset --> DateStamp : dates
+        
+      Dataset : funding
+        
+          Dataset --> Funding : funding
+        
+      Dataset : grid_preparation
+        
+          Dataset --> string : grid_preparation
+        
+      Dataset : key_photos
+        
+          Dataset --> PicturePath : key_photos
+        
+      Dataset : organism
+        
+          Dataset --> Organism : organism
+        
+      Dataset : other_setup
+        
+          Dataset --> string : other_setup
+        
+      Dataset : sample_preparation
+        
+          Dataset --> string : sample_preparation
+        
+      Dataset : sample_type
+        
+          Dataset --> string : sample_type
+        
+      Dataset : tissue
+        
+          Dataset --> Tissue : tissue
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* **Dataset** [ [DatestampedEntity](DatestampedEntity.md) [AuthoredEntity](AuthoredEntity.md) [FundedEntity](FundedEntity.md) [PicturedEntity](PicturedEntity.md) [CrossReferencedEntity](CrossReferencedEntity.md) [ExperimentalMetadata](ExperimentalMetadata.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [dataset_identifier](dataset_identifier.md) | 0..1 <br/> [xsd:integer](http://www.w3.org/2001/XMLSchema#integer) | An identifier for a CryoET dataset, assigned by the Data Portal | direct |
+| [dataset_title](dataset_title.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Title of a CryoET dataset | direct |
+| [dataset_description](dataset_description.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | A short description of a CryoET dataset, similar to an abstract for a journal... | direct |
+| [dates](dates.md) | 1..1 <br/> [DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... | direct |
+| [authors](authors.md) | 1..* <br/> [Author](Author.md) | Author of a scientific data entity | direct |
+| [funding](funding.md) | 0..* _recommended_ <br/> [Funding](Funding.md) | A funding source for a scientific data entity (base for JSON and DB represent... | direct |
+| [key_photos](key_photos.md) | 1..1 <br/> [PicturePath](PicturePath.md) | A set of paths to representative images of a piece of data | direct |
+| [cross_references](cross_references.md) | 0..1 <br/> [CrossReferences](CrossReferences.md) | A set of cross-references to other databases and publications | direct |
+| [sample_type](sample_type.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Type of sample imaged in a CryoET study | direct |
+| [sample_preparation](sample_preparation.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Describes how the sample was prepared | direct |
+| [grid_preparation](grid_preparation.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Describes Cryo-ET grid preparation | direct |
+| [other_setup](other_setup.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Describes other setup not covered by sample preparation or grid preparation t... | direct |
+| [organism](organism.md) | 0..1 <br/> [Organism](Organism.md) | The species from which the sample was derived | direct |
+| [tissue](tissue.md) | 0..1 <br/> [Tissue](Tissue.md) | The type of tissue from which the sample was derived | direct |
+| [cell_type](cell_type.md) | 0..1 <br/> [CellType](CellType.md) | The cell type from which the sample was derived | direct |
+| [cell_strain](cell_strain.md) | 0..1 <br/> [CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived | direct |
+| [cell_component](cell_component.md) | 0..1 <br/> [CellComponent](CellComponent.md) | The cellular component from which the sample was derived | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:Dataset |
+| native | cdp-meta:Dataset |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Dataset
+description: High-level description of a cryoET dataset.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+mixins:
+- DatestampedEntity
+- AuthoredEntity
+- FundedEntity
+- PicturedEntity
+- CrossReferencedEntity
+- ExperimentalMetadata
+attributes:
+  dataset_identifier:
+    name: dataset_identifier
+    description: An identifier for a CryoET dataset, assigned by the Data Portal.
+      Used to identify the dataset as the directory  name in data tree.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:dataset_identifier
+    rank: 1000
+    alias: dataset_identifier
+    owner: Dataset
+    domain_of:
+    - Dataset
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  dataset_title:
+    name: dataset_title
+    description: Title of a CryoET dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:dataset_title
+    rank: 1000
+    alias: dataset_title
+    owner: Dataset
+    domain_of:
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  dataset_description:
+    name: dataset_description
+    description: A short description of a CryoET dataset, similar to an abstract for
+      a journal article or dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:dataset_description
+    rank: 1000
+    alias: dataset_description
+    owner: Dataset
+    domain_of:
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  dates:
+    name: dates
+    description: A set of dates at which a data item was deposited, published and
+      last modified.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: dates
+    owner: Dataset
+    domain_of:
+    - DatestampedEntity
+    - Dataset
+    - Annotation
+    range: DateStamp
+    required: true
+    inlined: true
+    inlined_as_list: true
+  authors:
+    name: authors
+    description: Author of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    multivalued: true
+    list_elements_ordered: true
+    alias: authors
+    owner: Dataset
+    domain_of:
+    - AuthoredEntity
+    - AnnotatoredEntity
+    - Dataset
+    - Tomogram
+    - Annotation
+    range: Author
+    required: true
+    inlined: true
+    inlined_as_list: true
+  funding:
+    name: funding
+    description: A funding source for a scientific data entity (base for JSON and
+      DB representation).
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    multivalued: true
+    list_elements_ordered: true
+    alias: funding
+    owner: Dataset
+    domain_of:
+    - FundedEntity
+    - Dataset
+    range: Funding
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+  key_photos:
+    name: key_photos
+    description: A set of paths to representative images of a piece of data.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: key_photos
+    owner: Dataset
+    domain_of:
+    - PicturedEntity
+    - Dataset
+    - Tomogram
+    range: PicturePath
+    required: true
+    inlined: true
+    inlined_as_list: true
+  cross_references:
+    name: cross_references
+    description: A set of cross-references to other databases and publications.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: cross_references
+    owner: Dataset
+    domain_of:
+    - CrossReferencedEntity
+    - Dataset
+    range: CrossReferences
+    inlined: true
+    inlined_as_list: true
+  sample_type:
+    name: sample_type
+    description: Type of sample imaged in a CryoET study.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:preparation_sample_type
+    alias: sample_type
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  sample_preparation:
+    name: sample_preparation
+    description: Describes how the sample was prepared.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:sample_preparation
+    alias: sample_preparation
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  grid_preparation:
+    name: grid_preparation
+    description: Describes Cryo-ET grid preparation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:grid_preparation
+    alias: grid_preparation
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  other_setup:
+    name: other_setup
+    description: Describes other setup not covered by sample preparation or grid preparation
+      that may make this dataset unique in   the same publication.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:preparation_other_setup
+    alias: other_setup
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  organism:
+    name: organism
+    description: The species from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: organism
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: Organism
+    inlined: true
+    inlined_as_list: true
+  tissue:
+    name: tissue
+    description: The type of tissue from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: tissue
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: Tissue
+    inlined: true
+    inlined_as_list: true
+  cell_type:
+    name: cell_type
+    description: The cell type from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: cell_type
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellType
+    inlined: true
+    inlined_as_list: true
+  cell_strain:
+    name: cell_strain
+    description: The strain or cell line from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: cell_strain
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellStrain
+    inlined: true
+    inlined_as_list: true
+  cell_component:
+    name: cell_component
+    description: The cellular component from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: cell_component
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellComponent
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Dataset
+description: High-level description of a cryoET dataset.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+mixins:
+- DatestampedEntity
+- AuthoredEntity
+- FundedEntity
+- PicturedEntity
+- CrossReferencedEntity
+- ExperimentalMetadata
+attributes:
+  dataset_identifier:
+    name: dataset_identifier
+    description: An identifier for a CryoET dataset, assigned by the Data Portal.
+      Used to identify the dataset as the directory  name in data tree.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:dataset_identifier
+    rank: 1000
+    alias: dataset_identifier
+    owner: Dataset
+    domain_of:
+    - Dataset
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  dataset_title:
+    name: dataset_title
+    description: Title of a CryoET dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:dataset_title
+    rank: 1000
+    alias: dataset_title
+    owner: Dataset
+    domain_of:
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  dataset_description:
+    name: dataset_description
+    description: A short description of a CryoET dataset, similar to an abstract for
+      a journal article or dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:dataset_description
+    rank: 1000
+    alias: dataset_description
+    owner: Dataset
+    domain_of:
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  dates:
+    name: dates
+    description: A set of dates at which a data item was deposited, published and
+      last modified.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: dates
+    owner: Dataset
+    domain_of:
+    - DatestampedEntity
+    - Dataset
+    - Annotation
+    range: DateStamp
+    required: true
+    inlined: true
+    inlined_as_list: true
+  authors:
+    name: authors
+    description: Author of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    multivalued: true
+    list_elements_ordered: true
+    alias: authors
+    owner: Dataset
+    domain_of:
+    - AuthoredEntity
+    - AnnotatoredEntity
+    - Dataset
+    - Tomogram
+    - Annotation
+    range: Author
+    required: true
+    inlined: true
+    inlined_as_list: true
+  funding:
+    name: funding
+    description: A funding source for a scientific data entity (base for JSON and
+      DB representation).
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    multivalued: true
+    list_elements_ordered: true
+    alias: funding
+    owner: Dataset
+    domain_of:
+    - FundedEntity
+    - Dataset
+    range: Funding
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+  key_photos:
+    name: key_photos
+    description: A set of paths to representative images of a piece of data.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: key_photos
+    owner: Dataset
+    domain_of:
+    - PicturedEntity
+    - Dataset
+    - Tomogram
+    range: PicturePath
+    required: true
+    inlined: true
+    inlined_as_list: true
+  cross_references:
+    name: cross_references
+    description: A set of cross-references to other databases and publications.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: cross_references
+    owner: Dataset
+    domain_of:
+    - CrossReferencedEntity
+    - Dataset
+    range: CrossReferences
+    inlined: true
+    inlined_as_list: true
+  sample_type:
+    name: sample_type
+    description: Type of sample imaged in a CryoET study.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:preparation_sample_type
+    alias: sample_type
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  sample_preparation:
+    name: sample_preparation
+    description: Describes how the sample was prepared.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:sample_preparation
+    alias: sample_preparation
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  grid_preparation:
+    name: grid_preparation
+    description: Describes Cryo-ET grid preparation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:grid_preparation
+    alias: grid_preparation
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  other_setup:
+    name: other_setup
+    description: Describes other setup not covered by sample preparation or grid preparation
+      that may make this dataset unique in   the same publication.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:preparation_other_setup
+    alias: other_setup
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  organism:
+    name: organism
+    description: The species from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: organism
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: Organism
+    inlined: true
+    inlined_as_list: true
+  tissue:
+    name: tissue
+    description: The type of tissue from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: tissue
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: Tissue
+    inlined: true
+    inlined_as_list: true
+  cell_type:
+    name: cell_type
+    description: The cell type from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: cell_type
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellType
+    inlined: true
+    inlined_as_list: true
+  cell_strain:
+    name: cell_strain
+    description: The strain or cell line from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: cell_strain
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellStrain
+    inlined: true
+    inlined_as_list: true
+  cell_component:
+    name: cell_component
+    description: The cellular component from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: cell_component
+    owner: Dataset
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellComponent
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/Dataset.md
+++ b/schema/v1.1.0/metadata-docs/Dataset.md
@@ -7,7 +7,7 @@ _High-level description of a cryoET dataset._
 
 
 
-URI: [cdp-meta:Dataset](https://cryoetdataportal.czscience.com/schema/metadata/Dataset)
+URI: [cdp-meta:Dataset](metadataDataset)
 
 
 
@@ -143,7 +143,7 @@ URI: [cdp-meta:Dataset](https://cryoetdataportal.czscience.com/schema/metadata/D
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -170,7 +170,7 @@ URI: [cdp-meta:Dataset](https://cryoetdataportal.czscience.com/schema/metadata/D
 ```yaml
 name: Dataset
 description: High-level description of a cryoET dataset.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 mixins:
 - DatestampedEntity
 - AuthoredEntity
@@ -183,7 +183,7 @@ attributes:
     name: dataset_identifier
     description: An identifier for a CryoET dataset, assigned by the Data Portal.
       Used to identify the dataset as the directory  name in data tree.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:dataset_identifier
     rank: 1000
@@ -197,7 +197,7 @@ attributes:
   dataset_title:
     name: dataset_title
     description: Title of a CryoET dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:dataset_title
     rank: 1000
@@ -212,7 +212,7 @@ attributes:
     name: dataset_description
     description: A short description of a CryoET dataset, similar to an abstract for
       a journal article or dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:dataset_description
     rank: 1000
@@ -227,7 +227,7 @@ attributes:
     name: dates
     description: A set of dates at which a data item was deposited, published and
       last modified.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: dates
     owner: Dataset
     domain_of:
@@ -241,7 +241,7 @@ attributes:
   authors:
     name: authors
     description: Author of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     multivalued: true
     list_elements_ordered: true
     alias: authors
@@ -260,7 +260,7 @@ attributes:
     name: funding
     description: A funding source for a scientific data entity (base for JSON and
       DB representation).
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     multivalued: true
     list_elements_ordered: true
     alias: funding
@@ -275,7 +275,7 @@ attributes:
   key_photos:
     name: key_photos
     description: A set of paths to representative images of a piece of data.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: key_photos
     owner: Dataset
     domain_of:
@@ -289,7 +289,7 @@ attributes:
   cross_references:
     name: cross_references
     description: A set of cross-references to other databases and publications.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: cross_references
     owner: Dataset
     domain_of:
@@ -301,7 +301,7 @@ attributes:
   sample_type:
     name: sample_type
     description: Type of sample imaged in a CryoET study.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:preparation_sample_type
     alias: sample_type
@@ -315,7 +315,7 @@ attributes:
   sample_preparation:
     name: sample_preparation
     description: Describes how the sample was prepared.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:sample_preparation
     alias: sample_preparation
@@ -329,7 +329,7 @@ attributes:
   grid_preparation:
     name: grid_preparation
     description: Describes Cryo-ET grid preparation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:grid_preparation
     alias: grid_preparation
@@ -344,7 +344,7 @@ attributes:
     name: other_setup
     description: Describes other setup not covered by sample preparation or grid preparation
       that may make this dataset unique in   the same publication.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:preparation_other_setup
     alias: other_setup
@@ -358,7 +358,7 @@ attributes:
   organism:
     name: organism
     description: The species from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: organism
     owner: Dataset
     domain_of:
@@ -370,7 +370,7 @@ attributes:
   tissue:
     name: tissue
     description: The type of tissue from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: tissue
     owner: Dataset
     domain_of:
@@ -382,7 +382,7 @@ attributes:
   cell_type:
     name: cell_type
     description: The cell type from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: cell_type
     owner: Dataset
     domain_of:
@@ -394,7 +394,7 @@ attributes:
   cell_strain:
     name: cell_strain
     description: The strain or cell line from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: cell_strain
     owner: Dataset
     domain_of:
@@ -406,7 +406,7 @@ attributes:
   cell_component:
     name: cell_component
     description: The cellular component from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: cell_component
     owner: Dataset
     domain_of:
@@ -425,7 +425,7 @@ attributes:
 ```yaml
 name: Dataset
 description: High-level description of a cryoET dataset.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 mixins:
 - DatestampedEntity
 - AuthoredEntity
@@ -438,7 +438,7 @@ attributes:
     name: dataset_identifier
     description: An identifier for a CryoET dataset, assigned by the Data Portal.
       Used to identify the dataset as the directory  name in data tree.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:dataset_identifier
     rank: 1000
@@ -452,7 +452,7 @@ attributes:
   dataset_title:
     name: dataset_title
     description: Title of a CryoET dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:dataset_title
     rank: 1000
@@ -467,7 +467,7 @@ attributes:
     name: dataset_description
     description: A short description of a CryoET dataset, similar to an abstract for
       a journal article or dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:dataset_description
     rank: 1000
@@ -482,7 +482,7 @@ attributes:
     name: dates
     description: A set of dates at which a data item was deposited, published and
       last modified.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: dates
     owner: Dataset
     domain_of:
@@ -496,7 +496,7 @@ attributes:
   authors:
     name: authors
     description: Author of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     multivalued: true
     list_elements_ordered: true
     alias: authors
@@ -515,7 +515,7 @@ attributes:
     name: funding
     description: A funding source for a scientific data entity (base for JSON and
       DB representation).
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     multivalued: true
     list_elements_ordered: true
     alias: funding
@@ -530,7 +530,7 @@ attributes:
   key_photos:
     name: key_photos
     description: A set of paths to representative images of a piece of data.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: key_photos
     owner: Dataset
     domain_of:
@@ -544,7 +544,7 @@ attributes:
   cross_references:
     name: cross_references
     description: A set of cross-references to other databases and publications.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: cross_references
     owner: Dataset
     domain_of:
@@ -556,7 +556,7 @@ attributes:
   sample_type:
     name: sample_type
     description: Type of sample imaged in a CryoET study.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:preparation_sample_type
     alias: sample_type
@@ -570,7 +570,7 @@ attributes:
   sample_preparation:
     name: sample_preparation
     description: Describes how the sample was prepared.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:sample_preparation
     alias: sample_preparation
@@ -584,7 +584,7 @@ attributes:
   grid_preparation:
     name: grid_preparation
     description: Describes Cryo-ET grid preparation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:grid_preparation
     alias: grid_preparation
@@ -599,7 +599,7 @@ attributes:
     name: other_setup
     description: Describes other setup not covered by sample preparation or grid preparation
       that may make this dataset unique in   the same publication.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:preparation_other_setup
     alias: other_setup
@@ -613,7 +613,7 @@ attributes:
   organism:
     name: organism
     description: The species from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: organism
     owner: Dataset
     domain_of:
@@ -625,7 +625,7 @@ attributes:
   tissue:
     name: tissue
     description: The type of tissue from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: tissue
     owner: Dataset
     domain_of:
@@ -637,7 +637,7 @@ attributes:
   cell_type:
     name: cell_type
     description: The cell type from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: cell_type
     owner: Dataset
     domain_of:
@@ -649,7 +649,7 @@ attributes:
   cell_strain:
     name: cell_strain
     description: The strain or cell line from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: cell_strain
     owner: Dataset
     domain_of:
@@ -661,7 +661,7 @@ attributes:
   cell_component:
     name: cell_component
     description: The cellular component from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: cell_component
     owner: Dataset
     domain_of:

--- a/schema/v1.1.0/metadata-docs/DateStamp.md
+++ b/schema/v1.1.0/metadata-docs/DateStamp.md
@@ -1,0 +1,245 @@
+# Class: DateStamp
+
+
+_A set of dates at which a data item was deposited, published and last modified._
+
+
+
+
+* __NOTE__: this is an abstract class and should not be instantiated directly
+
+
+URI: [cdp-meta:DateStamp](https://cryoetdataportal.czscience.com/schema/metadata/DateStamp)
+
+
+
+
+```mermaid
+ classDiagram
+    class DateStamp
+      DateStamp : deposition_date
+        
+          DateStamp --> date : deposition_date
+        
+      DateStamp : last_modified_date
+        
+          DateStamp --> date : last_modified_date
+        
+      DateStamp : release_date
+        
+          DateStamp --> date : release_date
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [deposition_date](deposition_date.md) | 1..1 <br/> [xsd:date](http://www.w3.org/2001/XMLSchema#date) | The date a data item was received by the cryoET data portal | direct |
+| [release_date](release_date.md) | 1..1 _recommended_ <br/> [xsd:date](http://www.w3.org/2001/XMLSchema#date) | The date a data item was received by the cryoET data portal | direct |
+| [last_modified_date](last_modified_date.md) | 1..1 _recommended_ <br/> [xsd:date](http://www.w3.org/2001/XMLSchema#date) | The date a piece of data was last modified on the cryoET data portal | direct |
+| [deposition_date](deposition_date.md) | 1..1 <br/> [xsd:date](http://www.w3.org/2001/XMLSchema#date) | The date a data item was received by the cryoET data portal | direct |
+| [release_date](release_date.md) | 1..1 _recommended_ <br/> [xsd:date](http://www.w3.org/2001/XMLSchema#date) | The date a data item was received by the cryoET data portal | direct |
+| [last_modified_date](last_modified_date.md) | 1..1 _recommended_ <br/> [xsd:date](http://www.w3.org/2001/XMLSchema#date) | The date a piece of data was last modified on the cryoET data portal | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [DatestampedEntity](DatestampedEntity.md) | [dates](dates.md) | range | [DateStamp](DateStamp.md) |
+| [Dataset](Dataset.md) | [dates](dates.md) | range | [DateStamp](DateStamp.md) |
+| [Annotation](Annotation.md) | [dates](dates.md) | range | [DateStamp](DateStamp.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:DateStamp |
+| native | cdp-meta:DateStamp |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: DateStamp
+description: A set of dates at which a data item was deposited, published and last
+  modified.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+slots:
+- deposition_date
+- release_date
+- last_modified_date
+slot_usage:
+  deposition_date:
+    name: deposition_date
+    domain_of:
+    - DateStamp
+    required: true
+  release_date:
+    name: release_date
+    domain_of:
+    - DateStamp
+    recommended: true
+  last_modified_date:
+    name: last_modified_date
+    domain_of:
+    - DateStamp
+    recommended: true
+attributes:
+  deposition_date:
+    name: deposition_date
+    description: The date a data item was received by the cryoET data portal.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: deposition_date
+    owner: DateStamp
+    domain_of:
+    - DateStamp
+    range: date
+    required: true
+    inlined: true
+    inlined_as_list: true
+  release_date:
+    name: release_date
+    description: The date a data item was received by the cryoET data portal.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: release_date
+    owner: DateStamp
+    domain_of:
+    - DateStamp
+    range: date
+    required: true
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+  last_modified_date:
+    name: last_modified_date
+    description: The date a piece of data was last modified on the cryoET data portal.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: last_modified_date
+    owner: DateStamp
+    domain_of:
+    - DateStamp
+    range: date
+    required: true
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: DateStamp
+description: A set of dates at which a data item was deposited, published and last
+  modified.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+slot_usage:
+  deposition_date:
+    name: deposition_date
+    domain_of:
+    - DateStamp
+    required: true
+  release_date:
+    name: release_date
+    domain_of:
+    - DateStamp
+    recommended: true
+  last_modified_date:
+    name: last_modified_date
+    domain_of:
+    - DateStamp
+    recommended: true
+attributes:
+  deposition_date:
+    name: deposition_date
+    description: The date a data item was received by the cryoET data portal.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: deposition_date
+    owner: DateStamp
+    domain_of:
+    - DateStamp
+    range: date
+    required: true
+    inlined: true
+    inlined_as_list: true
+  release_date:
+    name: release_date
+    description: The date a data item was received by the cryoET data portal.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: release_date
+    owner: DateStamp
+    domain_of:
+    - DateStamp
+    range: date
+    required: true
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+  last_modified_date:
+    name: last_modified_date
+    description: The date a piece of data was last modified on the cryoET data portal.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: last_modified_date
+    owner: DateStamp
+    domain_of:
+    - DateStamp
+    range: date
+    required: true
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/DateStamp.md
+++ b/schema/v1.1.0/metadata-docs/DateStamp.md
@@ -9,7 +9,7 @@ _A set of dates at which a data item was deposited, published and last modified.
 * __NOTE__: this is an abstract class and should not be instantiated directly
 
 
-URI: [cdp-meta:DateStamp](https://cryoetdataportal.czscience.com/schema/metadata/DateStamp)
+URI: [cdp-meta:DateStamp](metadataDateStamp)
 
 
 
@@ -77,7 +77,7 @@ URI: [cdp-meta:DateStamp](https://cryoetdataportal.czscience.com/schema/metadata
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -105,7 +105,7 @@ URI: [cdp-meta:DateStamp](https://cryoetdataportal.czscience.com/schema/metadata
 name: DateStamp
 description: A set of dates at which a data item was deposited, published and last
   modified.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 slots:
 - deposition_date
@@ -131,7 +131,7 @@ attributes:
   deposition_date:
     name: deposition_date
     description: The date a data item was received by the cryoET data portal.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: deposition_date
     owner: DateStamp
@@ -144,7 +144,7 @@ attributes:
   release_date:
     name: release_date
     description: The date a data item was received by the cryoET data portal.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: release_date
     owner: DateStamp
@@ -158,7 +158,7 @@ attributes:
   last_modified_date:
     name: last_modified_date
     description: The date a piece of data was last modified on the cryoET data portal.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: last_modified_date
     owner: DateStamp
@@ -180,7 +180,7 @@ attributes:
 name: DateStamp
 description: A set of dates at which a data item was deposited, published and last
   modified.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 slot_usage:
   deposition_date:
@@ -202,7 +202,7 @@ attributes:
   deposition_date:
     name: deposition_date
     description: The date a data item was received by the cryoET data portal.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: deposition_date
     owner: DateStamp
@@ -215,7 +215,7 @@ attributes:
   release_date:
     name: release_date
     description: The date a data item was received by the cryoET data portal.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: release_date
     owner: DateStamp
@@ -229,7 +229,7 @@ attributes:
   last_modified_date:
     name: last_modified_date
     description: The date a piece of data was last modified on the cryoET data portal.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: last_modified_date
     owner: DateStamp

--- a/schema/v1.1.0/metadata-docs/DatestampedEntity.md
+++ b/schema/v1.1.0/metadata-docs/DatestampedEntity.md
@@ -9,7 +9,7 @@ _An entity with associated deposition, release and last modified dates._
 * __NOTE__: this is an abstract class and should not be instantiated directly
 
 
-URI: [cdp-meta:DatestampedEntity](https://cryoetdataportal.czscience.com/schema/metadata/DatestampedEntity)
+URI: [cdp-meta:DatestampedEntity](metadataDatestampedEntity)
 
 
 
@@ -58,7 +58,7 @@ URI: [cdp-meta:DatestampedEntity](https://cryoetdataportal.czscience.com/schema/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -85,14 +85,14 @@ URI: [cdp-meta:DatestampedEntity](https://cryoetdataportal.czscience.com/schema/
 ```yaml
 name: DatestampedEntity
 description: An entity with associated deposition, release and last modified dates.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   dates:
     name: dates
     description: A set of dates at which a data item was deposited, published and
       last modified.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: dates
     owner: DatestampedEntity
@@ -114,14 +114,14 @@ attributes:
 ```yaml
 name: DatestampedEntity
 description: An entity with associated deposition, release and last modified dates.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   dates:
     name: dates
     description: A set of dates at which a data item was deposited, published and
       last modified.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: dates
     owner: DatestampedEntity

--- a/schema/v1.1.0/metadata-docs/DatestampedEntity.md
+++ b/schema/v1.1.0/metadata-docs/DatestampedEntity.md
@@ -1,0 +1,138 @@
+# Class: DatestampedEntity
+
+
+_An entity with associated deposition, release and last modified dates._
+
+
+
+
+* __NOTE__: this is an abstract class and should not be instantiated directly
+
+
+URI: [cdp-meta:DatestampedEntity](https://cryoetdataportal.czscience.com/schema/metadata/DatestampedEntity)
+
+
+
+
+```mermaid
+ classDiagram
+    class DatestampedEntity
+      DatestampedEntity <|-- Dataset
+      DatestampedEntity <|-- Annotation
+      
+      DatestampedEntity : dates
+        
+          DatestampedEntity --> DateStamp : dates
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [dates](dates.md) | 1..1 <br/> [DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:DatestampedEntity |
+| native | cdp-meta:DatestampedEntity |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: DatestampedEntity
+description: An entity with associated deposition, release and last modified dates.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  dates:
+    name: dates
+    description: A set of dates at which a data item was deposited, published and
+      last modified.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: dates
+    owner: DatestampedEntity
+    domain_of:
+    - DatestampedEntity
+    - Dataset
+    - Annotation
+    range: DateStamp
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: DatestampedEntity
+description: An entity with associated deposition, release and last modified dates.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  dates:
+    name: dates
+    description: A set of dates at which a data item was deposited, published and
+      last modified.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: dates
+    owner: DatestampedEntity
+    domain_of:
+    - DatestampedEntity
+    - Dataset
+    - Annotation
+    range: DateStamp
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/ExperimentalMetadata.md
+++ b/schema/v1.1.0/metadata-docs/ExperimentalMetadata.md
@@ -9,7 +9,7 @@ _Metadata describing sample and sample preparation methods used in a cryoET data
 * __NOTE__: this is an abstract class and should not be instantiated directly
 
 
-URI: [cdp-meta:ExperimentalMetadata](https://cryoetdataportal.czscience.com/schema/metadata/ExperimentalMetadata)
+URI: [cdp-meta:ExperimentalMetadata](metadataExperimentalMetadata)
 
 
 
@@ -97,7 +97,7 @@ URI: [cdp-meta:ExperimentalMetadata](https://cryoetdataportal.czscience.com/sche
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -125,13 +125,13 @@ URI: [cdp-meta:ExperimentalMetadata](https://cryoetdataportal.czscience.com/sche
 name: ExperimentalMetadata
 description: Metadata describing sample and sample preparation methods used in a cryoET
   dataset.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   sample_type:
     name: sample_type
     description: Type of sample imaged in a CryoET study.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:preparation_sample_type
     rank: 1000
@@ -146,7 +146,7 @@ attributes:
   sample_preparation:
     name: sample_preparation
     description: Describes how the sample was prepared.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:sample_preparation
     rank: 1000
@@ -161,7 +161,7 @@ attributes:
   grid_preparation:
     name: grid_preparation
     description: Describes Cryo-ET grid preparation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:grid_preparation
     rank: 1000
@@ -177,7 +177,7 @@ attributes:
     name: other_setup
     description: Describes other setup not covered by sample preparation or grid preparation
       that may make this dataset unique in   the same publication.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:preparation_other_setup
     rank: 1000
@@ -192,7 +192,7 @@ attributes:
   organism:
     name: organism
     description: The species from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: organism
     owner: ExperimentalMetadata
@@ -205,7 +205,7 @@ attributes:
   tissue:
     name: tissue
     description: The type of tissue from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: tissue
     owner: ExperimentalMetadata
@@ -218,7 +218,7 @@ attributes:
   cell_type:
     name: cell_type
     description: The cell type from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: cell_type
     owner: ExperimentalMetadata
@@ -231,7 +231,7 @@ attributes:
   cell_strain:
     name: cell_strain
     description: The strain or cell line from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: cell_strain
     owner: ExperimentalMetadata
@@ -244,7 +244,7 @@ attributes:
   cell_component:
     name: cell_component
     description: The cellular component from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: cell_component
     owner: ExperimentalMetadata
@@ -265,13 +265,13 @@ attributes:
 name: ExperimentalMetadata
 description: Metadata describing sample and sample preparation methods used in a cryoET
   dataset.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   sample_type:
     name: sample_type
     description: Type of sample imaged in a CryoET study.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:preparation_sample_type
     rank: 1000
@@ -286,7 +286,7 @@ attributes:
   sample_preparation:
     name: sample_preparation
     description: Describes how the sample was prepared.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:sample_preparation
     rank: 1000
@@ -301,7 +301,7 @@ attributes:
   grid_preparation:
     name: grid_preparation
     description: Describes Cryo-ET grid preparation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:grid_preparation
     rank: 1000
@@ -317,7 +317,7 @@ attributes:
     name: other_setup
     description: Describes other setup not covered by sample preparation or grid preparation
       that may make this dataset unique in   the same publication.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:preparation_other_setup
     rank: 1000
@@ -332,7 +332,7 @@ attributes:
   organism:
     name: organism
     description: The species from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: organism
     owner: ExperimentalMetadata
@@ -345,7 +345,7 @@ attributes:
   tissue:
     name: tissue
     description: The type of tissue from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: tissue
     owner: ExperimentalMetadata
@@ -358,7 +358,7 @@ attributes:
   cell_type:
     name: cell_type
     description: The cell type from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: cell_type
     owner: ExperimentalMetadata
@@ -371,7 +371,7 @@ attributes:
   cell_strain:
     name: cell_strain
     description: The strain or cell line from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: cell_strain
     owner: ExperimentalMetadata
@@ -384,7 +384,7 @@ attributes:
   cell_component:
     name: cell_component
     description: The cellular component from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: cell_component
     owner: ExperimentalMetadata

--- a/schema/v1.1.0/metadata-docs/ExperimentalMetadata.md
+++ b/schema/v1.1.0/metadata-docs/ExperimentalMetadata.md
@@ -1,0 +1,399 @@
+# Class: ExperimentalMetadata
+
+
+_Metadata describing sample and sample preparation methods used in a cryoET dataset._
+
+
+
+
+* __NOTE__: this is an abstract class and should not be instantiated directly
+
+
+URI: [cdp-meta:ExperimentalMetadata](https://cryoetdataportal.czscience.com/schema/metadata/ExperimentalMetadata)
+
+
+
+
+```mermaid
+ classDiagram
+    class ExperimentalMetadata
+      ExperimentalMetadata <|-- Dataset
+      
+      ExperimentalMetadata : cell_component
+        
+          ExperimentalMetadata --> CellComponent : cell_component
+        
+      ExperimentalMetadata : cell_strain
+        
+          ExperimentalMetadata --> CellStrain : cell_strain
+        
+      ExperimentalMetadata : cell_type
+        
+          ExperimentalMetadata --> CellType : cell_type
+        
+      ExperimentalMetadata : grid_preparation
+        
+          ExperimentalMetadata --> string : grid_preparation
+        
+      ExperimentalMetadata : organism
+        
+          ExperimentalMetadata --> Organism : organism
+        
+      ExperimentalMetadata : other_setup
+        
+          ExperimentalMetadata --> string : other_setup
+        
+      ExperimentalMetadata : sample_preparation
+        
+          ExperimentalMetadata --> string : sample_preparation
+        
+      ExperimentalMetadata : sample_type
+        
+          ExperimentalMetadata --> sample_type_enum : sample_type
+        
+      ExperimentalMetadata : tissue
+        
+          ExperimentalMetadata --> Tissue : tissue
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [sample_type](sample_type.md) | 0..1 <br/> [SampleTypeEnum](SampleTypeEnum.md) | Type of sample imaged in a CryoET study | direct |
+| [sample_preparation](sample_preparation.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Describes how the sample was prepared | direct |
+| [grid_preparation](grid_preparation.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Describes Cryo-ET grid preparation | direct |
+| [other_setup](other_setup.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Describes other setup not covered by sample preparation or grid preparation t... | direct |
+| [organism](organism.md) | 0..1 <br/> [Organism](Organism.md) | The species from which the sample was derived | direct |
+| [tissue](tissue.md) | 0..1 <br/> [Tissue](Tissue.md) | The type of tissue from which the sample was derived | direct |
+| [cell_type](cell_type.md) | 0..1 <br/> [CellType](CellType.md) | The cell type from which the sample was derived | direct |
+| [cell_strain](cell_strain.md) | 0..1 <br/> [CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived | direct |
+| [cell_component](cell_component.md) | 0..1 <br/> [CellComponent](CellComponent.md) | The cellular component from which the sample was derived | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:ExperimentalMetadata |
+| native | cdp-meta:ExperimentalMetadata |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: ExperimentalMetadata
+description: Metadata describing sample and sample preparation methods used in a cryoET
+  dataset.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  sample_type:
+    name: sample_type
+    description: Type of sample imaged in a CryoET study.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:preparation_sample_type
+    rank: 1000
+    alias: sample_type
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: sample_type_enum
+    inlined: true
+    inlined_as_list: true
+  sample_preparation:
+    name: sample_preparation
+    description: Describes how the sample was prepared.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:sample_preparation
+    rank: 1000
+    alias: sample_preparation
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  grid_preparation:
+    name: grid_preparation
+    description: Describes Cryo-ET grid preparation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:grid_preparation
+    rank: 1000
+    alias: grid_preparation
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  other_setup:
+    name: other_setup
+    description: Describes other setup not covered by sample preparation or grid preparation
+      that may make this dataset unique in   the same publication.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:preparation_other_setup
+    rank: 1000
+    alias: other_setup
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  organism:
+    name: organism
+    description: The species from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: organism
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: Organism
+    inlined: true
+    inlined_as_list: true
+  tissue:
+    name: tissue
+    description: The type of tissue from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: tissue
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: Tissue
+    inlined: true
+    inlined_as_list: true
+  cell_type:
+    name: cell_type
+    description: The cell type from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: cell_type
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellType
+    inlined: true
+    inlined_as_list: true
+  cell_strain:
+    name: cell_strain
+    description: The strain or cell line from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: cell_strain
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellStrain
+    inlined: true
+    inlined_as_list: true
+  cell_component:
+    name: cell_component
+    description: The cellular component from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: cell_component
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellComponent
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: ExperimentalMetadata
+description: Metadata describing sample and sample preparation methods used in a cryoET
+  dataset.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  sample_type:
+    name: sample_type
+    description: Type of sample imaged in a CryoET study.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:preparation_sample_type
+    rank: 1000
+    alias: sample_type
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: sample_type_enum
+    inlined: true
+    inlined_as_list: true
+  sample_preparation:
+    name: sample_preparation
+    description: Describes how the sample was prepared.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:sample_preparation
+    rank: 1000
+    alias: sample_preparation
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  grid_preparation:
+    name: grid_preparation
+    description: Describes Cryo-ET grid preparation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:grid_preparation
+    rank: 1000
+    alias: grid_preparation
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  other_setup:
+    name: other_setup
+    description: Describes other setup not covered by sample preparation or grid preparation
+      that may make this dataset unique in   the same publication.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:preparation_other_setup
+    rank: 1000
+    alias: other_setup
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  organism:
+    name: organism
+    description: The species from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: organism
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: Organism
+    inlined: true
+    inlined_as_list: true
+  tissue:
+    name: tissue
+    description: The type of tissue from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: tissue
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: Tissue
+    inlined: true
+    inlined_as_list: true
+  cell_type:
+    name: cell_type
+    description: The cell type from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: cell_type
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellType
+    inlined: true
+    inlined_as_list: true
+  cell_strain:
+    name: cell_strain
+    description: The strain or cell line from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: cell_strain
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellStrain
+    inlined: true
+    inlined_as_list: true
+  cell_component:
+    name: cell_component
+    description: The cellular component from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: cell_component
+    owner: ExperimentalMetadata
+    domain_of:
+    - ExperimentalMetadata
+    - Dataset
+    range: CellComponent
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/FiducialAlignmentStatusEnum.md
+++ b/schema/v1.1.0/metadata-docs/FiducialAlignmentStatusEnum.md
@@ -1,0 +1,66 @@
+# Enum: FiducialAlignmentStatusEnum
+
+
+
+
+_Fiducial Alignment method_
+
+
+
+URI: [FiducialAlignmentStatusEnum](FiducialAlignmentStatusEnum.md)
+
+## Permissible Values
+
+| Value | Meaning | Description |
+| --- | --- | --- |
+| FIDUCIAL | None | Alignment computed based on fiducial markers |
+| NON_FIDUCIAL | None | Alignment computed without fiducial markers |
+
+
+
+
+## Slots
+
+| Name | Description |
+| ---  | --- |
+| [fiducial_alignment_status](fiducial_alignment_status.md) | Whether the tomographic alignment was computed based on fiducial markers |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: fiducial_alignment_status_enum
+description: Fiducial Alignment method
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+permissible_values:
+  FIDUCIAL:
+    text: FIDUCIAL
+    description: Alignment computed based on fiducial markers
+  NON_FIDUCIAL:
+    text: NON_FIDUCIAL
+    description: Alignment computed without fiducial markers
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/FiducialAlignmentStatusEnum.md
+++ b/schema/v1.1.0/metadata-docs/FiducialAlignmentStatusEnum.md
@@ -41,7 +41,7 @@ URI: [FiducialAlignmentStatusEnum](FiducialAlignmentStatusEnum.md)
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -52,7 +52,7 @@ URI: [FiducialAlignmentStatusEnum](FiducialAlignmentStatusEnum.md)
 ```yaml
 name: fiducial_alignment_status_enum
 description: Fiducial Alignment method
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 permissible_values:
   FIDUCIAL:

--- a/schema/v1.1.0/metadata-docs/FundedEntity.md
+++ b/schema/v1.1.0/metadata-docs/FundedEntity.md
@@ -1,0 +1,139 @@
+# Class: FundedEntity
+
+
+_An entity with associated funding sources._
+
+
+
+
+* __NOTE__: this is an abstract class and should not be instantiated directly
+
+
+URI: [cdp-meta:FundedEntity](https://cryoetdataportal.czscience.com/schema/metadata/FundedEntity)
+
+
+
+
+```mermaid
+ classDiagram
+    class FundedEntity
+      FundedEntity <|-- Dataset
+      
+      FundedEntity : funding
+        
+          FundedEntity --> Funding : funding
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [funding](funding.md) | 0..* _recommended_ <br/> [Funding](Funding.md) | A funding source for a scientific data entity (base for JSON and DB represent... | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:FundedEntity |
+| native | cdp-meta:FundedEntity |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: FundedEntity
+description: An entity with associated funding sources.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  funding:
+    name: funding
+    description: A funding source for a scientific data entity (base for JSON and
+      DB representation).
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    multivalued: true
+    list_elements_ordered: true
+    alias: funding
+    owner: FundedEntity
+    domain_of:
+    - FundedEntity
+    - Dataset
+    range: Funding
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: FundedEntity
+description: An entity with associated funding sources.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  funding:
+    name: funding
+    description: A funding source for a scientific data entity (base for JSON and
+      DB representation).
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    multivalued: true
+    list_elements_ordered: true
+    alias: funding
+    owner: FundedEntity
+    domain_of:
+    - FundedEntity
+    - Dataset
+    range: Funding
+    recommended: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/FundedEntity.md
+++ b/schema/v1.1.0/metadata-docs/FundedEntity.md
@@ -9,7 +9,7 @@ _An entity with associated funding sources._
 * __NOTE__: this is an abstract class and should not be instantiated directly
 
 
-URI: [cdp-meta:FundedEntity](https://cryoetdataportal.czscience.com/schema/metadata/FundedEntity)
+URI: [cdp-meta:FundedEntity](metadataFundedEntity)
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:FundedEntity](https://cryoetdataportal.czscience.com/schema/metad
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -84,14 +84,14 @@ URI: [cdp-meta:FundedEntity](https://cryoetdataportal.czscience.com/schema/metad
 ```yaml
 name: FundedEntity
 description: An entity with associated funding sources.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   funding:
     name: funding
     description: A funding source for a scientific data entity (base for JSON and
       DB representation).
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     multivalued: true
     list_elements_ordered: true
@@ -114,14 +114,14 @@ attributes:
 ```yaml
 name: FundedEntity
 description: An entity with associated funding sources.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   funding:
     name: funding
     description: A funding source for a scientific data entity (base for JSON and
       DB representation).
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     multivalued: true
     list_elements_ordered: true

--- a/schema/v1.1.0/metadata-docs/Funding.md
+++ b/schema/v1.1.0/metadata-docs/Funding.md
@@ -1,6 +1,6 @@
 # Slot: funding
 
-URI: [cdp-meta:funding](https://cryoetdataportal.czscience.com/schema/metadata/funding)
+URI: [cdp-meta:funding](metadatafunding)
 
 
 

--- a/schema/v1.1.0/metadata-docs/Funding.md
+++ b/schema/v1.1.0/metadata-docs/Funding.md
@@ -1,0 +1,54 @@
+# Slot: funding
+
+URI: [cdp-meta:funding](https://cryoetdataportal.czscience.com/schema/metadata/funding)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[FundedEntity](FundedEntity.md) | An entity with associated funding sources |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: funding
+alias: funding
+domain_of:
+- FundedEntity
+- Dataset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/Microscope.md
+++ b/schema/v1.1.0/metadata-docs/Microscope.md
@@ -1,0 +1,70 @@
+# Slot: microscope
+
+
+_The microscope used to collect the tilt series._
+
+
+
+URI: [cdp-meta:microscope](https://cryoetdataportal.czscience.com/schema/metadata/microscope)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Microscope](Microscope.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: microscope
+description: The microscope used to collect the tilt series.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: microscope
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: Microscope
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/Microscope.md
+++ b/schema/v1.1.0/metadata-docs/Microscope.md
@@ -5,7 +5,7 @@ _The microscope used to collect the tilt series._
 
 
 
-URI: [cdp-meta:microscope](https://cryoetdataportal.czscience.com/schema/metadata/microscope)
+URI: [cdp-meta:microscope](metadatamicroscope)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:microscope](https://cryoetdataportal.czscience.com/schema/metadat
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:microscope](https://cryoetdataportal.czscience.com/schema/metadat
 ```yaml
 name: microscope
 description: The microscope used to collect the tilt series.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: microscope
 owner: TiltSeries

--- a/schema/v1.1.0/metadata-docs/MicroscopeOpticalSetup.md
+++ b/schema/v1.1.0/metadata-docs/MicroscopeOpticalSetup.md
@@ -7,7 +7,7 @@ _The optical setup of the microscope used to collect the tilt series._
 
 
 
-URI: [cdp-meta:MicroscopeOpticalSetup](https://cryoetdataportal.czscience.com/schema/metadata/MicroscopeOpticalSetup)
+URI: [cdp-meta:MicroscopeOpticalSetup](metadataMicroscopeOpticalSetup)
 
 
 
@@ -70,7 +70,7 @@ URI: [cdp-meta:MicroscopeOpticalSetup](https://cryoetdataportal.czscience.com/sc
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -97,12 +97,12 @@ URI: [cdp-meta:MicroscopeOpticalSetup](https://cryoetdataportal.czscience.com/sc
 ```yaml
 name: MicroscopeOpticalSetup
 description: The optical setup of the microscope used to collect the tilt series.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   energy_filter:
     name: energy_filter
     description: Energy filter setup used
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_microscope_energy_filter
     rank: 1000
@@ -116,7 +116,7 @@ attributes:
   phase_plate:
     name: phase_plate
     description: Phase plate configuration
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_microscope_phase_plate
     rank: 1000
@@ -130,7 +130,7 @@ attributes:
   image_corrector:
     name: image_corrector
     description: Image corrector setup
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_microscope_image_corrector
     rank: 1000
@@ -151,12 +151,12 @@ attributes:
 ```yaml
 name: MicroscopeOpticalSetup
 description: The optical setup of the microscope used to collect the tilt series.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   energy_filter:
     name: energy_filter
     description: Energy filter setup used
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_microscope_energy_filter
     rank: 1000
@@ -170,7 +170,7 @@ attributes:
   phase_plate:
     name: phase_plate
     description: Phase plate configuration
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_microscope_phase_plate
     rank: 1000
@@ -184,7 +184,7 @@ attributes:
   image_corrector:
     name: image_corrector
     description: Image corrector setup
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_microscope_image_corrector
     rank: 1000

--- a/schema/v1.1.0/metadata-docs/MicroscopeOpticalSetup.md
+++ b/schema/v1.1.0/metadata-docs/MicroscopeOpticalSetup.md
@@ -1,0 +1,200 @@
+# Class: MicroscopeOpticalSetup
+
+
+_The optical setup of the microscope used to collect the tilt series._
+
+
+
+
+
+URI: [cdp-meta:MicroscopeOpticalSetup](https://cryoetdataportal.czscience.com/schema/metadata/MicroscopeOpticalSetup)
+
+
+
+
+```mermaid
+ classDiagram
+    class MicroscopeOpticalSetup
+      MicroscopeOpticalSetup : energy_filter
+        
+          MicroscopeOpticalSetup --> string : energy_filter
+        
+      MicroscopeOpticalSetup : image_corrector
+        
+          MicroscopeOpticalSetup --> string : image_corrector
+        
+      MicroscopeOpticalSetup : phase_plate
+        
+          MicroscopeOpticalSetup --> string : phase_plate
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [energy_filter](energy_filter.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Energy filter setup used | direct |
+| [phase_plate](phase_plate.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Phase plate configuration | direct |
+| [image_corrector](image_corrector.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Image corrector setup | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [TiltSeries](TiltSeries.md) | [microscope_optical_setup](microscope_optical_setup.md) | range | [MicroscopeOpticalSetup](MicroscopeOpticalSetup.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:MicroscopeOpticalSetup |
+| native | cdp-meta:MicroscopeOpticalSetup |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: MicroscopeOpticalSetup
+description: The optical setup of the microscope used to collect the tilt series.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  energy_filter:
+    name: energy_filter
+    description: Energy filter setup used
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_microscope_energy_filter
+    rank: 1000
+    alias: energy_filter
+    owner: MicroscopeOpticalSetup
+    domain_of:
+    - MicroscopeOpticalSetup
+    range: string
+    inlined: true
+    inlined_as_list: true
+  phase_plate:
+    name: phase_plate
+    description: Phase plate configuration
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_microscope_phase_plate
+    rank: 1000
+    alias: phase_plate
+    owner: MicroscopeOpticalSetup
+    domain_of:
+    - MicroscopeOpticalSetup
+    range: string
+    inlined: true
+    inlined_as_list: true
+  image_corrector:
+    name: image_corrector
+    description: Image corrector setup
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_microscope_image_corrector
+    rank: 1000
+    alias: image_corrector
+    owner: MicroscopeOpticalSetup
+    domain_of:
+    - MicroscopeOpticalSetup
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: MicroscopeOpticalSetup
+description: The optical setup of the microscope used to collect the tilt series.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  energy_filter:
+    name: energy_filter
+    description: Energy filter setup used
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_microscope_energy_filter
+    rank: 1000
+    alias: energy_filter
+    owner: MicroscopeOpticalSetup
+    domain_of:
+    - MicroscopeOpticalSetup
+    range: string
+    inlined: true
+    inlined_as_list: true
+  phase_plate:
+    name: phase_plate
+    description: Phase plate configuration
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_microscope_phase_plate
+    rank: 1000
+    alias: phase_plate
+    owner: MicroscopeOpticalSetup
+    domain_of:
+    - MicroscopeOpticalSetup
+    range: string
+    inlined: true
+    inlined_as_list: true
+  image_corrector:
+    name: image_corrector
+    description: Image corrector setup
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_microscope_image_corrector
+    rank: 1000
+    alias: image_corrector
+    owner: MicroscopeOpticalSetup
+    domain_of:
+    - MicroscopeOpticalSetup
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/ORCID.md
+++ b/schema/v1.1.0/metadata-docs/ORCID.md
@@ -1,6 +1,6 @@
 # Slot: ORCID
 
-URI: [cdp-meta:ORCID](https://cryoetdataportal.czscience.com/schema/metadata/ORCID)
+URI: [cdp-meta:ORCID](metadataORCID)
 
 
 

--- a/schema/v1.1.0/metadata-docs/ORCID.md
+++ b/schema/v1.1.0/metadata-docs/ORCID.md
@@ -1,0 +1,54 @@
+# Slot: ORCID
+
+URI: [cdp-meta:ORCID](https://cryoetdataportal.czscience.com/schema/metadata/ORCID)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Author](Author.md) | Author of a scientific data entity |  no  |
+[Annotator](Annotator.md) | Annotator of a scientific data entity |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: ORCID
+alias: ORCID
+domain_of:
+- Author
+- Annotator
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/Organism.md
+++ b/schema/v1.1.0/metadata-docs/Organism.md
@@ -1,0 +1,54 @@
+# Slot: organism
+
+URI: [cdp-meta:organism](https://cryoetdataportal.czscience.com/schema/metadata/organism)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: organism
+alias: organism
+domain_of:
+- ExperimentalMetadata
+- Dataset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/Organism.md
+++ b/schema/v1.1.0/metadata-docs/Organism.md
@@ -1,6 +1,6 @@
 # Slot: organism
 
-URI: [cdp-meta:organism](https://cryoetdataportal.czscience.com/schema/metadata/organism)
+URI: [cdp-meta:organism](metadataorganism)
 
 
 

--- a/schema/v1.1.0/metadata-docs/PicturePath.md
+++ b/schema/v1.1.0/metadata-docs/PicturePath.md
@@ -7,7 +7,7 @@ _A set of paths to representative images of a piece of data._
 
 
 
-URI: [cdp-meta:PicturePath](https://cryoetdataportal.czscience.com/schema/metadata/PicturePath)
+URI: [cdp-meta:PicturePath](metadataPicturePath)
 
 
 
@@ -67,7 +67,7 @@ URI: [cdp-meta:PicturePath](https://cryoetdataportal.czscience.com/schema/metada
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -94,13 +94,13 @@ URI: [cdp-meta:PicturePath](https://cryoetdataportal.czscience.com/schema/metada
 ```yaml
 name: PicturePath
 description: A set of paths to representative images of a piece of data.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   snapshot:
     name: snapshot
     description: Path to the dataset preview image relative to the dataset directory
       root.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: snapshot
     owner: PicturePath
@@ -113,7 +113,7 @@ attributes:
     name: thumbnail
     description: Path to the thumbnail of preview image relative to the dataset directory
       root.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: thumbnail
     owner: PicturePath
@@ -132,13 +132,13 @@ attributes:
 ```yaml
 name: PicturePath
 description: A set of paths to representative images of a piece of data.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   snapshot:
     name: snapshot
     description: Path to the dataset preview image relative to the dataset directory
       root.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: snapshot
     owner: PicturePath
@@ -151,7 +151,7 @@ attributes:
     name: thumbnail
     description: Path to the thumbnail of preview image relative to the dataset directory
       root.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: thumbnail
     owner: PicturePath

--- a/schema/v1.1.0/metadata-docs/PicturePath.md
+++ b/schema/v1.1.0/metadata-docs/PicturePath.md
@@ -1,0 +1,165 @@
+# Class: PicturePath
+
+
+_A set of paths to representative images of a piece of data._
+
+
+
+
+
+URI: [cdp-meta:PicturePath](https://cryoetdataportal.czscience.com/schema/metadata/PicturePath)
+
+
+
+
+```mermaid
+ classDiagram
+    class PicturePath
+      PicturePath : snapshot
+        
+          PicturePath --> string : snapshot
+        
+      PicturePath : thumbnail
+        
+          PicturePath --> string : thumbnail
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [snapshot](snapshot.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Path to the dataset preview image relative to the dataset directory root | direct |
+| [thumbnail](thumbnail.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Path to the thumbnail of preview image relative to the dataset directory root | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [PicturedEntity](PicturedEntity.md) | [key_photos](key_photos.md) | range | [PicturePath](PicturePath.md) |
+| [Dataset](Dataset.md) | [key_photos](key_photos.md) | range | [PicturePath](PicturePath.md) |
+| [Tomogram](Tomogram.md) | [key_photos](key_photos.md) | range | [PicturePath](PicturePath.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:PicturePath |
+| native | cdp-meta:PicturePath |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: PicturePath
+description: A set of paths to representative images of a piece of data.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  snapshot:
+    name: snapshot
+    description: Path to the dataset preview image relative to the dataset directory
+      root.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: snapshot
+    owner: PicturePath
+    domain_of:
+    - PicturePath
+    range: string
+    inlined: true
+    inlined_as_list: true
+  thumbnail:
+    name: thumbnail
+    description: Path to the thumbnail of preview image relative to the dataset directory
+      root.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: thumbnail
+    owner: PicturePath
+    domain_of:
+    - PicturePath
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: PicturePath
+description: A set of paths to representative images of a piece of data.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  snapshot:
+    name: snapshot
+    description: Path to the dataset preview image relative to the dataset directory
+      root.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: snapshot
+    owner: PicturePath
+    domain_of:
+    - PicturePath
+    range: string
+    inlined: true
+    inlined_as_list: true
+  thumbnail:
+    name: thumbnail
+    description: Path to the thumbnail of preview image relative to the dataset directory
+      root.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: thumbnail
+    owner: PicturePath
+    domain_of:
+    - PicturePath
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/PicturedEntity.md
+++ b/schema/v1.1.0/metadata-docs/PicturedEntity.md
@@ -1,0 +1,136 @@
+# Class: PicturedEntity
+
+
+_An entity with associated preview images._
+
+
+
+
+* __NOTE__: this is an abstract class and should not be instantiated directly
+
+
+URI: [cdp-meta:PicturedEntity](https://cryoetdataportal.czscience.com/schema/metadata/PicturedEntity)
+
+
+
+
+```mermaid
+ classDiagram
+    class PicturedEntity
+      PicturedEntity <|-- Dataset
+      PicturedEntity <|-- Tomogram
+      
+      PicturedEntity : key_photos
+        
+          PicturedEntity --> PicturePath : key_photos
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [key_photos](key_photos.md) | 1..1 <br/> [PicturePath](PicturePath.md) | A set of paths to representative images of a piece of data | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:PicturedEntity |
+| native | cdp-meta:PicturedEntity |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: PicturedEntity
+description: An entity with associated preview images.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  key_photos:
+    name: key_photos
+    description: A set of paths to representative images of a piece of data.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: key_photos
+    owner: PicturedEntity
+    domain_of:
+    - PicturedEntity
+    - Dataset
+    - Tomogram
+    range: PicturePath
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: PicturedEntity
+description: An entity with associated preview images.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+abstract: true
+attributes:
+  key_photos:
+    name: key_photos
+    description: A set of paths to representative images of a piece of data.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: key_photos
+    owner: PicturedEntity
+    domain_of:
+    - PicturedEntity
+    - Dataset
+    - Tomogram
+    range: PicturePath
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/PicturedEntity.md
+++ b/schema/v1.1.0/metadata-docs/PicturedEntity.md
@@ -9,7 +9,7 @@ _An entity with associated preview images._
 * __NOTE__: this is an abstract class and should not be instantiated directly
 
 
-URI: [cdp-meta:PicturedEntity](https://cryoetdataportal.czscience.com/schema/metadata/PicturedEntity)
+URI: [cdp-meta:PicturedEntity](metadataPicturedEntity)
 
 
 
@@ -58,7 +58,7 @@ URI: [cdp-meta:PicturedEntity](https://cryoetdataportal.czscience.com/schema/met
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -85,13 +85,13 @@ URI: [cdp-meta:PicturedEntity](https://cryoetdataportal.czscience.com/schema/met
 ```yaml
 name: PicturedEntity
 description: An entity with associated preview images.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   key_photos:
     name: key_photos
     description: A set of paths to representative images of a piece of data.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: key_photos
     owner: PicturedEntity
@@ -113,13 +113,13 @@ attributes:
 ```yaml
 name: PicturedEntity
 description: An entity with associated preview images.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 abstract: true
 attributes:
   key_photos:
     name: key_photos
     description: A set of paths to representative images of a piece of data.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: key_photos
     owner: PicturedEntity

--- a/schema/v1.1.0/metadata-docs/SampleTypeEnum.md
+++ b/schema/v1.1.0/metadata-docs/SampleTypeEnum.md
@@ -47,7 +47,7 @@ URI: [SampleTypeEnum](SampleTypeEnum.md)
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -58,7 +58,7 @@ URI: [SampleTypeEnum](SampleTypeEnum.md)
 ```yaml
 name: sample_type_enum
 description: Type of sample imaged in a CryoET study.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 permissible_values:
   cell:

--- a/schema/v1.1.0/metadata-docs/SampleTypeEnum.md
+++ b/schema/v1.1.0/metadata-docs/SampleTypeEnum.md
@@ -1,0 +1,91 @@
+# Enum: SampleTypeEnum
+
+
+
+
+_Type of sample imaged in a CryoET study._
+
+
+
+URI: [SampleTypeEnum](SampleTypeEnum.md)
+
+## Permissible Values
+
+| Value | Meaning | Description |
+| --- | --- | --- |
+| cell | None | Tomographic data of whole cells or cell sections |
+| tissue | None | Tomographic data of tissue sections |
+| organism | None | Tomographic data of sections through multicellular organisms |
+| organelle | None | Tomographic data of purified organelles |
+| virus | None | Tomographic data of purified viruses or VLPs |
+| in_vitro | None | Tomographic data of in vitro reconstituted systems or mixtures of proteins |
+| in_silico | None | Simulated tomographic data |
+| other | None | Other type of sample |
+
+
+
+
+## Slots
+
+| Name | Description |
+| ---  | --- |
+| [sample_type](sample_type.md) | Type of sample imaged in a CryoET study |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: sample_type_enum
+description: Type of sample imaged in a CryoET study.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+permissible_values:
+  cell:
+    text: cell
+    description: Tomographic data of whole cells or cell sections.
+  tissue:
+    text: tissue
+    description: Tomographic data of tissue sections.
+  organism:
+    text: organism
+    description: Tomographic data of sections through multicellular organisms.
+  organelle:
+    text: organelle
+    description: Tomographic data of purified organelles.
+  virus:
+    text: virus
+    description: Tomographic data of purified viruses or VLPs.
+  in_vitro:
+    text: in_vitro
+    description: Tomographic data of in vitro reconstituted systems or mixtures of
+      proteins.
+  in_silico:
+    text: in_silico
+    description: Simulated tomographic data.
+  other:
+    text: other
+    description: Other type of sample.
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/TiltRange.md
+++ b/schema/v1.1.0/metadata-docs/TiltRange.md
@@ -1,0 +1,167 @@
+# Class: TiltRange
+
+
+_The range of tilt angles in the tilt series._
+
+
+
+
+
+URI: [cdp-meta:TiltRange](https://cryoetdataportal.czscience.com/schema/metadata/TiltRange)
+
+
+
+
+```mermaid
+ classDiagram
+    class TiltRange
+      TiltRange : max
+        
+          TiltRange --> float : max
+        
+      TiltRange : min
+        
+          TiltRange --> float : min
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [min](min.md) | 0..1 <br/> [xsd:float](http://www.w3.org/2001/XMLSchema#float) | Minimal tilt angle in degrees | direct |
+| [max](max.md) | 0..1 <br/> [xsd:float](http://www.w3.org/2001/XMLSchema#float) | Maximal tilt angle in degrees | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [TiltSeries](TiltSeries.md) | [tilt_range](tilt_range.md) | range | [TiltRange](TiltRange.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:TiltRange |
+| native | cdp-meta:TiltRange |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: TiltRange
+description: The range of tilt angles in the tilt series.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  min:
+    name: min
+    description: Minimal tilt angle in degrees
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilt_min
+    rank: 1000
+    alias: min
+    owner: TiltRange
+    domain_of:
+    - TiltRange
+    range: float
+    inlined: true
+    inlined_as_list: true
+  max:
+    name: max
+    description: Maximal tilt angle in degrees
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilt_max
+    rank: 1000
+    alias: max
+    owner: TiltRange
+    domain_of:
+    - TiltRange
+    range: float
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: TiltRange
+description: The range of tilt angles in the tilt series.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  min:
+    name: min
+    description: Minimal tilt angle in degrees
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilt_min
+    rank: 1000
+    alias: min
+    owner: TiltRange
+    domain_of:
+    - TiltRange
+    range: float
+    inlined: true
+    inlined_as_list: true
+  max:
+    name: max
+    description: Maximal tilt angle in degrees
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilt_max
+    rank: 1000
+    alias: max
+    owner: TiltRange
+    domain_of:
+    - TiltRange
+    range: float
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/TiltRange.md
+++ b/schema/v1.1.0/metadata-docs/TiltRange.md
@@ -7,7 +7,7 @@ _The range of tilt angles in the tilt series._
 
 
 
-URI: [cdp-meta:TiltRange](https://cryoetdataportal.czscience.com/schema/metadata/TiltRange)
+URI: [cdp-meta:TiltRange](metadataTiltRange)
 
 
 
@@ -65,7 +65,7 @@ URI: [cdp-meta:TiltRange](https://cryoetdataportal.czscience.com/schema/metadata
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -92,12 +92,12 @@ URI: [cdp-meta:TiltRange](https://cryoetdataportal.czscience.com/schema/metadata
 ```yaml
 name: TiltRange
 description: The range of tilt angles in the tilt series.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   min:
     name: min
     description: Minimal tilt angle in degrees
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilt_min
     rank: 1000
@@ -111,7 +111,7 @@ attributes:
   max:
     name: max
     description: Maximal tilt angle in degrees
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilt_max
     rank: 1000
@@ -132,12 +132,12 @@ attributes:
 ```yaml
 name: TiltRange
 description: The range of tilt angles in the tilt series.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   min:
     name: min
     description: Minimal tilt angle in degrees
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilt_min
     rank: 1000
@@ -151,7 +151,7 @@ attributes:
   max:
     name: max
     description: Maximal tilt angle in degrees
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilt_max
     rank: 1000

--- a/schema/v1.1.0/metadata-docs/TiltSeries.md
+++ b/schema/v1.1.0/metadata-docs/TiltSeries.md
@@ -7,7 +7,7 @@ _Metadata describing a tilt series._
 
 
 
-URI: [cdp-meta:TiltSeries](https://cryoetdataportal.czscience.com/schema/metadata/TiltSeries)
+URI: [cdp-meta:TiltSeries](metadataTiltSeries)
 
 
 
@@ -133,7 +133,7 @@ URI: [cdp-meta:TiltSeries](https://cryoetdataportal.czscience.com/schema/metadat
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -160,12 +160,12 @@ URI: [cdp-meta:TiltSeries](https://cryoetdataportal.czscience.com/schema/metadat
 ```yaml
 name: TiltSeries
 description: Metadata describing a tilt series.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   acceleration_voltage:
     name: acceleration_voltage
     description: Electron Microscope Accelerator voltage in volts
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_acceleration_voltage
     rank: 1000
@@ -179,7 +179,7 @@ attributes:
   spherical_aberration_constant:
     name: spherical_aberration_constant
     description: Spherical Aberration Constant of the objective lens in millimeters
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_spherical_aberration_constant
     rank: 1000
@@ -194,7 +194,7 @@ attributes:
     name: microscope_additional_info
     description: Other microscope optical setup information, in addition to energy
       filter, phase plate and image corrector
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_microscope_additional_info
     rank: 1000
@@ -208,7 +208,7 @@ attributes:
   tilt_axis:
     name: tilt_axis
     description: Rotation angle in degrees
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilt_axis
     rank: 1000
@@ -222,7 +222,7 @@ attributes:
   tilt_step:
     name: tilt_step
     description: Tilt step in degrees
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilt_step
     rank: 1000
@@ -236,7 +236,7 @@ attributes:
   tilting_scheme:
     name: tilting_scheme
     description: The order of stage tilting during acquisition of the data
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilting_scheme
     rank: 1000
@@ -251,7 +251,7 @@ attributes:
     name: total_flux
     description: Number of Electrons reaching the specimen in a square Angstrom area
       for the entire tilt series
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_total_flux
     rank: 1000
@@ -265,7 +265,7 @@ attributes:
   data_acquisition_software:
     name: data_acquisition_software
     description: Software used to collect data
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_data_acquisition_software
     rank: 1000
@@ -279,7 +279,7 @@ attributes:
   binning_from_frames:
     name: binning_from_frames
     description: Describes the binning factor from frames to tilt series file
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_binning_from_frames
     rank: 1000
@@ -294,7 +294,7 @@ attributes:
     name: tilt_series_quality
     description: Author assessment of tilt series quality within the dataset (1-5,
       5 is best)
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilt_series_quality
     rank: 1000
@@ -308,7 +308,7 @@ attributes:
   pixel_spacing:
     name: pixel_spacing
     description: Pixel spacing for the tilt series
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_pixel_spacing
     rank: 1000
@@ -322,7 +322,7 @@ attributes:
   aligned_tiltseries_binning:
     name: aligned_tiltseries_binning
     description: Binning factor of the aligned tilt series
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_aligned_tiltseries_binning
     rank: 1000
@@ -336,7 +336,7 @@ attributes:
   frames_count:
     name: frames_count
     description: Number of frames associated with this tiltseries
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_frames_count
     rank: 1000
@@ -350,7 +350,7 @@ attributes:
   camera:
     name: camera
     description: The camera used to collect the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: camera
     owner: TiltSeries
@@ -362,7 +362,7 @@ attributes:
   microscope:
     name: microscope
     description: The microscope used to collect the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: microscope
     owner: TiltSeries
@@ -374,7 +374,7 @@ attributes:
   microscope_optical_setup:
     name: microscope_optical_setup
     description: The optical setup of the microscope used to collect the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: microscope_optical_setup
     owner: TiltSeries
@@ -386,7 +386,7 @@ attributes:
   tilt_range:
     name: tilt_range
     description: The range of tilt angles in the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: tilt_range
     owner: TiltSeries
@@ -405,12 +405,12 @@ attributes:
 ```yaml
 name: TiltSeries
 description: Metadata describing a tilt series.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   acceleration_voltage:
     name: acceleration_voltage
     description: Electron Microscope Accelerator voltage in volts
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_acceleration_voltage
     rank: 1000
@@ -424,7 +424,7 @@ attributes:
   spherical_aberration_constant:
     name: spherical_aberration_constant
     description: Spherical Aberration Constant of the objective lens in millimeters
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_spherical_aberration_constant
     rank: 1000
@@ -439,7 +439,7 @@ attributes:
     name: microscope_additional_info
     description: Other microscope optical setup information, in addition to energy
       filter, phase plate and image corrector
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_microscope_additional_info
     rank: 1000
@@ -453,7 +453,7 @@ attributes:
   tilt_axis:
     name: tilt_axis
     description: Rotation angle in degrees
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilt_axis
     rank: 1000
@@ -467,7 +467,7 @@ attributes:
   tilt_step:
     name: tilt_step
     description: Tilt step in degrees
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilt_step
     rank: 1000
@@ -481,7 +481,7 @@ attributes:
   tilting_scheme:
     name: tilting_scheme
     description: The order of stage tilting during acquisition of the data
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilting_scheme
     rank: 1000
@@ -496,7 +496,7 @@ attributes:
     name: total_flux
     description: Number of Electrons reaching the specimen in a square Angstrom area
       for the entire tilt series
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_total_flux
     rank: 1000
@@ -510,7 +510,7 @@ attributes:
   data_acquisition_software:
     name: data_acquisition_software
     description: Software used to collect data
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_data_acquisition_software
     rank: 1000
@@ -524,7 +524,7 @@ attributes:
   binning_from_frames:
     name: binning_from_frames
     description: Describes the binning factor from frames to tilt series file
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_binning_from_frames
     rank: 1000
@@ -539,7 +539,7 @@ attributes:
     name: tilt_series_quality
     description: Author assessment of tilt series quality within the dataset (1-5,
       5 is best)
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_tilt_series_quality
     rank: 1000
@@ -553,7 +553,7 @@ attributes:
   pixel_spacing:
     name: pixel_spacing
     description: Pixel spacing for the tilt series
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_pixel_spacing
     rank: 1000
@@ -567,7 +567,7 @@ attributes:
   aligned_tiltseries_binning:
     name: aligned_tiltseries_binning
     description: Binning factor of the aligned tilt series
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_aligned_tiltseries_binning
     rank: 1000
@@ -581,7 +581,7 @@ attributes:
   frames_count:
     name: frames_count
     description: Number of frames associated with this tiltseries
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tiltseries_frames_count
     rank: 1000
@@ -595,7 +595,7 @@ attributes:
   camera:
     name: camera
     description: The camera used to collect the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: camera
     owner: TiltSeries
@@ -607,7 +607,7 @@ attributes:
   microscope:
     name: microscope
     description: The microscope used to collect the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: microscope
     owner: TiltSeries
@@ -619,7 +619,7 @@ attributes:
   microscope_optical_setup:
     name: microscope_optical_setup
     description: The optical setup of the microscope used to collect the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: microscope_optical_setup
     owner: TiltSeries
@@ -631,7 +631,7 @@ attributes:
   tilt_range:
     name: tilt_range
     description: The range of tilt angles in the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: tilt_range
     owner: TiltSeries

--- a/schema/v1.1.0/metadata-docs/TiltSeries.md
+++ b/schema/v1.1.0/metadata-docs/TiltSeries.md
@@ -1,0 +1,645 @@
+# Class: TiltSeries
+
+
+_Metadata describing a tilt series._
+
+
+
+
+
+URI: [cdp-meta:TiltSeries](https://cryoetdataportal.czscience.com/schema/metadata/TiltSeries)
+
+
+
+
+```mermaid
+ classDiagram
+    class TiltSeries
+      TiltSeries : acceleration_voltage
+        
+          TiltSeries --> integer : acceleration_voltage
+        
+      TiltSeries : aligned_tiltseries_binning
+        
+          TiltSeries --> integer : aligned_tiltseries_binning
+        
+      TiltSeries : binning_from_frames
+        
+          TiltSeries --> float : binning_from_frames
+        
+      TiltSeries : camera
+        
+          TiltSeries --> Camera : camera
+        
+      TiltSeries : data_acquisition_software
+        
+          TiltSeries --> string : data_acquisition_software
+        
+      TiltSeries : frames_count
+        
+          TiltSeries --> integer : frames_count
+        
+      TiltSeries : microscope
+        
+          TiltSeries --> Microscope : microscope
+        
+      TiltSeries : microscope_additional_info
+        
+          TiltSeries --> string : microscope_additional_info
+        
+      TiltSeries : microscope_optical_setup
+        
+          TiltSeries --> MicroscopeOpticalSetup : microscope_optical_setup
+        
+      TiltSeries : pixel_spacing
+        
+          TiltSeries --> float : pixel_spacing
+        
+      TiltSeries : spherical_aberration_constant
+        
+          TiltSeries --> float : spherical_aberration_constant
+        
+      TiltSeries : tilt_axis
+        
+          TiltSeries --> float : tilt_axis
+        
+      TiltSeries : tilt_range
+        
+          TiltSeries --> TiltRange : tilt_range
+        
+      TiltSeries : tilt_series_quality
+        
+          TiltSeries --> integer : tilt_series_quality
+        
+      TiltSeries : tilt_step
+        
+          TiltSeries --> float : tilt_step
+        
+      TiltSeries : tilting_scheme
+        
+          TiltSeries --> string : tilting_scheme
+        
+      TiltSeries : total_flux
+        
+          TiltSeries --> float : total_flux
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [acceleration_voltage](acceleration_voltage.md) | 0..1 <br/> [xsd:integer](http://www.w3.org/2001/XMLSchema#integer) | Electron Microscope Accelerator voltage in volts | direct |
+| [spherical_aberration_constant](spherical_aberration_constant.md) | 0..1 <br/> [xsd:float](http://www.w3.org/2001/XMLSchema#float) | Spherical Aberration Constant of the objective lens in millimeters | direct |
+| [microscope_additional_info](microscope_additional_info.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Other microscope optical setup information, in addition to energy filter, pha... | direct |
+| [tilt_axis](tilt_axis.md) | 0..1 <br/> [xsd:float](http://www.w3.org/2001/XMLSchema#float) | Rotation angle in degrees | direct |
+| [tilt_step](tilt_step.md) | 0..1 <br/> [xsd:float](http://www.w3.org/2001/XMLSchema#float) | Tilt step in degrees | direct |
+| [tilting_scheme](tilting_scheme.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | The order of stage tilting during acquisition of the data | direct |
+| [total_flux](total_flux.md) | 0..1 <br/> [xsd:float](http://www.w3.org/2001/XMLSchema#float) | Number of Electrons reaching the specimen in a square Angstrom area for the e... | direct |
+| [data_acquisition_software](data_acquisition_software.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Software used to collect data | direct |
+| [binning_from_frames](binning_from_frames.md) | 0..1 <br/> [xsd:float](http://www.w3.org/2001/XMLSchema#float) | Describes the binning factor from frames to tilt series file | direct |
+| [tilt_series_quality](tilt_series_quality.md) | 0..1 <br/> [xsd:integer](http://www.w3.org/2001/XMLSchema#integer) | Author assessment of tilt series quality within the dataset (1-5, 5 is best) | direct |
+| [pixel_spacing](pixel_spacing.md) | 0..1 <br/> [xsd:float](http://www.w3.org/2001/XMLSchema#float) | Pixel spacing for the tilt series | direct |
+| [aligned_tiltseries_binning](aligned_tiltseries_binning.md) | 0..1 <br/> [xsd:integer](http://www.w3.org/2001/XMLSchema#integer) | Binning factor of the aligned tilt series | direct |
+| [frames_count](frames_count.md) | 0..1 <br/> [xsd:integer](http://www.w3.org/2001/XMLSchema#integer) | Number of frames associated with this tiltseries | direct |
+| [camera](camera.md) | 0..1 <br/> [Camera](Camera.md) | The camera used to collect the tilt series | direct |
+| [microscope](microscope.md) | 0..1 <br/> [Microscope](Microscope.md) | The microscope used to collect the tilt series | direct |
+| [microscope_optical_setup](microscope_optical_setup.md) | 0..1 <br/> [MicroscopeOpticalSetup](MicroscopeOpticalSetup.md) | The optical setup of the microscope used to collect the tilt series | direct |
+| [tilt_range](tilt_range.md) | 0..1 <br/> [TiltRange](TiltRange.md) | The range of tilt angles in the tilt series | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:TiltSeries |
+| native | cdp-meta:TiltSeries |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: TiltSeries
+description: Metadata describing a tilt series.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  acceleration_voltage:
+    name: acceleration_voltage
+    description: Electron Microscope Accelerator voltage in volts
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_acceleration_voltage
+    rank: 1000
+    alias: acceleration_voltage
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  spherical_aberration_constant:
+    name: spherical_aberration_constant
+    description: Spherical Aberration Constant of the objective lens in millimeters
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_spherical_aberration_constant
+    rank: 1000
+    alias: spherical_aberration_constant
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  microscope_additional_info:
+    name: microscope_additional_info
+    description: Other microscope optical setup information, in addition to energy
+      filter, phase plate and image corrector
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_microscope_additional_info
+    rank: 1000
+    alias: microscope_additional_info
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: string
+    inlined: true
+    inlined_as_list: true
+  tilt_axis:
+    name: tilt_axis
+    description: Rotation angle in degrees
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilt_axis
+    rank: 1000
+    alias: tilt_axis
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  tilt_step:
+    name: tilt_step
+    description: Tilt step in degrees
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilt_step
+    rank: 1000
+    alias: tilt_step
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  tilting_scheme:
+    name: tilting_scheme
+    description: The order of stage tilting during acquisition of the data
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilting_scheme
+    rank: 1000
+    alias: tilting_scheme
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: string
+    inlined: true
+    inlined_as_list: true
+  total_flux:
+    name: total_flux
+    description: Number of Electrons reaching the specimen in a square Angstrom area
+      for the entire tilt series
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_total_flux
+    rank: 1000
+    alias: total_flux
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  data_acquisition_software:
+    name: data_acquisition_software
+    description: Software used to collect data
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_data_acquisition_software
+    rank: 1000
+    alias: data_acquisition_software
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: string
+    inlined: true
+    inlined_as_list: true
+  binning_from_frames:
+    name: binning_from_frames
+    description: Describes the binning factor from frames to tilt series file
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_binning_from_frames
+    rank: 1000
+    alias: binning_from_frames
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  tilt_series_quality:
+    name: tilt_series_quality
+    description: Author assessment of tilt series quality within the dataset (1-5,
+      5 is best)
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilt_series_quality
+    rank: 1000
+    alias: tilt_series_quality
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  pixel_spacing:
+    name: pixel_spacing
+    description: Pixel spacing for the tilt series
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_pixel_spacing
+    rank: 1000
+    alias: pixel_spacing
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  aligned_tiltseries_binning:
+    name: aligned_tiltseries_binning
+    description: Binning factor of the aligned tilt series
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_aligned_tiltseries_binning
+    rank: 1000
+    alias: aligned_tiltseries_binning
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  frames_count:
+    name: frames_count
+    description: Number of frames associated with this tiltseries
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_frames_count
+    rank: 1000
+    alias: frames_count
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  camera:
+    name: camera
+    description: The camera used to collect the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: camera
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: Camera
+    inlined: true
+    inlined_as_list: true
+  microscope:
+    name: microscope
+    description: The microscope used to collect the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: microscope
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: Microscope
+    inlined: true
+    inlined_as_list: true
+  microscope_optical_setup:
+    name: microscope_optical_setup
+    description: The optical setup of the microscope used to collect the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: microscope_optical_setup
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: MicroscopeOpticalSetup
+    inlined: true
+    inlined_as_list: true
+  tilt_range:
+    name: tilt_range
+    description: The range of tilt angles in the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: tilt_range
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: TiltRange
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: TiltSeries
+description: Metadata describing a tilt series.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  acceleration_voltage:
+    name: acceleration_voltage
+    description: Electron Microscope Accelerator voltage in volts
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_acceleration_voltage
+    rank: 1000
+    alias: acceleration_voltage
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  spherical_aberration_constant:
+    name: spherical_aberration_constant
+    description: Spherical Aberration Constant of the objective lens in millimeters
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_spherical_aberration_constant
+    rank: 1000
+    alias: spherical_aberration_constant
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  microscope_additional_info:
+    name: microscope_additional_info
+    description: Other microscope optical setup information, in addition to energy
+      filter, phase plate and image corrector
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_microscope_additional_info
+    rank: 1000
+    alias: microscope_additional_info
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: string
+    inlined: true
+    inlined_as_list: true
+  tilt_axis:
+    name: tilt_axis
+    description: Rotation angle in degrees
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilt_axis
+    rank: 1000
+    alias: tilt_axis
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  tilt_step:
+    name: tilt_step
+    description: Tilt step in degrees
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilt_step
+    rank: 1000
+    alias: tilt_step
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  tilting_scheme:
+    name: tilting_scheme
+    description: The order of stage tilting during acquisition of the data
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilting_scheme
+    rank: 1000
+    alias: tilting_scheme
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: string
+    inlined: true
+    inlined_as_list: true
+  total_flux:
+    name: total_flux
+    description: Number of Electrons reaching the specimen in a square Angstrom area
+      for the entire tilt series
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_total_flux
+    rank: 1000
+    alias: total_flux
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  data_acquisition_software:
+    name: data_acquisition_software
+    description: Software used to collect data
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_data_acquisition_software
+    rank: 1000
+    alias: data_acquisition_software
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: string
+    inlined: true
+    inlined_as_list: true
+  binning_from_frames:
+    name: binning_from_frames
+    description: Describes the binning factor from frames to tilt series file
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_binning_from_frames
+    rank: 1000
+    alias: binning_from_frames
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  tilt_series_quality:
+    name: tilt_series_quality
+    description: Author assessment of tilt series quality within the dataset (1-5,
+      5 is best)
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_tilt_series_quality
+    rank: 1000
+    alias: tilt_series_quality
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  pixel_spacing:
+    name: pixel_spacing
+    description: Pixel spacing for the tilt series
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_pixel_spacing
+    rank: 1000
+    alias: pixel_spacing
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: float
+    inlined: true
+    inlined_as_list: true
+  aligned_tiltseries_binning:
+    name: aligned_tiltseries_binning
+    description: Binning factor of the aligned tilt series
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_aligned_tiltseries_binning
+    rank: 1000
+    alias: aligned_tiltseries_binning
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  frames_count:
+    name: frames_count
+    description: Number of frames associated with this tiltseries
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tiltseries_frames_count
+    rank: 1000
+    alias: frames_count
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  camera:
+    name: camera
+    description: The camera used to collect the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: camera
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: Camera
+    inlined: true
+    inlined_as_list: true
+  microscope:
+    name: microscope
+    description: The microscope used to collect the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: microscope
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: Microscope
+    inlined: true
+    inlined_as_list: true
+  microscope_optical_setup:
+    name: microscope_optical_setup
+    description: The optical setup of the microscope used to collect the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: microscope_optical_setup
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: MicroscopeOpticalSetup
+    inlined: true
+    inlined_as_list: true
+  tilt_range:
+    name: tilt_range
+    description: The range of tilt angles in the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: tilt_range
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: TiltRange
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/Tissue.md
+++ b/schema/v1.1.0/metadata-docs/Tissue.md
@@ -1,6 +1,6 @@
 # Slot: tissue
 
-URI: [cdp-meta:tissue](https://cryoetdataportal.czscience.com/schema/metadata/tissue)
+URI: [cdp-meta:tissue](metadatatissue)
 
 
 

--- a/schema/v1.1.0/metadata-docs/Tissue.md
+++ b/schema/v1.1.0/metadata-docs/Tissue.md
@@ -1,0 +1,54 @@
+# Slot: tissue
+
+URI: [cdp-meta:tissue](https://cryoetdataportal.czscience.com/schema/metadata/tissue)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: tissue
+alias: tissue
+domain_of:
+- ExperimentalMetadata
+- Dataset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/Tomogram.md
+++ b/schema/v1.1.0/metadata-docs/Tomogram.md
@@ -7,7 +7,7 @@ _Metadata describing a tomogram._
 
 
 
-URI: [cdp-meta:Tomogram](https://cryoetdataportal.czscience.com/schema/metadata/Tomogram)
+URI: [cdp-meta:Tomogram](metadataTomogram)
 
 
 
@@ -119,7 +119,7 @@ URI: [cdp-meta:Tomogram](https://cryoetdataportal.czscience.com/schema/metadata/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -146,7 +146,7 @@ URI: [cdp-meta:Tomogram](https://cryoetdataportal.czscience.com/schema/metadata/
 ```yaml
 name: Tomogram
 description: Metadata describing a tomogram.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 mixins:
 - AuthoredEntity
 - PicturedEntity
@@ -154,7 +154,7 @@ attributes:
   voxel_spacing:
     name: voxel_spacing
     description: Voxel spacing equal in all three axes in angstroms
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_voxel_spacing
     rank: 1000
@@ -169,7 +169,7 @@ attributes:
     name: fiducial_alignment_status
     description: Whether the tomographic alignment was computed based on fiducial
       markers.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_fiducial_alignment_status
     rank: 1000
@@ -183,7 +183,7 @@ attributes:
   ctf_corrected:
     name: ctf_corrected
     description: Whether this tomogram is CTF corrected
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_ctf_corrected
     rank: 1000
@@ -197,7 +197,7 @@ attributes:
   reconstruction_method:
     name: reconstruction_method
     description: Describe reconstruction method (Weighted back-projection, SART, SIRT)
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_reconstruction_method
     rank: 1000
@@ -211,7 +211,7 @@ attributes:
   reconstruction_software:
     name: reconstruction_software
     description: Name of software used for reconstruction
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_reconstruction_software
     rank: 1000
@@ -225,7 +225,7 @@ attributes:
   processing:
     name: processing
     description: Describe additional processing used to derive the tomogram
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_processing
     rank: 1000
@@ -239,7 +239,7 @@ attributes:
   processing_software:
     name: processing_software
     description: Processing software used to derive the tomogram
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_processing_software
     rank: 1000
@@ -255,7 +255,7 @@ attributes:
     description: Version of tomogram using the same software and post-processing.
       Version of tomogram using the same software and post-processing. This will be
       presented as the latest version
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_version
     rank: 1000
@@ -270,7 +270,7 @@ attributes:
     name: affine_transformation_matrix
     description: The flip or rotation transformation of this author submitted tomogram
       is indicated here
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_affine_transformation_matrix
     rank: 1000
@@ -284,7 +284,7 @@ attributes:
   size:
     name: size
     description: The size of a tomogram in voxels in each dimension.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: size
     owner: Tomogram
@@ -297,7 +297,7 @@ attributes:
     name: offset
     description: The offset of a tomogram in voxels in each dimension relative to
       the canonical tomogram.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: offset
     owner: Tomogram
@@ -309,7 +309,7 @@ attributes:
   authors:
     name: authors
     description: Author of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     multivalued: true
     list_elements_ordered: true
     alias: authors
@@ -327,7 +327,7 @@ attributes:
   key_photos:
     name: key_photos
     description: A set of paths to representative images of a piece of data.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: key_photos
     owner: Tomogram
     domain_of:
@@ -348,7 +348,7 @@ attributes:
 ```yaml
 name: Tomogram
 description: Metadata describing a tomogram.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 mixins:
 - AuthoredEntity
 - PicturedEntity
@@ -356,7 +356,7 @@ attributes:
   voxel_spacing:
     name: voxel_spacing
     description: Voxel spacing equal in all three axes in angstroms
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_voxel_spacing
     rank: 1000
@@ -371,7 +371,7 @@ attributes:
     name: fiducial_alignment_status
     description: Whether the tomographic alignment was computed based on fiducial
       markers.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_fiducial_alignment_status
     rank: 1000
@@ -385,7 +385,7 @@ attributes:
   ctf_corrected:
     name: ctf_corrected
     description: Whether this tomogram is CTF corrected
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_ctf_corrected
     rank: 1000
@@ -399,7 +399,7 @@ attributes:
   reconstruction_method:
     name: reconstruction_method
     description: Describe reconstruction method (Weighted back-projection, SART, SIRT)
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_reconstruction_method
     rank: 1000
@@ -413,7 +413,7 @@ attributes:
   reconstruction_software:
     name: reconstruction_software
     description: Name of software used for reconstruction
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_reconstruction_software
     rank: 1000
@@ -427,7 +427,7 @@ attributes:
   processing:
     name: processing
     description: Describe additional processing used to derive the tomogram
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_processing
     rank: 1000
@@ -441,7 +441,7 @@ attributes:
   processing_software:
     name: processing_software
     description: Processing software used to derive the tomogram
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_processing_software
     rank: 1000
@@ -457,7 +457,7 @@ attributes:
     description: Version of tomogram using the same software and post-processing.
       Version of tomogram using the same software and post-processing. This will be
       presented as the latest version
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_version
     rank: 1000
@@ -472,7 +472,7 @@ attributes:
     name: affine_transformation_matrix
     description: The flip or rotation transformation of this author submitted tomogram
       is indicated here
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_affine_transformation_matrix
     rank: 1000
@@ -486,7 +486,7 @@ attributes:
   size:
     name: size
     description: The size of a tomogram in voxels in each dimension.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: size
     owner: Tomogram
@@ -499,7 +499,7 @@ attributes:
     name: offset
     description: The offset of a tomogram in voxels in each dimension relative to
       the canonical tomogram.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     rank: 1000
     alias: offset
     owner: Tomogram
@@ -511,7 +511,7 @@ attributes:
   authors:
     name: authors
     description: Author of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     multivalued: true
     list_elements_ordered: true
     alias: authors
@@ -529,7 +529,7 @@ attributes:
   key_photos:
     name: key_photos
     description: A set of paths to representative images of a piece of data.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     alias: key_photos
     owner: Tomogram
     domain_of:

--- a/schema/v1.1.0/metadata-docs/Tomogram.md
+++ b/schema/v1.1.0/metadata-docs/Tomogram.md
@@ -1,0 +1,545 @@
+# Class: Tomogram
+
+
+_Metadata describing a tomogram._
+
+
+
+
+
+URI: [cdp-meta:Tomogram](https://cryoetdataportal.czscience.com/schema/metadata/Tomogram)
+
+
+
+
+```mermaid
+ classDiagram
+    class Tomogram
+      AuthoredEntity <|-- Tomogram
+      PicturedEntity <|-- Tomogram
+      
+      Tomogram : affine_transformation_matrix
+        
+          Tomogram --> string : affine_transformation_matrix
+        
+      Tomogram : authors
+        
+          Tomogram --> Author : authors
+        
+      Tomogram : ctf_corrected
+        
+          Tomogram --> boolean : ctf_corrected
+        
+      Tomogram : fiducial_alignment_status
+        
+          Tomogram --> fiducial_alignment_status_enum : fiducial_alignment_status
+        
+      Tomogram : key_photos
+        
+          Tomogram --> PicturePath : key_photos
+        
+      Tomogram : offset
+        
+          Tomogram --> TomogramOffset : offset
+        
+      Tomogram : processing
+        
+          Tomogram --> string : processing
+        
+      Tomogram : processing_software
+        
+          Tomogram --> string : processing_software
+        
+      Tomogram : reconstruction_method
+        
+          Tomogram --> string : reconstruction_method
+        
+      Tomogram : reconstruction_software
+        
+          Tomogram --> string : reconstruction_software
+        
+      Tomogram : size
+        
+          Tomogram --> TomogramSize : size
+        
+      Tomogram : tomogram_version
+        
+          Tomogram --> string : tomogram_version
+        
+      Tomogram : voxel_spacing
+        
+          Tomogram --> float : voxel_spacing
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* **Tomogram** [ [AuthoredEntity](AuthoredEntity.md) [PicturedEntity](PicturedEntity.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [voxel_spacing](voxel_spacing.md) | 0..1 <br/> [xsd:float](http://www.w3.org/2001/XMLSchema#float) | Voxel spacing equal in all three axes in angstroms | direct |
+| [fiducial_alignment_status](fiducial_alignment_status.md) | 0..1 <br/> [FiducialAlignmentStatusEnum](FiducialAlignmentStatusEnum.md) | Whether the tomographic alignment was computed based on fiducial markers | direct |
+| [ctf_corrected](ctf_corrected.md) | 0..1 <br/> [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean) | Whether this tomogram is CTF corrected | direct |
+| [reconstruction_method](reconstruction_method.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Describe reconstruction method (Weighted back-projection, SART, SIRT) | direct |
+| [reconstruction_software](reconstruction_software.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Name of software used for reconstruction | direct |
+| [processing](processing.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Describe additional processing used to derive the tomogram | direct |
+| [processing_software](processing_software.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Processing software used to derive the tomogram | direct |
+| [tomogram_version](tomogram_version.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | Version of tomogram using the same software and post-processing | direct |
+| [affine_transformation_matrix](affine_transformation_matrix.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) | The flip or rotation transformation of this author submitted tomogram is indi... | direct |
+| [size](size.md) | 0..1 <br/> [TomogramSize](TomogramSize.md) | The size of a tomogram in voxels in each dimension | direct |
+| [offset](offset.md) | 0..1 <br/> [TomogramOffset](TomogramOffset.md) | The offset of a tomogram in voxels in each dimension relative to the canonica... | direct |
+| [authors](authors.md) | 1..* <br/> [Author](Author.md) | Author of a scientific data entity | direct |
+| [key_photos](key_photos.md) | 1..1 <br/> [PicturePath](PicturePath.md) | A set of paths to representative images of a piece of data | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:Tomogram |
+| native | cdp-meta:Tomogram |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Tomogram
+description: Metadata describing a tomogram.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+mixins:
+- AuthoredEntity
+- PicturedEntity
+attributes:
+  voxel_spacing:
+    name: voxel_spacing
+    description: Voxel spacing equal in all three axes in angstroms
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_voxel_spacing
+    rank: 1000
+    alias: voxel_spacing
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: float
+    inlined: true
+    inlined_as_list: true
+  fiducial_alignment_status:
+    name: fiducial_alignment_status
+    description: Whether the tomographic alignment was computed based on fiducial
+      markers.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_fiducial_alignment_status
+    rank: 1000
+    alias: fiducial_alignment_status
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: fiducial_alignment_status_enum
+    inlined: true
+    inlined_as_list: true
+  ctf_corrected:
+    name: ctf_corrected
+    description: Whether this tomogram is CTF corrected
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_ctf_corrected
+    rank: 1000
+    alias: ctf_corrected
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  reconstruction_method:
+    name: reconstruction_method
+    description: Describe reconstruction method (Weighted back-projection, SART, SIRT)
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_reconstruction_method
+    rank: 1000
+    alias: reconstruction_method
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  reconstruction_software:
+    name: reconstruction_software
+    description: Name of software used for reconstruction
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_reconstruction_software
+    rank: 1000
+    alias: reconstruction_software
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  processing:
+    name: processing
+    description: Describe additional processing used to derive the tomogram
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_processing
+    rank: 1000
+    alias: processing
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  processing_software:
+    name: processing_software
+    description: Processing software used to derive the tomogram
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_processing_software
+    rank: 1000
+    alias: processing_software
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  tomogram_version:
+    name: tomogram_version
+    description: Version of tomogram using the same software and post-processing.
+      Version of tomogram using the same software and post-processing. This will be
+      presented as the latest version
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_version
+    rank: 1000
+    alias: tomogram_version
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affine_transformation_matrix:
+    name: affine_transformation_matrix
+    description: The flip or rotation transformation of this author submitted tomogram
+      is indicated here
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_affine_transformation_matrix
+    rank: 1000
+    alias: affine_transformation_matrix
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  size:
+    name: size
+    description: The size of a tomogram in voxels in each dimension.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: size
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: TomogramSize
+    inlined: true
+    inlined_as_list: true
+  offset:
+    name: offset
+    description: The offset of a tomogram in voxels in each dimension relative to
+      the canonical tomogram.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: offset
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: TomogramOffset
+    inlined: true
+    inlined_as_list: true
+  authors:
+    name: authors
+    description: Author of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    multivalued: true
+    list_elements_ordered: true
+    alias: authors
+    owner: Tomogram
+    domain_of:
+    - AuthoredEntity
+    - AnnotatoredEntity
+    - Dataset
+    - Tomogram
+    - Annotation
+    range: Author
+    required: true
+    inlined: true
+    inlined_as_list: true
+  key_photos:
+    name: key_photos
+    description: A set of paths to representative images of a piece of data.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: key_photos
+    owner: Tomogram
+    domain_of:
+    - PicturedEntity
+    - Dataset
+    - Tomogram
+    range: PicturePath
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Tomogram
+description: Metadata describing a tomogram.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+mixins:
+- AuthoredEntity
+- PicturedEntity
+attributes:
+  voxel_spacing:
+    name: voxel_spacing
+    description: Voxel spacing equal in all three axes in angstroms
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_voxel_spacing
+    rank: 1000
+    alias: voxel_spacing
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: float
+    inlined: true
+    inlined_as_list: true
+  fiducial_alignment_status:
+    name: fiducial_alignment_status
+    description: Whether the tomographic alignment was computed based on fiducial
+      markers.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_fiducial_alignment_status
+    rank: 1000
+    alias: fiducial_alignment_status
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: fiducial_alignment_status_enum
+    inlined: true
+    inlined_as_list: true
+  ctf_corrected:
+    name: ctf_corrected
+    description: Whether this tomogram is CTF corrected
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_ctf_corrected
+    rank: 1000
+    alias: ctf_corrected
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: boolean
+    inlined: true
+    inlined_as_list: true
+  reconstruction_method:
+    name: reconstruction_method
+    description: Describe reconstruction method (Weighted back-projection, SART, SIRT)
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_reconstruction_method
+    rank: 1000
+    alias: reconstruction_method
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  reconstruction_software:
+    name: reconstruction_software
+    description: Name of software used for reconstruction
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_reconstruction_software
+    rank: 1000
+    alias: reconstruction_software
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  processing:
+    name: processing
+    description: Describe additional processing used to derive the tomogram
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_processing
+    rank: 1000
+    alias: processing
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  processing_software:
+    name: processing_software
+    description: Processing software used to derive the tomogram
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_processing_software
+    rank: 1000
+    alias: processing_software
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  tomogram_version:
+    name: tomogram_version
+    description: Version of tomogram using the same software and post-processing.
+      Version of tomogram using the same software and post-processing. This will be
+      presented as the latest version
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_version
+    rank: 1000
+    alias: tomogram_version
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  affine_transformation_matrix:
+    name: affine_transformation_matrix
+    description: The flip or rotation transformation of this author submitted tomogram
+      is indicated here
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_affine_transformation_matrix
+    rank: 1000
+    alias: affine_transformation_matrix
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: string
+    inlined: true
+    inlined_as_list: true
+  size:
+    name: size
+    description: The size of a tomogram in voxels in each dimension.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: size
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: TomogramSize
+    inlined: true
+    inlined_as_list: true
+  offset:
+    name: offset
+    description: The offset of a tomogram in voxels in each dimension relative to
+      the canonical tomogram.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    rank: 1000
+    alias: offset
+    owner: Tomogram
+    domain_of:
+    - Tomogram
+    range: TomogramOffset
+    inlined: true
+    inlined_as_list: true
+  authors:
+    name: authors
+    description: Author of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    multivalued: true
+    list_elements_ordered: true
+    alias: authors
+    owner: Tomogram
+    domain_of:
+    - AuthoredEntity
+    - AnnotatoredEntity
+    - Dataset
+    - Tomogram
+    - Annotation
+    range: Author
+    required: true
+    inlined: true
+    inlined_as_list: true
+  key_photos:
+    name: key_photos
+    description: A set of paths to representative images of a piece of data.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    alias: key_photos
+    owner: Tomogram
+    domain_of:
+    - PicturedEntity
+    - Dataset
+    - Tomogram
+    range: PicturePath
+    required: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/TomogramOffset.md
+++ b/schema/v1.1.0/metadata-docs/TomogramOffset.md
@@ -7,7 +7,7 @@ _The offset of a tomogram in voxels in each dimension relative to the canonical 
 
 
 
-URI: [cdp-meta:TomogramOffset](https://cryoetdataportal.czscience.com/schema/metadata/TomogramOffset)
+URI: [cdp-meta:TomogramOffset](metadataTomogramOffset)
 
 
 
@@ -70,7 +70,7 @@ URI: [cdp-meta:TomogramOffset](https://cryoetdataportal.czscience.com/schema/met
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -98,11 +98,11 @@ URI: [cdp-meta:TomogramOffset](https://cryoetdataportal.czscience.com/schema/met
 name: TomogramOffset
 description: The offset of a tomogram in voxels in each dimension relative to the
   canonical tomogram.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   x:
     name: x
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_offset_x
     alias: x
@@ -115,7 +115,7 @@ attributes:
     inlined_as_list: true
   y:
     name: y
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_offset_y
     alias: y
@@ -128,7 +128,7 @@ attributes:
     inlined_as_list: true
   z:
     name: z
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_offset_z
     alias: z
@@ -150,11 +150,11 @@ attributes:
 name: TomogramOffset
 description: The offset of a tomogram in voxels in each dimension relative to the
   canonical tomogram.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   x:
     name: x
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_offset_x
     alias: x
@@ -167,7 +167,7 @@ attributes:
     inlined_as_list: true
   y:
     name: y
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_offset_y
     alias: y
@@ -180,7 +180,7 @@ attributes:
     inlined_as_list: true
   z:
     name: z
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_offset_z
     alias: z

--- a/schema/v1.1.0/metadata-docs/TomogramOffset.md
+++ b/schema/v1.1.0/metadata-docs/TomogramOffset.md
@@ -1,0 +1,196 @@
+# Class: TomogramOffset
+
+
+_The offset of a tomogram in voxels in each dimension relative to the canonical tomogram._
+
+
+
+
+
+URI: [cdp-meta:TomogramOffset](https://cryoetdataportal.czscience.com/schema/metadata/TomogramOffset)
+
+
+
+
+```mermaid
+ classDiagram
+    class TomogramOffset
+      TomogramOffset : x
+        
+          TomogramOffset --> string : x
+        
+      TomogramOffset : y
+        
+          TomogramOffset --> string : y
+        
+      TomogramOffset : z
+        
+          TomogramOffset --> string : z
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [x](x.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [y](y.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+| [z](z.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string) |  | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Tomogram](Tomogram.md) | [offset](offset.md) | range | [TomogramOffset](TomogramOffset.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:TomogramOffset |
+| native | cdp-meta:TomogramOffset |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: TomogramOffset
+description: The offset of a tomogram in voxels in each dimension relative to the
+  canonical tomogram.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  x:
+    name: x
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_offset_x
+    alias: x
+    owner: TomogramOffset
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  y:
+    name: y
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_offset_y
+    alias: y
+    owner: TomogramOffset
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  z:
+    name: z
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_offset_z
+    alias: z
+    owner: TomogramOffset
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: TomogramOffset
+description: The offset of a tomogram in voxels in each dimension relative to the
+  canonical tomogram.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  x:
+    name: x
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_offset_x
+    alias: x
+    owner: TomogramOffset
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  y:
+    name: y
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_offset_y
+    alias: y
+    owner: TomogramOffset
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: string
+    inlined: true
+    inlined_as_list: true
+  z:
+    name: z
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_offset_z
+    alias: z
+    owner: TomogramOffset
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: string
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/TomogramSize.md
+++ b/schema/v1.1.0/metadata-docs/TomogramSize.md
@@ -1,0 +1,208 @@
+# Class: TomogramSize
+
+
+_The size of a tomogram in voxels in each dimension._
+
+
+
+
+
+URI: [cdp-meta:TomogramSize](https://cryoetdataportal.czscience.com/schema/metadata/TomogramSize)
+
+
+
+
+```mermaid
+ classDiagram
+    class TomogramSize
+      TomogramSize : x
+        
+          TomogramSize --> integer : x
+        
+      TomogramSize : y
+        
+          TomogramSize --> integer : y
+        
+      TomogramSize : z
+        
+          TomogramSize --> integer : z
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [x](x.md) | 0..1 <br/> [xsd:integer](http://www.w3.org/2001/XMLSchema#integer) | Number of pixels in the 3D data fast axis | direct |
+| [y](y.md) | 0..1 <br/> [xsd:integer](http://www.w3.org/2001/XMLSchema#integer) | Number of pixels in the 3D data medium axis | direct |
+| [z](z.md) | 0..1 <br/> [xsd:integer](http://www.w3.org/2001/XMLSchema#integer) | Number of pixels in the 3D data slow axis | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Tomogram](Tomogram.md) | [size](size.md) | range | [TomogramSize](TomogramSize.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | cdp-meta:TomogramSize |
+| native | cdp-meta:TomogramSize |
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: TomogramSize
+description: The size of a tomogram in voxels in each dimension.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  x:
+    name: x
+    description: Number of pixels in the 3D data fast axis
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_size_x
+    rank: 1000
+    alias: x
+    owner: TomogramSize
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  y:
+    name: y
+    description: Number of pixels in the 3D data medium axis
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_size_y
+    rank: 1000
+    alias: y
+    owner: TomogramSize
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  z:
+    name: z
+    description: Number of pixels in the 3D data slow axis.  This is the image projection
+      direction at zero stage tilt
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_size_z
+    rank: 1000
+    alias: z
+    owner: TomogramSize
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: integer
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: TomogramSize
+description: The size of a tomogram in voxels in each dimension.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+attributes:
+  x:
+    name: x
+    description: Number of pixels in the 3D data fast axis
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_size_x
+    rank: 1000
+    alias: x
+    owner: TomogramSize
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  y:
+    name: y
+    description: Number of pixels in the 3D data medium axis
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_size_y
+    rank: 1000
+    alias: y
+    owner: TomogramSize
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: integer
+    inlined: true
+    inlined_as_list: true
+  z:
+    name: z
+    description: Number of pixels in the 3D data slow axis.  This is the image projection
+      direction at zero stage tilt
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    exact_mappings:
+    - cdp-common:tomogram_size_z
+    rank: 1000
+    alias: z
+    owner: TomogramSize
+    domain_of:
+    - TomogramSize
+    - TomogramOffset
+    range: integer
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/TomogramSize.md
+++ b/schema/v1.1.0/metadata-docs/TomogramSize.md
@@ -7,7 +7,7 @@ _The size of a tomogram in voxels in each dimension._
 
 
 
-URI: [cdp-meta:TomogramSize](https://cryoetdataportal.czscience.com/schema/metadata/TomogramSize)
+URI: [cdp-meta:TomogramSize](metadataTomogramSize)
 
 
 
@@ -70,7 +70,7 @@ URI: [cdp-meta:TomogramSize](https://cryoetdataportal.czscience.com/schema/metad
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -97,12 +97,12 @@ URI: [cdp-meta:TomogramSize](https://cryoetdataportal.czscience.com/schema/metad
 ```yaml
 name: TomogramSize
 description: The size of a tomogram in voxels in each dimension.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   x:
     name: x
     description: Number of pixels in the 3D data fast axis
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_size_x
     rank: 1000
@@ -117,7 +117,7 @@ attributes:
   y:
     name: y
     description: Number of pixels in the 3D data medium axis
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_size_y
     rank: 1000
@@ -133,7 +133,7 @@ attributes:
     name: z
     description: Number of pixels in the 3D data slow axis.  This is the image projection
       direction at zero stage tilt
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_size_z
     rank: 1000
@@ -155,12 +155,12 @@ attributes:
 ```yaml
 name: TomogramSize
 description: The size of a tomogram in voxels in each dimension.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 attributes:
   x:
     name: x
     description: Number of pixels in the 3D data fast axis
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_size_x
     rank: 1000
@@ -175,7 +175,7 @@ attributes:
   y:
     name: y
     description: Number of pixels in the 3D data medium axis
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_size_y
     rank: 1000
@@ -191,7 +191,7 @@ attributes:
     name: z
     description: Number of pixels in the 3D data slow axis.  This is the image projection
       direction at zero stage tilt
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     exact_mappings:
     - cdp-common:tomogram_size_z
     rank: 1000

--- a/schema/v1.1.0/metadata-docs/TomogramTypeEnum.md
+++ b/schema/v1.1.0/metadata-docs/TomogramTypeEnum.md
@@ -1,0 +1,56 @@
+# Enum: TomogramTypeEnum
+
+
+
+
+_Tomogram type_
+
+
+
+URI: [TomogramTypeEnum](TomogramTypeEnum.md)
+
+## Permissible Values
+
+| Value | Meaning | Description |
+| --- | --- | --- |
+| CANONICAL | None | Canonical tomogram (basis geometry for all annotations) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: tomogram_type_enum
+description: Tomogram type
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+permissible_values:
+  CANONICAL:
+    text: CANONICAL
+    description: Canonical tomogram (basis geometry for all annotations)
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/TomogramTypeEnum.md
+++ b/schema/v1.1.0/metadata-docs/TomogramTypeEnum.md
@@ -34,7 +34,7 @@ URI: [TomogramTypeEnum](TomogramTypeEnum.md)
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -45,7 +45,7 @@ URI: [TomogramTypeEnum](TomogramTypeEnum.md)
 ```yaml
 name: tomogram_type_enum
 description: Tomogram type
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 permissible_values:
   CANONICAL:

--- a/schema/v1.1.0/metadata-docs/acceleration_voltage.md
+++ b/schema/v1.1.0/metadata-docs/acceleration_voltage.md
@@ -5,7 +5,7 @@ _Electron Microscope Accelerator voltage in volts_
 
 
 
-URI: [cdp-meta:acceleration_voltage](https://cryoetdataportal.czscience.com/schema/metadata/acceleration_voltage)
+URI: [cdp-meta:acceleration_voltage](metadataacceleration_voltage)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:acceleration_voltage](https://cryoetdataportal.czscience.com/sche
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:acceleration_voltage](https://cryoetdataportal.czscience.com/sche
 ```yaml
 name: acceleration_voltage
 description: Electron Microscope Accelerator voltage in volts
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_acceleration_voltage
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/acceleration_voltage.md
+++ b/schema/v1.1.0/metadata-docs/acceleration_voltage.md
@@ -1,0 +1,72 @@
+# Slot: acceleration_voltage
+
+
+_Electron Microscope Accelerator voltage in volts_
+
+
+
+URI: [cdp-meta:acceleration_voltage](https://cryoetdataportal.czscience.com/schema/metadata/acceleration_voltage)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:integer](http://www.w3.org/2001/XMLSchema#integer)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: acceleration_voltage
+description: Electron Microscope Accelerator voltage in volts
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_acceleration_voltage
+rank: 1000
+alias: acceleration_voltage
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: integer
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/affiliation_address.md
+++ b/schema/v1.1.0/metadata-docs/affiliation_address.md
@@ -1,0 +1,54 @@
+# Slot: affiliation_address
+
+URI: [cdp-meta:affiliation_address](https://cryoetdataportal.czscience.com/schema/metadata/affiliation_address)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Author](Author.md) | Author of a scientific data entity |  no  |
+[Annotator](Annotator.md) | Annotator of a scientific data entity |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: affiliation_address
+alias: affiliation_address
+domain_of:
+- Author
+- Annotator
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/affiliation_address.md
+++ b/schema/v1.1.0/metadata-docs/affiliation_address.md
@@ -1,6 +1,6 @@
 # Slot: affiliation_address
 
-URI: [cdp-meta:affiliation_address](https://cryoetdataportal.czscience.com/schema/metadata/affiliation_address)
+URI: [cdp-meta:affiliation_address](metadataaffiliation_address)
 
 
 

--- a/schema/v1.1.0/metadata-docs/affiliation_identifier.md
+++ b/schema/v1.1.0/metadata-docs/affiliation_identifier.md
@@ -1,6 +1,6 @@
 # Slot: affiliation_identifier
 
-URI: [cdp-meta:affiliation_identifier](https://cryoetdataportal.czscience.com/schema/metadata/affiliation_identifier)
+URI: [cdp-meta:affiliation_identifier](metadataaffiliation_identifier)
 
 
 

--- a/schema/v1.1.0/metadata-docs/affiliation_identifier.md
+++ b/schema/v1.1.0/metadata-docs/affiliation_identifier.md
@@ -1,0 +1,54 @@
+# Slot: affiliation_identifier
+
+URI: [cdp-meta:affiliation_identifier](https://cryoetdataportal.czscience.com/schema/metadata/affiliation_identifier)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Author](Author.md) | Author of a scientific data entity |  no  |
+[Annotator](Annotator.md) | Annotator of a scientific data entity |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: affiliation_identifier
+alias: affiliation_identifier
+domain_of:
+- Author
+- Annotator
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/affiliation_name.md
+++ b/schema/v1.1.0/metadata-docs/affiliation_name.md
@@ -1,6 +1,6 @@
 # Slot: affiliation_name
 
-URI: [cdp-meta:affiliation_name](https://cryoetdataportal.czscience.com/schema/metadata/affiliation_name)
+URI: [cdp-meta:affiliation_name](metadataaffiliation_name)
 
 
 

--- a/schema/v1.1.0/metadata-docs/affiliation_name.md
+++ b/schema/v1.1.0/metadata-docs/affiliation_name.md
@@ -1,0 +1,54 @@
+# Slot: affiliation_name
+
+URI: [cdp-meta:affiliation_name](https://cryoetdataportal.czscience.com/schema/metadata/affiliation_name)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Author](Author.md) | Author of a scientific data entity |  no  |
+[Annotator](Annotator.md) | Annotator of a scientific data entity |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: affiliation_name
+alias: affiliation_name
+domain_of:
+- Author
+- Annotator
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/affine_transformation_matrix.md
+++ b/schema/v1.1.0/metadata-docs/affine_transformation_matrix.md
@@ -5,7 +5,7 @@ _The flip or rotation transformation of this author submitted tomogram is indica
 
 
 
-URI: [cdp-meta:affine_transformation_matrix](https://cryoetdataportal.czscience.com/schema/metadata/affine_transformation_matrix)
+URI: [cdp-meta:affine_transformation_matrix](metadataaffine_transformation_matrix)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:affine_transformation_matrix](https://cryoetdataportal.czscience.
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:affine_transformation_matrix](https://cryoetdataportal.czscience.
 name: affine_transformation_matrix
 description: The flip or rotation transformation of this author submitted tomogram
   is indicated here
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tomogram_affine_transformation_matrix
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/affine_transformation_matrix.md
+++ b/schema/v1.1.0/metadata-docs/affine_transformation_matrix.md
@@ -1,0 +1,73 @@
+# Slot: affine_transformation_matrix
+
+
+_The flip or rotation transformation of this author submitted tomogram is indicated here_
+
+
+
+URI: [cdp-meta:affine_transformation_matrix](https://cryoetdataportal.czscience.com/schema/metadata/affine_transformation_matrix)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: affine_transformation_matrix
+description: The flip or rotation transformation of this author submitted tomogram
+  is indicated here
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tomogram_affine_transformation_matrix
+rank: 1000
+alias: affine_transformation_matrix
+owner: Tomogram
+domain_of:
+- Tomogram
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/aligned_tiltseries_binning.md
+++ b/schema/v1.1.0/metadata-docs/aligned_tiltseries_binning.md
@@ -1,0 +1,72 @@
+# Slot: aligned_tiltseries_binning
+
+
+_Binning factor of the aligned tilt series_
+
+
+
+URI: [cdp-meta:aligned_tiltseries_binning](https://cryoetdataportal.czscience.com/schema/metadata/aligned_tiltseries_binning)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:integer](http://www.w3.org/2001/XMLSchema#integer)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: aligned_tiltseries_binning
+description: Binning factor of the aligned tilt series
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_aligned_tiltseries_binning
+rank: 1000
+alias: aligned_tiltseries_binning
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: integer
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/aligned_tiltseries_binning.md
+++ b/schema/v1.1.0/metadata-docs/aligned_tiltseries_binning.md
@@ -5,7 +5,7 @@ _Binning factor of the aligned tilt series_
 
 
 
-URI: [cdp-meta:aligned_tiltseries_binning](https://cryoetdataportal.czscience.com/schema/metadata/aligned_tiltseries_binning)
+URI: [cdp-meta:aligned_tiltseries_binning](metadataaligned_tiltseries_binning)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:aligned_tiltseries_binning](https://cryoetdataportal.czscience.co
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:aligned_tiltseries_binning](https://cryoetdataportal.czscience.co
 ```yaml
 name: aligned_tiltseries_binning
 description: Binning factor of the aligned tilt series
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_aligned_tiltseries_binning
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/annotation_method.md
+++ b/schema/v1.1.0/metadata-docs/annotation_method.md
@@ -1,0 +1,73 @@
+# Slot: annotation_method
+
+
+_Describe how the annotation is made (e.g. Manual, crYoLO, Positive Unlabeled Learning, template matching)_
+
+
+
+URI: [cdp-meta:annotation_method](https://cryoetdataportal.czscience.com/schema/metadata/annotation_method)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: annotation_method
+description: Describe how the annotation is made (e.g. Manual, crYoLO, Positive Unlabeled
+  Learning, template matching)
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_method
+rank: 1000
+alias: annotation_method
+owner: Annotation
+domain_of:
+- Annotation
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/annotation_method.md
+++ b/schema/v1.1.0/metadata-docs/annotation_method.md
@@ -5,7 +5,7 @@ _Describe how the annotation is made (e.g. Manual, crYoLO, Positive Unlabeled Le
 
 
 
-URI: [cdp-meta:annotation_method](https://cryoetdataportal.czscience.com/schema/metadata/annotation_method)
+URI: [cdp-meta:annotation_method](metadataannotation_method)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:annotation_method](https://cryoetdataportal.czscience.com/schema/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:annotation_method](https://cryoetdataportal.czscience.com/schema/
 name: annotation_method
 description: Describe how the annotation is made (e.g. Manual, crYoLO, Positive Unlabeled
   Learning, template matching)
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_method
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/annotation_method_type.md
+++ b/schema/v1.1.0/metadata-docs/annotation_method_type.md
@@ -5,7 +5,7 @@ _Classification of the annotation method based on supervision._
 
 
 
-URI: [cdp-meta:annotation_method_type](https://cryoetdataportal.czscience.com/schema/metadata/annotation_method_type)
+URI: [cdp-meta:annotation_method_type](metadataannotation_method_type)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:annotation_method_type](https://cryoetdataportal.czscience.com/sc
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:annotation_method_type](https://cryoetdataportal.czscience.com/sc
 ```yaml
 name: annotation_method_type
 description: Classification of the annotation method based on supervision.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_method_type
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/annotation_method_type.md
+++ b/schema/v1.1.0/metadata-docs/annotation_method_type.md
@@ -1,0 +1,72 @@
+# Slot: annotation_method_type
+
+
+_Classification of the annotation method based on supervision._
+
+
+
+URI: [cdp-meta:annotation_method_type](https://cryoetdataportal.czscience.com/schema/metadata/annotation_method_type)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [AnnotationMethodTypeEnum](AnnotationMethodTypeEnum.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: annotation_method_type
+description: Classification of the annotation method based on supervision.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_method_type
+rank: 1000
+alias: annotation_method_type
+owner: Annotation
+domain_of:
+- Annotation
+range: annotation_method_type_enum
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/annotation_object.md
+++ b/schema/v1.1.0/metadata-docs/annotation_object.md
@@ -5,7 +5,7 @@ _Metadata describing the object being annotated._
 
 
 
-URI: [cdp-meta:annotation_object](https://cryoetdataportal.czscience.com/schema/metadata/annotation_object)
+URI: [cdp-meta:annotation_object](metadataannotation_object)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:annotation_object](https://cryoetdataportal.czscience.com/schema/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:annotation_object](https://cryoetdataportal.czscience.com/schema/
 ```yaml
 name: annotation_object
 description: Metadata describing the object being annotated.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: annotation_object
 owner: Annotation

--- a/schema/v1.1.0/metadata-docs/annotation_object.md
+++ b/schema/v1.1.0/metadata-docs/annotation_object.md
@@ -1,0 +1,70 @@
+# Slot: annotation_object
+
+
+_Metadata describing the object being annotated._
+
+
+
+URI: [cdp-meta:annotation_object](https://cryoetdataportal.czscience.com/schema/metadata/annotation_object)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [AnnotationObject](AnnotationObject.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: annotation_object
+description: Metadata describing the object being annotated.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: annotation_object
+owner: Annotation
+domain_of:
+- Annotation
+range: AnnotationObject
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/annotation_publications.md
+++ b/schema/v1.1.0/metadata-docs/annotation_publications.md
@@ -1,0 +1,73 @@
+# Slot: annotation_publications
+
+
+_DOIs for publications that describe the dataset. Use a comma to separate multiple DOIs._
+
+
+
+URI: [cdp-meta:annotation_publications](https://cryoetdataportal.czscience.com/schema/metadata/annotation_publications)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: annotation_publications
+description: DOIs for publications that describe the dataset. Use a comma to separate
+  multiple DOIs.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_publication
+rank: 1000
+alias: annotation_publications
+owner: Annotation
+domain_of:
+- Annotation
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/annotation_publications.md
+++ b/schema/v1.1.0/metadata-docs/annotation_publications.md
@@ -5,7 +5,7 @@ _DOIs for publications that describe the dataset. Use a comma to separate multip
 
 
 
-URI: [cdp-meta:annotation_publications](https://cryoetdataportal.czscience.com/schema/metadata/annotation_publications)
+URI: [cdp-meta:annotation_publications](metadataannotation_publications)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:annotation_publications](https://cryoetdataportal.czscience.com/s
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:annotation_publications](https://cryoetdataportal.czscience.com/s
 name: annotation_publications
 description: DOIs for publications that describe the dataset. Use a comma to separate
   multiple DOIs.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_publication
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/annotation_software.md
+++ b/schema/v1.1.0/metadata-docs/annotation_software.md
@@ -1,0 +1,72 @@
+# Slot: annotation_software
+
+
+_Software used for generating this annotation_
+
+
+
+URI: [cdp-meta:annotation_software](https://cryoetdataportal.czscience.com/schema/metadata/annotation_software)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: annotation_software
+description: Software used for generating this annotation
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_software
+rank: 1000
+alias: annotation_software
+owner: Annotation
+domain_of:
+- Annotation
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/annotation_software.md
+++ b/schema/v1.1.0/metadata-docs/annotation_software.md
@@ -5,7 +5,7 @@ _Software used for generating this annotation_
 
 
 
-URI: [cdp-meta:annotation_software](https://cryoetdataportal.czscience.com/schema/metadata/annotation_software)
+URI: [cdp-meta:annotation_software](metadataannotation_software)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:annotation_software](https://cryoetdataportal.czscience.com/schem
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:annotation_software](https://cryoetdataportal.czscience.com/schem
 ```yaml
 name: annotation_software
 description: Software used for generating this annotation
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_software
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/authors.md
+++ b/schema/v1.1.0/metadata-docs/authors.md
@@ -1,6 +1,6 @@
 # Slot: authors
 
-URI: [cdp-meta:authors](https://cryoetdataportal.czscience.com/schema/metadata/authors)
+URI: [cdp-meta:authors](metadataauthors)
 
 
 

--- a/schema/v1.1.0/metadata-docs/authors.md
+++ b/schema/v1.1.0/metadata-docs/authors.md
@@ -1,0 +1,60 @@
+# Slot: authors
+
+URI: [cdp-meta:authors](https://cryoetdataportal.czscience.com/schema/metadata/authors)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[AuthoredEntity](AuthoredEntity.md) | An entity with associated authors |  no  |
+[AnnotatoredEntity](AnnotatoredEntity.md) | An entity with associated annotation authors |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: authors
+alias: authors
+domain_of:
+- AuthoredEntity
+- AnnotatoredEntity
+- Dataset
+- Tomogram
+- Annotation
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/binning_from_frames.md
+++ b/schema/v1.1.0/metadata-docs/binning_from_frames.md
@@ -5,7 +5,7 @@ _Describes the binning factor from frames to tilt series file_
 
 
 
-URI: [cdp-meta:binning_from_frames](https://cryoetdataportal.czscience.com/schema/metadata/binning_from_frames)
+URI: [cdp-meta:binning_from_frames](metadatabinning_from_frames)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:binning_from_frames](https://cryoetdataportal.czscience.com/schem
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:binning_from_frames](https://cryoetdataportal.czscience.com/schem
 ```yaml
 name: binning_from_frames
 description: Describes the binning factor from frames to tilt series file
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_binning_from_frames
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/binning_from_frames.md
+++ b/schema/v1.1.0/metadata-docs/binning_from_frames.md
@@ -1,0 +1,72 @@
+# Slot: binning_from_frames
+
+
+_Describes the binning factor from frames to tilt series file_
+
+
+
+URI: [cdp-meta:binning_from_frames](https://cryoetdataportal.czscience.com/schema/metadata/binning_from_frames)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: binning_from_frames
+description: Describes the binning factor from frames to tilt series file
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_binning_from_frames
+rank: 1000
+alias: binning_from_frames
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: float
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/cdp-meta.md
+++ b/schema/v1.1.0/metadata-docs/cdp-meta.md
@@ -1,0 +1,6 @@
+# cdp-meta
+
+None
+
+URI: https://cryoetdataportal.czscience.com/schema-docs/metadata
+

--- a/schema/v1.1.0/metadata-docs/cdp-meta.md
+++ b/schema/v1.1.0/metadata-docs/cdp-meta.md
@@ -2,5 +2,5 @@
 
 None
 
-URI: https://cryoetdataportal.czscience.com/schema-docs/metadata
+URI: metadata
 

--- a/schema/v1.1.0/metadata-docs/cell_component.md
+++ b/schema/v1.1.0/metadata-docs/cell_component.md
@@ -1,0 +1,54 @@
+# Slot: cell_component
+
+URI: [cdp-meta:cell_component](https://cryoetdataportal.czscience.com/schema/metadata/cell_component)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: cell_component
+alias: cell_component
+domain_of:
+- ExperimentalMetadata
+- Dataset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/cell_component.md
+++ b/schema/v1.1.0/metadata-docs/cell_component.md
@@ -1,6 +1,6 @@
 # Slot: cell_component
 
-URI: [cdp-meta:cell_component](https://cryoetdataportal.czscience.com/schema/metadata/cell_component)
+URI: [cdp-meta:cell_component](metadatacell_component)
 
 
 

--- a/schema/v1.1.0/metadata-docs/cell_strain.md
+++ b/schema/v1.1.0/metadata-docs/cell_strain.md
@@ -1,0 +1,54 @@
+# Slot: cell_strain
+
+URI: [cdp-meta:cell_strain](https://cryoetdataportal.czscience.com/schema/metadata/cell_strain)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: cell_strain
+alias: cell_strain
+domain_of:
+- ExperimentalMetadata
+- Dataset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/cell_strain.md
+++ b/schema/v1.1.0/metadata-docs/cell_strain.md
@@ -1,6 +1,6 @@
 # Slot: cell_strain
 
-URI: [cdp-meta:cell_strain](https://cryoetdataportal.czscience.com/schema/metadata/cell_strain)
+URI: [cdp-meta:cell_strain](metadatacell_strain)
 
 
 

--- a/schema/v1.1.0/metadata-docs/cell_type.md
+++ b/schema/v1.1.0/metadata-docs/cell_type.md
@@ -1,0 +1,54 @@
+# Slot: cell_type
+
+URI: [cdp-meta:cell_type](https://cryoetdataportal.czscience.com/schema/metadata/cell_type)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: cell_type
+alias: cell_type
+domain_of:
+- ExperimentalMetadata
+- Dataset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/cell_type.md
+++ b/schema/v1.1.0/metadata-docs/cell_type.md
@@ -1,6 +1,6 @@
 # Slot: cell_type
 
-URI: [cdp-meta:cell_type](https://cryoetdataportal.czscience.com/schema/metadata/cell_type)
+URI: [cdp-meta:cell_type](metadatacell_type)
 
 
 

--- a/schema/v1.1.0/metadata-docs/confidence.md
+++ b/schema/v1.1.0/metadata-docs/confidence.md
@@ -5,7 +5,7 @@ _Metadata describing the confidence of an annotation._
 
 
 
-URI: [cdp-meta:confidence](https://cryoetdataportal.czscience.com/schema/metadata/confidence)
+URI: [cdp-meta:confidence](metadataconfidence)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:confidence](https://cryoetdataportal.czscience.com/schema/metadat
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:confidence](https://cryoetdataportal.czscience.com/schema/metadat
 ```yaml
 name: confidence
 description: Metadata describing the confidence of an annotation.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: confidence
 owner: Annotation

--- a/schema/v1.1.0/metadata-docs/confidence.md
+++ b/schema/v1.1.0/metadata-docs/confidence.md
@@ -1,0 +1,70 @@
+# Slot: confidence
+
+
+_Metadata describing the confidence of an annotation._
+
+
+
+URI: [cdp-meta:confidence](https://cryoetdataportal.czscience.com/schema/metadata/confidence)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [AnnotationConfidence](AnnotationConfidence.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: confidence
+description: Metadata describing the confidence of an annotation.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: confidence
+owner: Annotation
+domain_of:
+- Annotation
+range: AnnotationConfidence
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/cross_references.md
+++ b/schema/v1.1.0/metadata-docs/cross_references.md
@@ -1,0 +1,54 @@
+# Slot: cross_references
+
+URI: [cdp-meta:cross_references](https://cryoetdataportal.czscience.com/schema/metadata/cross_references)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[CrossReferencedEntity](CrossReferencedEntity.md) | An entity with associated cross-references to other databases and publication... |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: cross_references
+alias: cross_references
+domain_of:
+- CrossReferencedEntity
+- Dataset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/cross_references.md
+++ b/schema/v1.1.0/metadata-docs/cross_references.md
@@ -1,6 +1,6 @@
 # Slot: cross_references
 
-URI: [cdp-meta:cross_references](https://cryoetdataportal.czscience.com/schema/metadata/cross_references)
+URI: [cdp-meta:cross_references](metadatacross_references)
 
 
 

--- a/schema/v1.1.0/metadata-docs/ctf_corrected.md
+++ b/schema/v1.1.0/metadata-docs/ctf_corrected.md
@@ -1,0 +1,72 @@
+# Slot: ctf_corrected
+
+
+_Whether this tomogram is CTF corrected_
+
+
+
+URI: [cdp-meta:ctf_corrected](https://cryoetdataportal.czscience.com/schema/metadata/ctf_corrected)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: ctf_corrected
+description: Whether this tomogram is CTF corrected
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tomogram_ctf_corrected
+rank: 1000
+alias: ctf_corrected
+owner: Tomogram
+domain_of:
+- Tomogram
+range: boolean
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/ctf_corrected.md
+++ b/schema/v1.1.0/metadata-docs/ctf_corrected.md
@@ -5,7 +5,7 @@ _Whether this tomogram is CTF corrected_
 
 
 
-URI: [cdp-meta:ctf_corrected](https://cryoetdataportal.czscience.com/schema/metadata/ctf_corrected)
+URI: [cdp-meta:ctf_corrected](metadatactf_corrected)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:ctf_corrected](https://cryoetdataportal.czscience.com/schema/meta
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:ctf_corrected](https://cryoetdataportal.czscience.com/schema/meta
 ```yaml
 name: ctf_corrected
 description: Whether this tomogram is CTF corrected
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tomogram_ctf_corrected
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/data_acquisition_software.md
+++ b/schema/v1.1.0/metadata-docs/data_acquisition_software.md
@@ -1,0 +1,72 @@
+# Slot: data_acquisition_software
+
+
+_Software used to collect data_
+
+
+
+URI: [cdp-meta:data_acquisition_software](https://cryoetdataportal.czscience.com/schema/metadata/data_acquisition_software)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: data_acquisition_software
+description: Software used to collect data
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_data_acquisition_software
+rank: 1000
+alias: data_acquisition_software
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/data_acquisition_software.md
+++ b/schema/v1.1.0/metadata-docs/data_acquisition_software.md
@@ -5,7 +5,7 @@ _Software used to collect data_
 
 
 
-URI: [cdp-meta:data_acquisition_software](https://cryoetdataportal.czscience.com/schema/metadata/data_acquisition_software)
+URI: [cdp-meta:data_acquisition_software](metadatadata_acquisition_software)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:data_acquisition_software](https://cryoetdataportal.czscience.com
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:data_acquisition_software](https://cryoetdataportal.czscience.com
 ```yaml
 name: data_acquisition_software
 description: Software used to collect data
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_data_acquisition_software
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/dataset_citations.md
+++ b/schema/v1.1.0/metadata-docs/dataset_citations.md
@@ -1,0 +1,70 @@
+# Slot: dataset_citations
+
+
+_Comma-separated list of DOIs for publications citing the dataset._
+
+
+
+URI: [cdp-meta:dataset_citations](https://cryoetdataportal.czscience.com/schema/metadata/dataset_citations)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[CrossReferences](CrossReferences.md) | A set of cross-references to other databases and publications |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: dataset_citations
+description: Comma-separated list of DOIs for publications citing the dataset.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: dataset_citations
+owner: CrossReferences
+domain_of:
+- CrossReferences
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/dataset_citations.md
+++ b/schema/v1.1.0/metadata-docs/dataset_citations.md
@@ -5,7 +5,7 @@ _Comma-separated list of DOIs for publications citing the dataset._
 
 
 
-URI: [cdp-meta:dataset_citations](https://cryoetdataportal.czscience.com/schema/metadata/dataset_citations)
+URI: [cdp-meta:dataset_citations](metadatadataset_citations)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:dataset_citations](https://cryoetdataportal.czscience.com/schema/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:dataset_citations](https://cryoetdataportal.czscience.com/schema/
 ```yaml
 name: dataset_citations
 description: Comma-separated list of DOIs for publications citing the dataset.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: dataset_citations
 owner: CrossReferences

--- a/schema/v1.1.0/metadata-docs/dataset_description.md
+++ b/schema/v1.1.0/metadata-docs/dataset_description.md
@@ -1,0 +1,73 @@
+# Slot: dataset_description
+
+
+_A short description of a CryoET dataset, similar to an abstract for a journal article or dataset._
+
+
+
+URI: [cdp-meta:dataset_description](https://cryoetdataportal.czscience.com/schema/metadata/dataset_description)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: dataset_description
+description: A short description of a CryoET dataset, similar to an abstract for a
+  journal article or dataset.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:dataset_description
+rank: 1000
+alias: dataset_description
+owner: Dataset
+domain_of:
+- Dataset
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/dataset_description.md
+++ b/schema/v1.1.0/metadata-docs/dataset_description.md
@@ -5,7 +5,7 @@ _A short description of a CryoET dataset, similar to an abstract for a journal a
 
 
 
-URI: [cdp-meta:dataset_description](https://cryoetdataportal.czscience.com/schema/metadata/dataset_description)
+URI: [cdp-meta:dataset_description](metadatadataset_description)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:dataset_description](https://cryoetdataportal.czscience.com/schem
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:dataset_description](https://cryoetdataportal.czscience.com/schem
 name: dataset_description
 description: A short description of a CryoET dataset, similar to an abstract for a
   journal article or dataset.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:dataset_description
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/dataset_identifier.md
+++ b/schema/v1.1.0/metadata-docs/dataset_identifier.md
@@ -5,7 +5,7 @@ _An identifier for a CryoET dataset, assigned by the Data Portal. Used to identi
 
 
 
-URI: [cdp-meta:dataset_identifier](https://cryoetdataportal.czscience.com/schema/metadata/dataset_identifier)
+URI: [cdp-meta:dataset_identifier](metadatadataset_identifier)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:dataset_identifier](https://cryoetdataportal.czscience.com/schema
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:dataset_identifier](https://cryoetdataportal.czscience.com/schema
 name: dataset_identifier
 description: An identifier for a CryoET dataset, assigned by the Data Portal. Used
   to identify the dataset as the directory  name in data tree.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:dataset_identifier
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/dataset_identifier.md
+++ b/schema/v1.1.0/metadata-docs/dataset_identifier.md
@@ -1,0 +1,73 @@
+# Slot: dataset_identifier
+
+
+_An identifier for a CryoET dataset, assigned by the Data Portal. Used to identify the dataset as the directory  name in data tree._
+
+
+
+URI: [cdp-meta:dataset_identifier](https://cryoetdataportal.czscience.com/schema/metadata/dataset_identifier)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:integer](http://www.w3.org/2001/XMLSchema#integer)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: dataset_identifier
+description: An identifier for a CryoET dataset, assigned by the Data Portal. Used
+  to identify the dataset as the directory  name in data tree.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:dataset_identifier
+rank: 1000
+alias: dataset_identifier
+owner: Dataset
+domain_of:
+- Dataset
+range: integer
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/dataset_publications.md
+++ b/schema/v1.1.0/metadata-docs/dataset_publications.md
@@ -1,0 +1,73 @@
+# Slot: dataset_publications
+
+
+_Comma-separated list of DOIs for publications associated with the dataset._
+
+
+
+URI: [cdp-meta:dataset_publications](https://cryoetdataportal.czscience.com/schema/metadata/dataset_publications)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[CrossReferences](CrossReferences.md) | A set of cross-references to other databases and publications |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* Recommended: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: dataset_publications
+description: Comma-separated list of DOIs for publications associated with the dataset.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: dataset_publications
+owner: CrossReferences
+domain_of:
+- CrossReferences
+range: string
+recommended: true
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/dataset_publications.md
+++ b/schema/v1.1.0/metadata-docs/dataset_publications.md
@@ -5,7 +5,7 @@ _Comma-separated list of DOIs for publications associated with the dataset._
 
 
 
-URI: [cdp-meta:dataset_publications](https://cryoetdataportal.czscience.com/schema/metadata/dataset_publications)
+URI: [cdp-meta:dataset_publications](metadatadataset_publications)
 
 
 
@@ -47,7 +47,7 @@ URI: [cdp-meta:dataset_publications](https://cryoetdataportal.czscience.com/sche
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -58,7 +58,7 @@ URI: [cdp-meta:dataset_publications](https://cryoetdataportal.czscience.com/sche
 ```yaml
 name: dataset_publications
 description: Comma-separated list of DOIs for publications associated with the dataset.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: dataset_publications
 owner: CrossReferences

--- a/schema/v1.1.0/metadata-docs/dataset_title.md
+++ b/schema/v1.1.0/metadata-docs/dataset_title.md
@@ -1,0 +1,72 @@
+# Slot: dataset_title
+
+
+_Title of a CryoET dataset._
+
+
+
+URI: [cdp-meta:dataset_title](https://cryoetdataportal.czscience.com/schema/metadata/dataset_title)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: dataset_title
+description: Title of a CryoET dataset.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:dataset_title
+rank: 1000
+alias: dataset_title
+owner: Dataset
+domain_of:
+- Dataset
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/dataset_title.md
+++ b/schema/v1.1.0/metadata-docs/dataset_title.md
@@ -5,7 +5,7 @@ _Title of a CryoET dataset._
 
 
 
-URI: [cdp-meta:dataset_title](https://cryoetdataportal.czscience.com/schema/metadata/dataset_title)
+URI: [cdp-meta:dataset_title](metadatadataset_title)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:dataset_title](https://cryoetdataportal.czscience.com/schema/meta
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:dataset_title](https://cryoetdataportal.czscience.com/schema/meta
 ```yaml
 name: dataset_title
 description: Title of a CryoET dataset.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:dataset_title
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/dates.md
+++ b/schema/v1.1.0/metadata-docs/dates.md
@@ -1,0 +1,56 @@
+# Slot: dates
+
+URI: [cdp-meta:dates](https://cryoetdataportal.czscience.com/schema/metadata/dates)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[DatestampedEntity](DatestampedEntity.md) | An entity with associated deposition, release and last modified dates |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: dates
+alias: dates
+domain_of:
+- DatestampedEntity
+- Dataset
+- Annotation
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/dates.md
+++ b/schema/v1.1.0/metadata-docs/dates.md
@@ -1,6 +1,6 @@
 # Slot: dates
 
-URI: [cdp-meta:dates](https://cryoetdataportal.czscience.com/schema/metadata/dates)
+URI: [cdp-meta:dates](metadatadates)
 
 
 

--- a/schema/v1.1.0/metadata-docs/deposition_date.md
+++ b/schema/v1.1.0/metadata-docs/deposition_date.md
@@ -1,0 +1,73 @@
+# Slot: deposition_date
+
+
+_The date a data item was received by the cryoET data portal._
+
+
+
+URI: [cdp-meta:deposition_date](https://cryoetdataportal.czscience.com/schema/metadata/deposition_date)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... |  yes  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:date](http://www.w3.org/2001/XMLSchema#date)
+
+* Required: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: deposition_date
+description: The date a data item was received by the cryoET data portal.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: deposition_date
+owner: DateStamp
+domain_of:
+- DateStamp
+range: date
+required: true
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/deposition_date.md
+++ b/schema/v1.1.0/metadata-docs/deposition_date.md
@@ -5,7 +5,7 @@ _The date a data item was received by the cryoET data portal._
 
 
 
-URI: [cdp-meta:deposition_date](https://cryoetdataportal.czscience.com/schema/metadata/deposition_date)
+URI: [cdp-meta:deposition_date](metadatadeposition_date)
 
 
 
@@ -47,7 +47,7 @@ URI: [cdp-meta:deposition_date](https://cryoetdataportal.czscience.com/schema/me
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -58,7 +58,7 @@ URI: [cdp-meta:deposition_date](https://cryoetdataportal.czscience.com/schema/me
 ```yaml
 name: deposition_date
 description: The date a data item was received by the cryoET data portal.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: deposition_date
 owner: DateStamp

--- a/schema/v1.1.0/metadata-docs/description.md
+++ b/schema/v1.1.0/metadata-docs/description.md
@@ -5,7 +5,7 @@ _A textual description of the annotation object, can be a longer description to 
 
 
 
-URI: [cdp-meta:description](https://cryoetdataportal.czscience.com/schema/metadata/description)
+URI: [cdp-meta:description](metadatadescription)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:description](https://cryoetdataportal.czscience.com/schema/metada
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -58,7 +58,7 @@ name: description
 description: A textual description of the annotation object, can be a longer description
   to include additional information not covered by the Annotation object name and
   state.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_object_description
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/description.md
+++ b/schema/v1.1.0/metadata-docs/description.md
@@ -1,0 +1,74 @@
+# Slot: description
+
+
+_A textual description of the annotation object, can be a longer description to include additional information not covered by the Annotation object name and state._
+
+
+
+URI: [cdp-meta:description](https://cryoetdataportal.czscience.com/schema/metadata/description)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: description
+description: A textual description of the annotation object, can be a longer description
+  to include additional information not covered by the Annotation object name and
+  state.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_object_description
+rank: 1000
+alias: description
+owner: AnnotationObject
+domain_of:
+- AnnotationObject
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/email.md
+++ b/schema/v1.1.0/metadata-docs/email.md
@@ -1,6 +1,6 @@
 # Slot: email
 
-URI: [cdp-meta:email](https://cryoetdataportal.czscience.com/schema/metadata/email)
+URI: [cdp-meta:email](metadataemail)
 
 
 

--- a/schema/v1.1.0/metadata-docs/email.md
+++ b/schema/v1.1.0/metadata-docs/email.md
@@ -1,0 +1,54 @@
+# Slot: email
+
+URI: [cdp-meta:email](https://cryoetdataportal.czscience.com/schema/metadata/email)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Author](Author.md) | Author of a scientific data entity |  no  |
+[Annotator](Annotator.md) | Annotator of a scientific data entity |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: email
+alias: email
+domain_of:
+- Author
+- Annotator
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/energy_filter.md
+++ b/schema/v1.1.0/metadata-docs/energy_filter.md
@@ -5,7 +5,7 @@ _Energy filter setup used_
 
 
 
-URI: [cdp-meta:energy_filter](https://cryoetdataportal.czscience.com/schema/metadata/energy_filter)
+URI: [cdp-meta:energy_filter](metadataenergy_filter)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:energy_filter](https://cryoetdataportal.czscience.com/schema/meta
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:energy_filter](https://cryoetdataportal.czscience.com/schema/meta
 ```yaml
 name: energy_filter
 description: Energy filter setup used
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_microscope_energy_filter
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/energy_filter.md
+++ b/schema/v1.1.0/metadata-docs/energy_filter.md
@@ -1,0 +1,72 @@
+# Slot: energy_filter
+
+
+_Energy filter setup used_
+
+
+
+URI: [cdp-meta:energy_filter](https://cryoetdataportal.czscience.com/schema/metadata/energy_filter)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[MicroscopeOpticalSetup](MicroscopeOpticalSetup.md) | The optical setup of the microscope used to collect the tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: energy_filter
+description: Energy filter setup used
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_microscope_energy_filter
+rank: 1000
+alias: energy_filter
+owner: MicroscopeOpticalSetup
+domain_of:
+- MicroscopeOpticalSetup
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/fiducial_alignment_status.md
+++ b/schema/v1.1.0/metadata-docs/fiducial_alignment_status.md
@@ -1,0 +1,72 @@
+# Slot: fiducial_alignment_status
+
+
+_Whether the tomographic alignment was computed based on fiducial markers._
+
+
+
+URI: [cdp-meta:fiducial_alignment_status](https://cryoetdataportal.czscience.com/schema/metadata/fiducial_alignment_status)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [FiducialAlignmentStatusEnum](FiducialAlignmentStatusEnum.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: fiducial_alignment_status
+description: Whether the tomographic alignment was computed based on fiducial markers.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tomogram_fiducial_alignment_status
+rank: 1000
+alias: fiducial_alignment_status
+owner: Tomogram
+domain_of:
+- Tomogram
+range: fiducial_alignment_status_enum
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/fiducial_alignment_status.md
+++ b/schema/v1.1.0/metadata-docs/fiducial_alignment_status.md
@@ -5,7 +5,7 @@ _Whether the tomographic alignment was computed based on fiducial markers._
 
 
 
-URI: [cdp-meta:fiducial_alignment_status](https://cryoetdataportal.czscience.com/schema/metadata/fiducial_alignment_status)
+URI: [cdp-meta:fiducial_alignment_status](metadatafiducial_alignment_status)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:fiducial_alignment_status](https://cryoetdataportal.czscience.com
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:fiducial_alignment_status](https://cryoetdataportal.czscience.com
 ```yaml
 name: fiducial_alignment_status
 description: Whether the tomographic alignment was computed based on fiducial markers.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tomogram_fiducial_alignment_status
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/files.md
+++ b/schema/v1.1.0/metadata-docs/files.md
@@ -1,0 +1,74 @@
+# Slot: files
+
+
+_Metadata describing a file containing an annotation._
+
+
+
+URI: [cdp-meta:files](https://cryoetdataportal.czscience.com/schema/metadata/files)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [AnnotationFile](AnnotationFile.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: files
+description: Metadata describing a file containing an annotation.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+multivalued: true
+list_elements_ordered: true
+alias: files
+owner: Annotation
+domain_of:
+- Annotation
+range: AnnotationFile
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/files.md
+++ b/schema/v1.1.0/metadata-docs/files.md
@@ -5,7 +5,7 @@ _Metadata describing a file containing an annotation._
 
 
 
-URI: [cdp-meta:files](https://cryoetdataportal.czscience.com/schema/metadata/files)
+URI: [cdp-meta:files](metadatafiles)
 
 
 
@@ -47,7 +47,7 @@ URI: [cdp-meta:files](https://cryoetdataportal.czscience.com/schema/metadata/fil
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -58,7 +58,7 @@ URI: [cdp-meta:files](https://cryoetdataportal.czscience.com/schema/metadata/fil
 ```yaml
 name: files
 description: Metadata describing a file containing an annotation.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 multivalued: true
 list_elements_ordered: true

--- a/schema/v1.1.0/metadata-docs/format.md
+++ b/schema/v1.1.0/metadata-docs/format.md
@@ -1,0 +1,72 @@
+# Slot: format
+
+
+_File format for this file_
+
+
+
+URI: [cdp-meta:format](https://cryoetdataportal.czscience.com/schema/metadata/format)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[AnnotationFile](AnnotationFile.md) | Metadata describing a file containing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: format
+description: File format for this file
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_file_format
+rank: 1000
+alias: format
+owner: AnnotationFile
+domain_of:
+- AnnotationFile
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/format.md
+++ b/schema/v1.1.0/metadata-docs/format.md
@@ -5,7 +5,7 @@ _File format for this file_
 
 
 
-URI: [cdp-meta:format](https://cryoetdataportal.czscience.com/schema/metadata/format)
+URI: [cdp-meta:format](metadataformat)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:format](https://cryoetdataportal.czscience.com/schema/metadata/fo
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:format](https://cryoetdataportal.czscience.com/schema/metadata/fo
 ```yaml
 name: format
 description: File format for this file
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_file_format
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/frames_count.md
+++ b/schema/v1.1.0/metadata-docs/frames_count.md
@@ -5,7 +5,7 @@ _Number of frames associated with this tiltseries_
 
 
 
-URI: [cdp-meta:frames_count](https://cryoetdataportal.czscience.com/schema/metadata/frames_count)
+URI: [cdp-meta:frames_count](metadataframes_count)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:frames_count](https://cryoetdataportal.czscience.com/schema/metad
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:frames_count](https://cryoetdataportal.czscience.com/schema/metad
 ```yaml
 name: frames_count
 description: Number of frames associated with this tiltseries
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_frames_count
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/frames_count.md
+++ b/schema/v1.1.0/metadata-docs/frames_count.md
@@ -1,0 +1,72 @@
+# Slot: frames_count
+
+
+_Number of frames associated with this tiltseries_
+
+
+
+URI: [cdp-meta:frames_count](https://cryoetdataportal.czscience.com/schema/metadata/frames_count)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:integer](http://www.w3.org/2001/XMLSchema#integer)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: frames_count
+description: Number of frames associated with this tiltseries
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_frames_count
+rank: 1000
+alias: frames_count
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: integer
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/funding_agency_name.md
+++ b/schema/v1.1.0/metadata-docs/funding_agency_name.md
@@ -1,0 +1,72 @@
+# Slot: funding_agency_name
+
+
+_The name of the funding source._
+
+
+
+URI: [cdp-meta:funding_agency_name](https://cryoetdataportal.czscience.com/schema/metadata/funding_agency_name)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Funding](Funding.md) | A funding source for a scientific data entity (base for JSON and DB represent... |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: funding_agency_name
+description: The name of the funding source.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:funding_agency_name
+rank: 1000
+alias: funding_agency_name
+owner: Funding
+domain_of:
+- Funding
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/funding_agency_name.md
+++ b/schema/v1.1.0/metadata-docs/funding_agency_name.md
@@ -5,7 +5,7 @@ _The name of the funding source._
 
 
 
-URI: [cdp-meta:funding_agency_name](https://cryoetdataportal.czscience.com/schema/metadata/funding_agency_name)
+URI: [cdp-meta:funding_agency_name](metadatafunding_agency_name)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:funding_agency_name](https://cryoetdataportal.czscience.com/schem
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:funding_agency_name](https://cryoetdataportal.czscience.com/schem
 ```yaml
 name: funding_agency_name
 description: The name of the funding source.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:funding_agency_name
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/grant_id.md
+++ b/schema/v1.1.0/metadata-docs/grant_id.md
@@ -5,7 +5,7 @@ _Grant identifier provided by the funding agency_
 
 
 
-URI: [cdp-meta:grant_id](https://cryoetdataportal.czscience.com/schema/metadata/grant_id)
+URI: [cdp-meta:grant_id](metadatagrant_id)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:grant_id](https://cryoetdataportal.czscience.com/schema/metadata/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:grant_id](https://cryoetdataportal.czscience.com/schema/metadata/
 ```yaml
 name: grant_id
 description: Grant identifier provided by the funding agency
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:funding_grant_id
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/grant_id.md
+++ b/schema/v1.1.0/metadata-docs/grant_id.md
@@ -1,0 +1,72 @@
+# Slot: grant_id
+
+
+_Grant identifier provided by the funding agency_
+
+
+
+URI: [cdp-meta:grant_id](https://cryoetdataportal.czscience.com/schema/metadata/grant_id)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Funding](Funding.md) | A funding source for a scientific data entity (base for JSON and DB represent... |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: grant_id
+description: Grant identifier provided by the funding agency
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:funding_grant_id
+rank: 1000
+alias: grant_id
+owner: Funding
+domain_of:
+- Funding
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/grid_preparation.md
+++ b/schema/v1.1.0/metadata-docs/grid_preparation.md
@@ -1,6 +1,6 @@
 # Slot: grid_preparation
 
-URI: [cdp-meta:grid_preparation](https://cryoetdataportal.czscience.com/schema/metadata/grid_preparation)
+URI: [cdp-meta:grid_preparation](metadatagrid_preparation)
 
 
 

--- a/schema/v1.1.0/metadata-docs/grid_preparation.md
+++ b/schema/v1.1.0/metadata-docs/grid_preparation.md
@@ -1,0 +1,54 @@
+# Slot: grid_preparation
+
+URI: [cdp-meta:grid_preparation](https://cryoetdataportal.czscience.com/schema/metadata/grid_preparation)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: grid_preparation
+alias: grid_preparation
+domain_of:
+- ExperimentalMetadata
+- Dataset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/ground_truth_status.md
+++ b/schema/v1.1.0/metadata-docs/ground_truth_status.md
@@ -1,0 +1,73 @@
+# Slot: ground_truth_status
+
+
+_Whether an annotation is considered ground truth, as determined by the annotator._
+
+
+
+URI: [cdp-meta:ground_truth_status](https://cryoetdataportal.czscience.com/schema/metadata/ground_truth_status)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: ground_truth_status
+description: Whether an annotation is considered ground truth, as determined by the
+  annotator.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_ground_truth_status
+rank: 1000
+alias: ground_truth_status
+owner: Annotation
+domain_of:
+- Annotation
+range: boolean
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/ground_truth_status.md
+++ b/schema/v1.1.0/metadata-docs/ground_truth_status.md
@@ -5,7 +5,7 @@ _Whether an annotation is considered ground truth, as determined by the annotato
 
 
 
-URI: [cdp-meta:ground_truth_status](https://cryoetdataportal.czscience.com/schema/metadata/ground_truth_status)
+URI: [cdp-meta:ground_truth_status](metadataground_truth_status)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:ground_truth_status](https://cryoetdataportal.czscience.com/schem
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:ground_truth_status](https://cryoetdataportal.czscience.com/schem
 name: ground_truth_status
 description: Whether an annotation is considered ground truth, as determined by the
   annotator.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_ground_truth_status
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/ground_truth_used.md
+++ b/schema/v1.1.0/metadata-docs/ground_truth_used.md
@@ -1,0 +1,72 @@
+# Slot: ground_truth_used
+
+
+_Annotation filename used as ground truth for precision and recall_
+
+
+
+URI: [cdp-meta:ground_truth_used](https://cryoetdataportal.czscience.com/schema/metadata/ground_truth_used)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[AnnotationConfidence](AnnotationConfidence.md) | Metadata describing the confidence of an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: ground_truth_used
+description: Annotation filename used as ground truth for precision and recall
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_ground_truth_used
+rank: 1000
+alias: ground_truth_used
+owner: AnnotationConfidence
+domain_of:
+- AnnotationConfidence
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/ground_truth_used.md
+++ b/schema/v1.1.0/metadata-docs/ground_truth_used.md
@@ -5,7 +5,7 @@ _Annotation filename used as ground truth for precision and recall_
 
 
 
-URI: [cdp-meta:ground_truth_used](https://cryoetdataportal.czscience.com/schema/metadata/ground_truth_used)
+URI: [cdp-meta:ground_truth_used](metadataground_truth_used)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:ground_truth_used](https://cryoetdataportal.czscience.com/schema/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:ground_truth_used](https://cryoetdataportal.czscience.com/schema/
 ```yaml
 name: ground_truth_used
 description: Annotation filename used as ground truth for precision and recall
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_ground_truth_used
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/id.md
+++ b/schema/v1.1.0/metadata-docs/id.md
@@ -1,6 +1,6 @@
 # Slot: id
 
-URI: [cdp-meta:id](https://cryoetdataportal.czscience.com/schema/metadata/id)
+URI: [cdp-meta:id](metadataid)
 
 
 

--- a/schema/v1.1.0/metadata-docs/id.md
+++ b/schema/v1.1.0/metadata-docs/id.md
@@ -1,0 +1,60 @@
+# Slot: id
+
+URI: [cdp-meta:id](https://cryoetdataportal.czscience.com/schema/metadata/id)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tissue](Tissue.md) | The type of tissue from which the sample was derived |  no  |
+[CellType](CellType.md) | The cell type from which the sample was derived |  no  |
+[CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived |  no  |
+[CellComponent](CellComponent.md) | The cellular component from which the sample was derived |  no  |
+[AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: id
+alias: id
+domain_of:
+- Tissue
+- CellType
+- CellStrain
+- CellComponent
+- AnnotationObject
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/image_corrector.md
+++ b/schema/v1.1.0/metadata-docs/image_corrector.md
@@ -5,7 +5,7 @@ _Image corrector setup_
 
 
 
-URI: [cdp-meta:image_corrector](https://cryoetdataportal.czscience.com/schema/metadata/image_corrector)
+URI: [cdp-meta:image_corrector](metadataimage_corrector)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:image_corrector](https://cryoetdataportal.czscience.com/schema/me
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:image_corrector](https://cryoetdataportal.czscience.com/schema/me
 ```yaml
 name: image_corrector
 description: Image corrector setup
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_microscope_image_corrector
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/image_corrector.md
+++ b/schema/v1.1.0/metadata-docs/image_corrector.md
@@ -1,0 +1,72 @@
+# Slot: image_corrector
+
+
+_Image corrector setup_
+
+
+
+URI: [cdp-meta:image_corrector](https://cryoetdataportal.czscience.com/schema/metadata/image_corrector)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[MicroscopeOpticalSetup](MicroscopeOpticalSetup.md) | The optical setup of the microscope used to collect the tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: image_corrector
+description: Image corrector setup
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_microscope_image_corrector
+rank: 1000
+alias: image_corrector
+owner: MicroscopeOpticalSetup
+domain_of:
+- MicroscopeOpticalSetup
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/index.md
+++ b/schema/v1.1.0/metadata-docs/index.md
@@ -2,7 +2,7 @@
 
 
 
-URI: https://cryoetdataportal.czscience.com/schema-docs/metadata
+URI: metadata
 
 Name: cdp-meta
 

--- a/schema/v1.1.0/metadata-docs/index.md
+++ b/schema/v1.1.0/metadata-docs/index.md
@@ -1,0 +1,171 @@
+# cdp-meta
+
+
+
+URI: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+Name: cdp-meta
+
+
+
+## Classes
+
+| Class | Description |
+| --- | --- |
+| [Annotation](Annotation.md) | Metadata describing an annotation. |
+| [AnnotationConfidence](AnnotationConfidence.md) | Metadata describing the confidence of an annotation. |
+| [AnnotationFile](AnnotationFile.md) | Metadata describing a file containing an annotation. |
+| [AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated. |
+| [Annotator](Annotator.md) | Annotator of a scientific data entity. |
+| [AnnotatoredEntity](AnnotatoredEntity.md) | An entity with associated annotation authors. |
+| [Author](Author.md) | Author of a scientific data entity. |
+| [AuthoredEntity](AuthoredEntity.md) | An entity with associated authors. |
+| [Camera](Camera.md) | The camera used to collect the tilt series. |
+| [CellComponent](CellComponent.md) | The cellular component from which the sample was derived. |
+| [CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived. |
+| [CellType](CellType.md) | The cell type from which the sample was derived. |
+| [CrossReferencedEntity](CrossReferencedEntity.md) | An entity with associated cross-references to other databases and publications. |
+| [CrossReferences](CrossReferences.md) | A set of cross-references to other databases and publications. |
+| [Dataset](Dataset.md) | High-level description of a cryoET dataset. |
+| [DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modified. |
+| [DatestampedEntity](DatestampedEntity.md) | An entity with associated deposition, release and last modified dates. |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET dataset. |
+| [FundedEntity](FundedEntity.md) | An entity with associated funding sources. |
+| [Funding](Funding.md) | A funding source for a scientific data entity (base for JSON and DB representation). |
+| [Microscope](Microscope.md) | The microscope used to collect the tilt series. |
+| [MicroscopeOpticalSetup](MicroscopeOpticalSetup.md) | The optical setup of the microscope used to collect the tilt series. |
+| [Organism](Organism.md) | The species from which the sample was derived. |
+| [PicturedEntity](PicturedEntity.md) | An entity with associated preview images. |
+| [PicturePath](PicturePath.md) | A set of paths to representative images of a piece of data. |
+| [TiltRange](TiltRange.md) | The range of tilt angles in the tilt series. |
+| [TiltSeries](TiltSeries.md) | Metadata describing a tilt series. |
+| [Tissue](Tissue.md) | The type of tissue from which the sample was derived. |
+| [Tomogram](Tomogram.md) | Metadata describing a tomogram. |
+| [TomogramOffset](TomogramOffset.md) | The offset of a tomogram in voxels in each dimension relative to the canonical tomogram. |
+| [TomogramSize](TomogramSize.md) | The size of a tomogram in voxels in each dimension. |
+
+
+
+## Slots
+
+| Slot | Description |
+| --- | --- |
+| [acceleration_voltage](acceleration_voltage.md) | Electron Microscope Accelerator voltage in volts |
+| [affiliation_address](affiliation_address.md) | The address of the author's affiliation |
+| [affiliation_identifier](affiliation_identifier.md) | A Research Organization Registry (ROR) identifier |
+| [affiliation_name](affiliation_name.md) | The name of the author's affiliation |
+| [affine_transformation_matrix](affine_transformation_matrix.md) | The flip or rotation transformation of this author submitted tomogram is indi... |
+| [aligned_tiltseries_binning](aligned_tiltseries_binning.md) | Binning factor of the aligned tilt series |
+| [annotation_method](annotation_method.md) | Describe how the annotation is made (e |
+| [annotation_method_type](annotation_method_type.md) | Classification of the annotation method based on supervision |
+| [annotation_object](annotation_object.md) | Metadata describing the object being annotated |
+| [annotation_publications](annotation_publications.md) | DOIs for publications that describe the dataset |
+| [annotation_software](annotation_software.md) | Software used for generating this annotation |
+| [authors](authors.md) | Author of a scientific data entity |
+| [binning_from_frames](binning_from_frames.md) | Describes the binning factor from frames to tilt series file |
+| [camera](camera.md) | The camera used to collect the tilt series |
+| [cell_component](cell_component.md) | The cellular component from which the sample was derived |
+| [cell_strain](cell_strain.md) | The strain or cell line from which the sample was derived |
+| [cell_type](cell_type.md) | The cell type from which the sample was derived |
+| [confidence](confidence.md) | Metadata describing the confidence of an annotation |
+| [cross_references](cross_references.md) | A set of cross-references to other databases and publications |
+| [ctf_corrected](ctf_corrected.md) | Whether this tomogram is CTF corrected |
+| [data_acquisition_software](data_acquisition_software.md) | Software used to collect data |
+| [dataset_citations](dataset_citations.md) | Comma-separated list of DOIs for publications citing the dataset |
+| [dataset_description](dataset_description.md) | A short description of a CryoET dataset, similar to an abstract for a journal... |
+| [dataset_identifier](dataset_identifier.md) | An identifier for a CryoET dataset, assigned by the Data Portal |
+| [dataset_publications](dataset_publications.md) | Comma-separated list of DOIs for publications associated with the dataset |
+| [dataset_title](dataset_title.md) | Title of a CryoET dataset |
+| [dates](dates.md) | A set of dates at which a data item was deposited, published and last modifie... |
+| [deposition_date](deposition_date.md) | The date a data item was received by the cryoET data portal |
+| [description](description.md) | A textual description of the annotation object, can be a longer description t... |
+| [email](email.md) | The email address of the author |
+| [energy_filter](energy_filter.md) | Energy filter setup used |
+| [fiducial_alignment_status](fiducial_alignment_status.md) | Whether the tomographic alignment was computed based on fiducial markers |
+| [files](files.md) | Metadata describing a file containing an annotation |
+| [format](format.md) | File format for this file |
+| [frames_count](frames_count.md) | Number of frames associated with this tiltseries |
+| [funding](funding.md) | A funding source for a scientific data entity (base for JSON and DB represent... |
+| [funding_agency_name](funding_agency_name.md) | The name of the funding source |
+| [grant_id](grant_id.md) | Grant identifier provided by the funding agency |
+| [grid_preparation](grid_preparation.md) | Describes Cryo-ET grid preparation |
+| [ground_truth_status](ground_truth_status.md) | Whether an annotation is considered ground truth, as determined by the annota... |
+| [ground_truth_used](ground_truth_used.md) | Annotation filename used as ground truth for precision and recall |
+| [id](id.md) | The UBERON identifier for the tissue |
+| [image_corrector](image_corrector.md) | Image corrector setup |
+| [is_corresponding](is_corresponding.md) | Whether the author is a corresponding author |
+| [is_curator_recommended](is_curator_recommended.md) | This annotation is recommended by the curator to be preferred for this object... |
+| [is_primary_annotator](is_primary_annotator.md) | Whether the author is a primary author |
+| [is_primary_author](is_primary_author.md) | Whether the author is a primary author |
+| [is_visualization_default](is_visualization_default.md) | This annotation will be rendered in neuroglancer by default |
+| [key_photos](key_photos.md) | A set of paths to representative images of a piece of data |
+| [last_modified_date](last_modified_date.md) | The date a piece of data was last modified on the cryoET data portal |
+| [manufacturer](manufacturer.md) | Name of the camera manufacturer |
+| [max](max.md) | Maximal tilt angle in degrees |
+| [microscope](microscope.md) | The microscope used to collect the tilt series |
+| [microscope_additional_info](microscope_additional_info.md) | Other microscope optical setup information, in addition to energy filter, pha... |
+| [microscope_optical_setup](microscope_optical_setup.md) | The optical setup of the microscope used to collect the tilt series |
+| [min](min.md) | Minimal tilt angle in degrees |
+| [model](model.md) | Camera model name |
+| [name](name.md) | The full name of the author |
+| [object_count](object_count.md) | Number of objects identified |
+| [offset](offset.md) | The offset of a tomogram in voxels in each dimension relative to the canonica... |
+| [ORCID](ORCID.md) | A unique, persistent identifier for researchers, provided by ORCID |
+| [organism](organism.md) | The species from which the sample was derived |
+| [other_setup](other_setup.md) | Describes other setup not covered by sample preparation or grid preparation t... |
+| [path](path.md) | Path to the annotation file relative to the dataset root |
+| [phase_plate](phase_plate.md) | Phase plate configuration |
+| [pixel_spacing](pixel_spacing.md) | Pixel spacing for the tilt series |
+| [precision](precision.md) | Describe the confidence level of the annotation |
+| [processing](processing.md) | Describe additional processing used to derive the tomogram |
+| [processing_software](processing_software.md) | Processing software used to derive the tomogram |
+| [recall](recall.md) | Describe the confidence level of the annotation |
+| [reconstruction_method](reconstruction_method.md) | Describe reconstruction method (Weighted back-projection, SART, SIRT) |
+| [reconstruction_software](reconstruction_software.md) | Name of software used for reconstruction |
+| [related_database_entries](related_database_entries.md) | Comma-separated list of related database entries for the dataset |
+| [related_database_links](related_database_links.md) | Comma-separated list of related database links for the dataset |
+| [release_date](release_date.md) | The date a data item was received by the cryoET data portal |
+| [sample_preparation](sample_preparation.md) | Describes how the sample was prepared |
+| [sample_type](sample_type.md) | Type of sample imaged in a CryoET study |
+| [shape](shape.md) | Describe whether this is a Point, OrientedPoint, or SegmentationMask file |
+| [size](size.md) | The size of a tomogram in voxels in each dimension |
+| [snapshot](snapshot.md) | Path to the dataset preview image relative to the dataset directory root |
+| [spherical_aberration_constant](spherical_aberration_constant.md) | Spherical Aberration Constant of the objective lens in millimeters |
+| [state](state.md) | Molecule state annotated (e |
+| [taxonomy_id](taxonomy_id.md) | NCBI taxonomy identifier for the organism, e |
+| [thumbnail](thumbnail.md) | Path to the thumbnail of preview image relative to the dataset directory root |
+| [tilt_axis](tilt_axis.md) | Rotation angle in degrees |
+| [tilt_range](tilt_range.md) | The range of tilt angles in the tilt series |
+| [tilt_series_quality](tilt_series_quality.md) | Author assessment of tilt series quality within the dataset (1-5, 5 is best) |
+| [tilt_step](tilt_step.md) | Tilt step in degrees |
+| [tilting_scheme](tilting_scheme.md) | The order of stage tilting during acquisition of the data |
+| [tissue](tissue.md) | The type of tissue from which the sample was derived |
+| [tomogram_version](tomogram_version.md) | Version of tomogram using the same software and post-processing |
+| [total_flux](total_flux.md) | Number of Electrons reaching the specimen in a square Angstrom area for the e... |
+| [voxel_spacing](voxel_spacing.md) | Voxel spacing equal in all three axes in angstroms |
+| [x](x.md) | Number of pixels in the 3D data fast axis |
+| [y](y.md) | Number of pixels in the 3D data medium axis |
+| [z](z.md) | Number of pixels in the 3D data slow axis |
+
+
+## Enumerations
+
+| Enumeration | Description |
+| --- | --- |
+| [AnnotationMethodTypeEnum](AnnotationMethodTypeEnum.md) | Describes how the annotations were generated |
+| [AnnotationShapeEnum](AnnotationShapeEnum.md) | Annotation shape types available on the data portal |
+| [FiducialAlignmentStatusEnum](FiducialAlignmentStatusEnum.md) | Fiducial Alignment method |
+| [SampleTypeEnum](SampleTypeEnum.md) | Type of sample imaged in a CryoET study |
+| [TomogramTypeEnum](TomogramTypeEnum.md) | Tomogram type |
+
+
+## Types
+
+| Type | Description |
+| --- | --- |
+
+
+## Subsets
+
+| Subset | Description |
+| --- | --- |

--- a/schema/v1.1.0/metadata-docs/is_corresponding.md
+++ b/schema/v1.1.0/metadata-docs/is_corresponding.md
@@ -1,0 +1,54 @@
+# Slot: is_corresponding
+
+URI: [cdp-meta:is_corresponding](https://cryoetdataportal.czscience.com/schema/metadata/is_corresponding)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Author](Author.md) | Author of a scientific data entity |  no  |
+[Annotator](Annotator.md) | Annotator of a scientific data entity |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: is_corresponding
+alias: is_corresponding
+domain_of:
+- Author
+- Annotator
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/is_corresponding.md
+++ b/schema/v1.1.0/metadata-docs/is_corresponding.md
@@ -1,6 +1,6 @@
 # Slot: is_corresponding
 
-URI: [cdp-meta:is_corresponding](https://cryoetdataportal.czscience.com/schema/metadata/is_corresponding)
+URI: [cdp-meta:is_corresponding](metadatais_corresponding)
 
 
 

--- a/schema/v1.1.0/metadata-docs/is_curator_recommended.md
+++ b/schema/v1.1.0/metadata-docs/is_curator_recommended.md
@@ -5,7 +5,7 @@ _This annotation is recommended by the curator to be preferred for this object t
 
 
 
-URI: [cdp-meta:is_curator_recommended](https://cryoetdataportal.czscience.com/schema/metadata/is_curator_recommended)
+URI: [cdp-meta:is_curator_recommended](metadatais_curator_recommended)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:is_curator_recommended](https://cryoetdataportal.czscience.com/sc
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:is_curator_recommended](https://cryoetdataportal.czscience.com/sc
 name: is_curator_recommended
 description: This annotation is recommended by the curator to be preferred for this
   object type.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_is_curator_recommended
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/is_curator_recommended.md
+++ b/schema/v1.1.0/metadata-docs/is_curator_recommended.md
@@ -1,0 +1,73 @@
+# Slot: is_curator_recommended
+
+
+_This annotation is recommended by the curator to be preferred for this object type._
+
+
+
+URI: [cdp-meta:is_curator_recommended](https://cryoetdataportal.czscience.com/schema/metadata/is_curator_recommended)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: is_curator_recommended
+description: This annotation is recommended by the curator to be preferred for this
+  object type.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_is_curator_recommended
+rank: 1000
+alias: is_curator_recommended
+owner: Annotation
+domain_of:
+- Annotation
+range: boolean
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/is_primary_annotator.md
+++ b/schema/v1.1.0/metadata-docs/is_primary_annotator.md
@@ -1,0 +1,72 @@
+# Slot: is_primary_annotator
+
+
+_Whether the author is a primary author._
+
+
+
+URI: [cdp-meta:is_primary_annotator](https://cryoetdataportal.czscience.com/schema/metadata/is_primary_annotator)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Annotator](Annotator.md) | Annotator of a scientific data entity |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: is_primary_annotator
+description: Whether the author is a primary author.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:author_primary_author_status
+rank: 1000
+alias: is_primary_annotator
+owner: Annotator
+domain_of:
+- Annotator
+range: boolean
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/is_primary_annotator.md
+++ b/schema/v1.1.0/metadata-docs/is_primary_annotator.md
@@ -5,7 +5,7 @@ _Whether the author is a primary author._
 
 
 
-URI: [cdp-meta:is_primary_annotator](https://cryoetdataportal.czscience.com/schema/metadata/is_primary_annotator)
+URI: [cdp-meta:is_primary_annotator](metadatais_primary_annotator)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:is_primary_annotator](https://cryoetdataportal.czscience.com/sche
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:is_primary_annotator](https://cryoetdataportal.czscience.com/sche
 ```yaml
 name: is_primary_annotator
 description: Whether the author is a primary author.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:author_primary_author_status
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/is_primary_author.md
+++ b/schema/v1.1.0/metadata-docs/is_primary_author.md
@@ -1,0 +1,72 @@
+# Slot: is_primary_author
+
+
+_Whether the author is a primary author._
+
+
+
+URI: [cdp-meta:is_primary_author](https://cryoetdataportal.czscience.com/schema/metadata/is_primary_author)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Author](Author.md) | Author of a scientific data entity |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: is_primary_author
+description: Whether the author is a primary author.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:author_primary_author_status
+rank: 1000
+alias: is_primary_author
+owner: Author
+domain_of:
+- Author
+range: boolean
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/is_primary_author.md
+++ b/schema/v1.1.0/metadata-docs/is_primary_author.md
@@ -5,7 +5,7 @@ _Whether the author is a primary author._
 
 
 
-URI: [cdp-meta:is_primary_author](https://cryoetdataportal.czscience.com/schema/metadata/is_primary_author)
+URI: [cdp-meta:is_primary_author](metadatais_primary_author)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:is_primary_author](https://cryoetdataportal.czscience.com/schema/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:is_primary_author](https://cryoetdataportal.czscience.com/schema/
 ```yaml
 name: is_primary_author
 description: Whether the author is a primary author.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:author_primary_author_status
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/is_visualization_default.md
+++ b/schema/v1.1.0/metadata-docs/is_visualization_default.md
@@ -1,0 +1,72 @@
+# Slot: is_visualization_default
+
+
+_This annotation will be rendered in neuroglancer by default._
+
+
+
+URI: [cdp-meta:is_visualization_default](https://cryoetdataportal.czscience.com/schema/metadata/is_visualization_default)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[AnnotationFile](AnnotationFile.md) | Metadata describing a file containing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: is_visualization_default
+description: This annotation will be rendered in neuroglancer by default.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_file_is_visualization_default
+rank: 1000
+alias: is_visualization_default
+owner: AnnotationFile
+domain_of:
+- AnnotationFile
+range: boolean
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/is_visualization_default.md
+++ b/schema/v1.1.0/metadata-docs/is_visualization_default.md
@@ -5,7 +5,7 @@ _This annotation will be rendered in neuroglancer by default._
 
 
 
-URI: [cdp-meta:is_visualization_default](https://cryoetdataportal.czscience.com/schema/metadata/is_visualization_default)
+URI: [cdp-meta:is_visualization_default](metadatais_visualization_default)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:is_visualization_default](https://cryoetdataportal.czscience.com/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:is_visualization_default](https://cryoetdataportal.czscience.com/
 ```yaml
 name: is_visualization_default
 description: This annotation will be rendered in neuroglancer by default.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_file_is_visualization_default
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/key_photos.md
+++ b/schema/v1.1.0/metadata-docs/key_photos.md
@@ -1,6 +1,6 @@
 # Slot: key_photos
 
-URI: [cdp-meta:key_photos](https://cryoetdataportal.czscience.com/schema/metadata/key_photos)
+URI: [cdp-meta:key_photos](metadatakey_photos)
 
 
 

--- a/schema/v1.1.0/metadata-docs/key_photos.md
+++ b/schema/v1.1.0/metadata-docs/key_photos.md
@@ -1,0 +1,56 @@
+# Slot: key_photos
+
+URI: [cdp-meta:key_photos](https://cryoetdataportal.czscience.com/schema/metadata/key_photos)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[PicturedEntity](PicturedEntity.md) | An entity with associated preview images |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: key_photos
+alias: key_photos
+domain_of:
+- PicturedEntity
+- Dataset
+- Tomogram
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/last_modified_date.md
+++ b/schema/v1.1.0/metadata-docs/last_modified_date.md
@@ -5,7 +5,7 @@ _The date a piece of data was last modified on the cryoET data portal._
 
 
 
-URI: [cdp-meta:last_modified_date](https://cryoetdataportal.czscience.com/schema/metadata/last_modified_date)
+URI: [cdp-meta:last_modified_date](metadatalast_modified_date)
 
 
 
@@ -47,7 +47,7 @@ URI: [cdp-meta:last_modified_date](https://cryoetdataportal.czscience.com/schema
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -58,7 +58,7 @@ URI: [cdp-meta:last_modified_date](https://cryoetdataportal.czscience.com/schema
 ```yaml
 name: last_modified_date
 description: The date a piece of data was last modified on the cryoET data portal.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: last_modified_date
 owner: DateStamp

--- a/schema/v1.1.0/metadata-docs/last_modified_date.md
+++ b/schema/v1.1.0/metadata-docs/last_modified_date.md
@@ -1,0 +1,74 @@
+# Slot: last_modified_date
+
+
+_The date a piece of data was last modified on the cryoET data portal._
+
+
+
+URI: [cdp-meta:last_modified_date](https://cryoetdataportal.czscience.com/schema/metadata/last_modified_date)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... |  yes  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:date](http://www.w3.org/2001/XMLSchema#date)
+
+* Required: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: last_modified_date
+description: The date a piece of data was last modified on the cryoET data portal.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: last_modified_date
+owner: DateStamp
+domain_of:
+- DateStamp
+range: date
+required: true
+recommended: true
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/manufacturer.md
+++ b/schema/v1.1.0/metadata-docs/manufacturer.md
@@ -1,6 +1,6 @@
 # Slot: manufacturer
 
-URI: [cdp-meta:manufacturer](https://cryoetdataportal.czscience.com/schema/metadata/manufacturer)
+URI: [cdp-meta:manufacturer](metadatamanufacturer)
 
 
 

--- a/schema/v1.1.0/metadata-docs/manufacturer.md
+++ b/schema/v1.1.0/metadata-docs/manufacturer.md
@@ -1,0 +1,54 @@
+# Slot: manufacturer
+
+URI: [cdp-meta:manufacturer](https://cryoetdataportal.czscience.com/schema/metadata/manufacturer)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Camera](Camera.md) | The camera used to collect the tilt series |  no  |
+[Microscope](Microscope.md) | The microscope used to collect the tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: manufacturer
+alias: manufacturer
+domain_of:
+- Camera
+- Microscope
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/max.md
+++ b/schema/v1.1.0/metadata-docs/max.md
@@ -1,0 +1,72 @@
+# Slot: max
+
+
+_Maximal tilt angle in degrees_
+
+
+
+URI: [cdp-meta:max](https://cryoetdataportal.czscience.com/schema/metadata/max)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltRange](TiltRange.md) | The range of tilt angles in the tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: max
+description: Maximal tilt angle in degrees
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_tilt_max
+rank: 1000
+alias: max
+owner: TiltRange
+domain_of:
+- TiltRange
+range: float
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/max.md
+++ b/schema/v1.1.0/metadata-docs/max.md
@@ -5,7 +5,7 @@ _Maximal tilt angle in degrees_
 
 
 
-URI: [cdp-meta:max](https://cryoetdataportal.czscience.com/schema/metadata/max)
+URI: [cdp-meta:max](metadatamax)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:max](https://cryoetdataportal.czscience.com/schema/metadata/max)
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:max](https://cryoetdataportal.czscience.com/schema/metadata/max)
 ```yaml
 name: max
 description: Maximal tilt angle in degrees
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_tilt_max
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/microscope_additional_info.md
+++ b/schema/v1.1.0/metadata-docs/microscope_additional_info.md
@@ -1,0 +1,73 @@
+# Slot: microscope_additional_info
+
+
+_Other microscope optical setup information, in addition to energy filter, phase plate and image corrector_
+
+
+
+URI: [cdp-meta:microscope_additional_info](https://cryoetdataportal.czscience.com/schema/metadata/microscope_additional_info)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: microscope_additional_info
+description: Other microscope optical setup information, in addition to energy filter,
+  phase plate and image corrector
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_microscope_additional_info
+rank: 1000
+alias: microscope_additional_info
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/microscope_additional_info.md
+++ b/schema/v1.1.0/metadata-docs/microscope_additional_info.md
@@ -5,7 +5,7 @@ _Other microscope optical setup information, in addition to energy filter, phase
 
 
 
-URI: [cdp-meta:microscope_additional_info](https://cryoetdataportal.czscience.com/schema/metadata/microscope_additional_info)
+URI: [cdp-meta:microscope_additional_info](metadatamicroscope_additional_info)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:microscope_additional_info](https://cryoetdataportal.czscience.co
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:microscope_additional_info](https://cryoetdataportal.czscience.co
 name: microscope_additional_info
 description: Other microscope optical setup information, in addition to energy filter,
   phase plate and image corrector
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_microscope_additional_info
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/microscope_optical_setup.md
+++ b/schema/v1.1.0/metadata-docs/microscope_optical_setup.md
@@ -1,0 +1,70 @@
+# Slot: microscope_optical_setup
+
+
+_The optical setup of the microscope used to collect the tilt series._
+
+
+
+URI: [cdp-meta:microscope_optical_setup](https://cryoetdataportal.czscience.com/schema/metadata/microscope_optical_setup)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [MicroscopeOpticalSetup](MicroscopeOpticalSetup.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: microscope_optical_setup
+description: The optical setup of the microscope used to collect the tilt series.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: microscope_optical_setup
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: MicroscopeOpticalSetup
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/microscope_optical_setup.md
+++ b/schema/v1.1.0/metadata-docs/microscope_optical_setup.md
@@ -5,7 +5,7 @@ _The optical setup of the microscope used to collect the tilt series._
 
 
 
-URI: [cdp-meta:microscope_optical_setup](https://cryoetdataportal.czscience.com/schema/metadata/microscope_optical_setup)
+URI: [cdp-meta:microscope_optical_setup](metadatamicroscope_optical_setup)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:microscope_optical_setup](https://cryoetdataportal.czscience.com/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:microscope_optical_setup](https://cryoetdataportal.czscience.com/
 ```yaml
 name: microscope_optical_setup
 description: The optical setup of the microscope used to collect the tilt series.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: microscope_optical_setup
 owner: TiltSeries

--- a/schema/v1.1.0/metadata-docs/min.md
+++ b/schema/v1.1.0/metadata-docs/min.md
@@ -1,0 +1,72 @@
+# Slot: min
+
+
+_Minimal tilt angle in degrees_
+
+
+
+URI: [cdp-meta:min](https://cryoetdataportal.czscience.com/schema/metadata/min)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltRange](TiltRange.md) | The range of tilt angles in the tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: min
+description: Minimal tilt angle in degrees
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_tilt_min
+rank: 1000
+alias: min
+owner: TiltRange
+domain_of:
+- TiltRange
+range: float
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/min.md
+++ b/schema/v1.1.0/metadata-docs/min.md
@@ -5,7 +5,7 @@ _Minimal tilt angle in degrees_
 
 
 
-URI: [cdp-meta:min](https://cryoetdataportal.czscience.com/schema/metadata/min)
+URI: [cdp-meta:min](metadatamin)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:min](https://cryoetdataportal.czscience.com/schema/metadata/min)
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:min](https://cryoetdataportal.czscience.com/schema/metadata/min)
 ```yaml
 name: min
 description: Minimal tilt angle in degrees
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_tilt_min
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/model.md
+++ b/schema/v1.1.0/metadata-docs/model.md
@@ -1,0 +1,54 @@
+# Slot: model
+
+URI: [cdp-meta:model](https://cryoetdataportal.czscience.com/schema/metadata/model)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Camera](Camera.md) | The camera used to collect the tilt series |  no  |
+[Microscope](Microscope.md) | The microscope used to collect the tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: model
+alias: model
+domain_of:
+- Camera
+- Microscope
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/model.md
+++ b/schema/v1.1.0/metadata-docs/model.md
@@ -1,6 +1,6 @@
 # Slot: model
 
-URI: [cdp-meta:model](https://cryoetdataportal.czscience.com/schema/metadata/model)
+URI: [cdp-meta:model](metadatamodel)
 
 
 

--- a/schema/v1.1.0/metadata-docs/name.md
+++ b/schema/v1.1.0/metadata-docs/name.md
@@ -1,0 +1,66 @@
+# Slot: name
+
+URI: [cdp-meta:name](https://cryoetdataportal.czscience.com/schema/metadata/name)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Author](Author.md) | Author of a scientific data entity |  no  |
+[Annotator](Annotator.md) | Annotator of a scientific data entity |  no  |
+[Organism](Organism.md) | The species from which the sample was derived |  no  |
+[Tissue](Tissue.md) | The type of tissue from which the sample was derived |  no  |
+[CellType](CellType.md) | The cell type from which the sample was derived |  no  |
+[CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived |  no  |
+[CellComponent](CellComponent.md) | The cellular component from which the sample was derived |  no  |
+[AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: name
+alias: name
+domain_of:
+- Author
+- Annotator
+- Organism
+- Tissue
+- CellType
+- CellStrain
+- CellComponent
+- AnnotationObject
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/name.md
+++ b/schema/v1.1.0/metadata-docs/name.md
@@ -1,6 +1,6 @@
 # Slot: name
 
-URI: [cdp-meta:name](https://cryoetdataportal.czscience.com/schema/metadata/name)
+URI: [cdp-meta:name](metadataname)
 
 
 

--- a/schema/v1.1.0/metadata-docs/object_count.md
+++ b/schema/v1.1.0/metadata-docs/object_count.md
@@ -1,0 +1,72 @@
+# Slot: object_count
+
+
+_Number of objects identified_
+
+
+
+URI: [cdp-meta:object_count](https://cryoetdataportal.czscience.com/schema/metadata/object_count)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:integer](http://www.w3.org/2001/XMLSchema#integer)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: object_count
+description: Number of objects identified
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_object_count
+rank: 1000
+alias: object_count
+owner: Annotation
+domain_of:
+- Annotation
+range: integer
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/object_count.md
+++ b/schema/v1.1.0/metadata-docs/object_count.md
@@ -5,7 +5,7 @@ _Number of objects identified_
 
 
 
-URI: [cdp-meta:object_count](https://cryoetdataportal.czscience.com/schema/metadata/object_count)
+URI: [cdp-meta:object_count](metadataobject_count)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:object_count](https://cryoetdataportal.czscience.com/schema/metad
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:object_count](https://cryoetdataportal.czscience.com/schema/metad
 ```yaml
 name: object_count
 description: Number of objects identified
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_object_count
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/offset.md
+++ b/schema/v1.1.0/metadata-docs/offset.md
@@ -1,0 +1,71 @@
+# Slot: offset
+
+
+_The offset of a tomogram in voxels in each dimension relative to the canonical tomogram._
+
+
+
+URI: [cdp-meta:offset](https://cryoetdataportal.czscience.com/schema/metadata/offset)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [TomogramOffset](TomogramOffset.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: offset
+description: The offset of a tomogram in voxels in each dimension relative to the
+  canonical tomogram.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: offset
+owner: Tomogram
+domain_of:
+- Tomogram
+range: TomogramOffset
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/offset.md
+++ b/schema/v1.1.0/metadata-docs/offset.md
@@ -5,7 +5,7 @@ _The offset of a tomogram in voxels in each dimension relative to the canonical 
 
 
 
-URI: [cdp-meta:offset](https://cryoetdataportal.czscience.com/schema/metadata/offset)
+URI: [cdp-meta:offset](metadataoffset)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:offset](https://cryoetdataportal.czscience.com/schema/metadata/of
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:offset](https://cryoetdataportal.czscience.com/schema/metadata/of
 name: offset
 description: The offset of a tomogram in voxels in each dimension relative to the
   canonical tomogram.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: offset
 owner: Tomogram

--- a/schema/v1.1.0/metadata-docs/other_setup.md
+++ b/schema/v1.1.0/metadata-docs/other_setup.md
@@ -1,6 +1,6 @@
 # Slot: other_setup
 
-URI: [cdp-meta:other_setup](https://cryoetdataportal.czscience.com/schema/metadata/other_setup)
+URI: [cdp-meta:other_setup](metadataother_setup)
 
 
 

--- a/schema/v1.1.0/metadata-docs/other_setup.md
+++ b/schema/v1.1.0/metadata-docs/other_setup.md
@@ -1,0 +1,54 @@
+# Slot: other_setup
+
+URI: [cdp-meta:other_setup](https://cryoetdataportal.czscience.com/schema/metadata/other_setup)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: other_setup
+alias: other_setup
+domain_of:
+- ExperimentalMetadata
+- Dataset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/path.md
+++ b/schema/v1.1.0/metadata-docs/path.md
@@ -5,7 +5,7 @@ _Path to the annotation file relative to the dataset root._
 
 
 
-URI: [cdp-meta:path](https://cryoetdataportal.czscience.com/schema/metadata/path)
+URI: [cdp-meta:path](metadatapath)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:path](https://cryoetdataportal.czscience.com/schema/metadata/path
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:path](https://cryoetdataportal.czscience.com/schema/metadata/path
 ```yaml
 name: path
 description: Path to the annotation file relative to the dataset root.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_file_path
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/path.md
+++ b/schema/v1.1.0/metadata-docs/path.md
@@ -1,0 +1,72 @@
+# Slot: path
+
+
+_Path to the annotation file relative to the dataset root._
+
+
+
+URI: [cdp-meta:path](https://cryoetdataportal.czscience.com/schema/metadata/path)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[AnnotationFile](AnnotationFile.md) | Metadata describing a file containing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: path
+description: Path to the annotation file relative to the dataset root.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_file_path
+rank: 1000
+alias: path
+owner: AnnotationFile
+domain_of:
+- AnnotationFile
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/phase_plate.md
+++ b/schema/v1.1.0/metadata-docs/phase_plate.md
@@ -5,7 +5,7 @@ _Phase plate configuration_
 
 
 
-URI: [cdp-meta:phase_plate](https://cryoetdataportal.czscience.com/schema/metadata/phase_plate)
+URI: [cdp-meta:phase_plate](metadataphase_plate)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:phase_plate](https://cryoetdataportal.czscience.com/schema/metada
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:phase_plate](https://cryoetdataportal.czscience.com/schema/metada
 ```yaml
 name: phase_plate
 description: Phase plate configuration
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_microscope_phase_plate
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/phase_plate.md
+++ b/schema/v1.1.0/metadata-docs/phase_plate.md
@@ -1,0 +1,72 @@
+# Slot: phase_plate
+
+
+_Phase plate configuration_
+
+
+
+URI: [cdp-meta:phase_plate](https://cryoetdataportal.czscience.com/schema/metadata/phase_plate)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[MicroscopeOpticalSetup](MicroscopeOpticalSetup.md) | The optical setup of the microscope used to collect the tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: phase_plate
+description: Phase plate configuration
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_microscope_phase_plate
+rank: 1000
+alias: phase_plate
+owner: MicroscopeOpticalSetup
+domain_of:
+- MicroscopeOpticalSetup
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/pixel_spacing.md
+++ b/schema/v1.1.0/metadata-docs/pixel_spacing.md
@@ -1,0 +1,72 @@
+# Slot: pixel_spacing
+
+
+_Pixel spacing for the tilt series_
+
+
+
+URI: [cdp-meta:pixel_spacing](https://cryoetdataportal.czscience.com/schema/metadata/pixel_spacing)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: pixel_spacing
+description: Pixel spacing for the tilt series
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_pixel_spacing
+rank: 1000
+alias: pixel_spacing
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: float
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/pixel_spacing.md
+++ b/schema/v1.1.0/metadata-docs/pixel_spacing.md
@@ -5,7 +5,7 @@ _Pixel spacing for the tilt series_
 
 
 
-URI: [cdp-meta:pixel_spacing](https://cryoetdataportal.czscience.com/schema/metadata/pixel_spacing)
+URI: [cdp-meta:pixel_spacing](metadatapixel_spacing)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:pixel_spacing](https://cryoetdataportal.czscience.com/schema/meta
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:pixel_spacing](https://cryoetdataportal.czscience.com/schema/meta
 ```yaml
 name: pixel_spacing
 description: Pixel spacing for the tilt series
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_pixel_spacing
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/precision.md
+++ b/schema/v1.1.0/metadata-docs/precision.md
@@ -5,7 +5,7 @@ _Describe the confidence level of the annotation. Precision is defined as the % 
 
 
 
-URI: [cdp-meta:precision](https://cryoetdataportal.czscience.com/schema/metadata/precision)
+URI: [cdp-meta:precision](metadataprecision)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:precision](https://cryoetdataportal.czscience.com/schema/metadata
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:precision](https://cryoetdataportal.czscience.com/schema/metadata
 name: precision
 description: Describe the confidence level of the annotation. Precision is defined
   as the % of annotation objects being true positive
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_confidence_precision
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/precision.md
+++ b/schema/v1.1.0/metadata-docs/precision.md
@@ -1,0 +1,73 @@
+# Slot: precision
+
+
+_Describe the confidence level of the annotation. Precision is defined as the % of annotation objects being true positive_
+
+
+
+URI: [cdp-meta:precision](https://cryoetdataportal.czscience.com/schema/metadata/precision)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[AnnotationConfidence](AnnotationConfidence.md) | Metadata describing the confidence of an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: precision
+description: Describe the confidence level of the annotation. Precision is defined
+  as the % of annotation objects being true positive
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_confidence_precision
+rank: 1000
+alias: precision
+owner: AnnotationConfidence
+domain_of:
+- AnnotationConfidence
+range: float
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/processing.md
+++ b/schema/v1.1.0/metadata-docs/processing.md
@@ -5,7 +5,7 @@ _Describe additional processing used to derive the tomogram_
 
 
 
-URI: [cdp-meta:processing](https://cryoetdataportal.czscience.com/schema/metadata/processing)
+URI: [cdp-meta:processing](metadataprocessing)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:processing](https://cryoetdataportal.czscience.com/schema/metadat
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:processing](https://cryoetdataportal.czscience.com/schema/metadat
 ```yaml
 name: processing
 description: Describe additional processing used to derive the tomogram
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tomogram_processing
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/processing.md
+++ b/schema/v1.1.0/metadata-docs/processing.md
@@ -1,0 +1,72 @@
+# Slot: processing
+
+
+_Describe additional processing used to derive the tomogram_
+
+
+
+URI: [cdp-meta:processing](https://cryoetdataportal.czscience.com/schema/metadata/processing)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: processing
+description: Describe additional processing used to derive the tomogram
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tomogram_processing
+rank: 1000
+alias: processing
+owner: Tomogram
+domain_of:
+- Tomogram
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/processing_software.md
+++ b/schema/v1.1.0/metadata-docs/processing_software.md
@@ -1,0 +1,72 @@
+# Slot: processing_software
+
+
+_Processing software used to derive the tomogram_
+
+
+
+URI: [cdp-meta:processing_software](https://cryoetdataportal.czscience.com/schema/metadata/processing_software)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: processing_software
+description: Processing software used to derive the tomogram
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tomogram_processing_software
+rank: 1000
+alias: processing_software
+owner: Tomogram
+domain_of:
+- Tomogram
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/processing_software.md
+++ b/schema/v1.1.0/metadata-docs/processing_software.md
@@ -5,7 +5,7 @@ _Processing software used to derive the tomogram_
 
 
 
-URI: [cdp-meta:processing_software](https://cryoetdataportal.czscience.com/schema/metadata/processing_software)
+URI: [cdp-meta:processing_software](metadataprocessing_software)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:processing_software](https://cryoetdataportal.czscience.com/schem
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:processing_software](https://cryoetdataportal.czscience.com/schem
 ```yaml
 name: processing_software
 description: Processing software used to derive the tomogram
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tomogram_processing_software
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/recall.md
+++ b/schema/v1.1.0/metadata-docs/recall.md
@@ -1,0 +1,73 @@
+# Slot: recall
+
+
+_Describe the confidence level of the annotation. Recall is defined as the % of true positives being annotated correctly_
+
+
+
+URI: [cdp-meta:recall](https://cryoetdataportal.czscience.com/schema/metadata/recall)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[AnnotationConfidence](AnnotationConfidence.md) | Metadata describing the confidence of an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: recall
+description: Describe the confidence level of the annotation. Recall is defined as
+  the % of true positives being annotated correctly
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_confidence_recall
+rank: 1000
+alias: recall
+owner: AnnotationConfidence
+domain_of:
+- AnnotationConfidence
+range: float
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/recall.md
+++ b/schema/v1.1.0/metadata-docs/recall.md
@@ -5,7 +5,7 @@ _Describe the confidence level of the annotation. Recall is defined as the % of 
 
 
 
-URI: [cdp-meta:recall](https://cryoetdataportal.czscience.com/schema/metadata/recall)
+URI: [cdp-meta:recall](metadatarecall)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:recall](https://cryoetdataportal.czscience.com/schema/metadata/re
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:recall](https://cryoetdataportal.czscience.com/schema/metadata/re
 name: recall
 description: Describe the confidence level of the annotation. Recall is defined as
   the % of true positives being annotated correctly
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_confidence_recall
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/reconstruction_method.md
+++ b/schema/v1.1.0/metadata-docs/reconstruction_method.md
@@ -5,7 +5,7 @@ _Describe reconstruction method (Weighted back-projection, SART, SIRT)_
 
 
 
-URI: [cdp-meta:reconstruction_method](https://cryoetdataportal.czscience.com/schema/metadata/reconstruction_method)
+URI: [cdp-meta:reconstruction_method](metadatareconstruction_method)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:reconstruction_method](https://cryoetdataportal.czscience.com/sch
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:reconstruction_method](https://cryoetdataportal.czscience.com/sch
 ```yaml
 name: reconstruction_method
 description: Describe reconstruction method (Weighted back-projection, SART, SIRT)
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tomogram_reconstruction_method
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/reconstruction_method.md
+++ b/schema/v1.1.0/metadata-docs/reconstruction_method.md
@@ -1,0 +1,72 @@
+# Slot: reconstruction_method
+
+
+_Describe reconstruction method (Weighted back-projection, SART, SIRT)_
+
+
+
+URI: [cdp-meta:reconstruction_method](https://cryoetdataportal.czscience.com/schema/metadata/reconstruction_method)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: reconstruction_method
+description: Describe reconstruction method (Weighted back-projection, SART, SIRT)
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tomogram_reconstruction_method
+rank: 1000
+alias: reconstruction_method
+owner: Tomogram
+domain_of:
+- Tomogram
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/reconstruction_software.md
+++ b/schema/v1.1.0/metadata-docs/reconstruction_software.md
@@ -1,0 +1,72 @@
+# Slot: reconstruction_software
+
+
+_Name of software used for reconstruction_
+
+
+
+URI: [cdp-meta:reconstruction_software](https://cryoetdataportal.czscience.com/schema/metadata/reconstruction_software)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: reconstruction_software
+description: Name of software used for reconstruction
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tomogram_reconstruction_software
+rank: 1000
+alias: reconstruction_software
+owner: Tomogram
+domain_of:
+- Tomogram
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/reconstruction_software.md
+++ b/schema/v1.1.0/metadata-docs/reconstruction_software.md
@@ -5,7 +5,7 @@ _Name of software used for reconstruction_
 
 
 
-URI: [cdp-meta:reconstruction_software](https://cryoetdataportal.czscience.com/schema/metadata/reconstruction_software)
+URI: [cdp-meta:reconstruction_software](metadatareconstruction_software)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:reconstruction_software](https://cryoetdataportal.czscience.com/s
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:reconstruction_software](https://cryoetdataportal.czscience.com/s
 ```yaml
 name: reconstruction_software
 description: Name of software used for reconstruction
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tomogram_reconstruction_software
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/related_database_entries.md
+++ b/schema/v1.1.0/metadata-docs/related_database_entries.md
@@ -1,0 +1,73 @@
+# Slot: related_database_entries
+
+
+_Comma-separated list of related database entries for the dataset._
+
+
+
+URI: [cdp-meta:related_database_entries](https://cryoetdataportal.czscience.com/schema/metadata/related_database_entries)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[CrossReferences](CrossReferences.md) | A set of cross-references to other databases and publications |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* Recommended: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: related_database_entries
+description: Comma-separated list of related database entries for the dataset.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: related_database_entries
+owner: CrossReferences
+domain_of:
+- CrossReferences
+range: string
+recommended: true
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/related_database_entries.md
+++ b/schema/v1.1.0/metadata-docs/related_database_entries.md
@@ -5,7 +5,7 @@ _Comma-separated list of related database entries for the dataset._
 
 
 
-URI: [cdp-meta:related_database_entries](https://cryoetdataportal.czscience.com/schema/metadata/related_database_entries)
+URI: [cdp-meta:related_database_entries](metadatarelated_database_entries)
 
 
 
@@ -47,7 +47,7 @@ URI: [cdp-meta:related_database_entries](https://cryoetdataportal.czscience.com/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -58,7 +58,7 @@ URI: [cdp-meta:related_database_entries](https://cryoetdataportal.czscience.com/
 ```yaml
 name: related_database_entries
 description: Comma-separated list of related database entries for the dataset.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: related_database_entries
 owner: CrossReferences

--- a/schema/v1.1.0/metadata-docs/related_database_links.md
+++ b/schema/v1.1.0/metadata-docs/related_database_links.md
@@ -5,7 +5,7 @@ _Comma-separated list of related database links for the dataset._
 
 
 
-URI: [cdp-meta:related_database_links](https://cryoetdataportal.czscience.com/schema/metadata/related_database_links)
+URI: [cdp-meta:related_database_links](metadatarelated_database_links)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:related_database_links](https://cryoetdataportal.czscience.com/sc
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:related_database_links](https://cryoetdataportal.czscience.com/sc
 ```yaml
 name: related_database_links
 description: Comma-separated list of related database links for the dataset.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: related_database_links
 owner: CrossReferences

--- a/schema/v1.1.0/metadata-docs/related_database_links.md
+++ b/schema/v1.1.0/metadata-docs/related_database_links.md
@@ -1,0 +1,70 @@
+# Slot: related_database_links
+
+
+_Comma-separated list of related database links for the dataset._
+
+
+
+URI: [cdp-meta:related_database_links](https://cryoetdataportal.czscience.com/schema/metadata/related_database_links)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[CrossReferences](CrossReferences.md) | A set of cross-references to other databases and publications |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: related_database_links
+description: Comma-separated list of related database links for the dataset.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: related_database_links
+owner: CrossReferences
+domain_of:
+- CrossReferences
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/release_date.md
+++ b/schema/v1.1.0/metadata-docs/release_date.md
@@ -1,0 +1,74 @@
+# Slot: release_date
+
+
+_The date a data item was received by the cryoET data portal._
+
+
+
+URI: [cdp-meta:release_date](https://cryoetdataportal.czscience.com/schema/metadata/release_date)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... |  yes  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:date](http://www.w3.org/2001/XMLSchema#date)
+
+* Required: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: release_date
+description: The date a data item was received by the cryoET data portal.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: release_date
+owner: DateStamp
+domain_of:
+- DateStamp
+range: date
+required: true
+recommended: true
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/release_date.md
+++ b/schema/v1.1.0/metadata-docs/release_date.md
@@ -5,7 +5,7 @@ _The date a data item was received by the cryoET data portal._
 
 
 
-URI: [cdp-meta:release_date](https://cryoetdataportal.czscience.com/schema/metadata/release_date)
+URI: [cdp-meta:release_date](metadatarelease_date)
 
 
 
@@ -47,7 +47,7 @@ URI: [cdp-meta:release_date](https://cryoetdataportal.czscience.com/schema/metad
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -58,7 +58,7 @@ URI: [cdp-meta:release_date](https://cryoetdataportal.czscience.com/schema/metad
 ```yaml
 name: release_date
 description: The date a data item was received by the cryoET data portal.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: release_date
 owner: DateStamp

--- a/schema/v1.1.0/metadata-docs/sample_preparation.md
+++ b/schema/v1.1.0/metadata-docs/sample_preparation.md
@@ -1,0 +1,54 @@
+# Slot: sample_preparation
+
+URI: [cdp-meta:sample_preparation](https://cryoetdataportal.czscience.com/schema/metadata/sample_preparation)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: sample_preparation
+alias: sample_preparation
+domain_of:
+- ExperimentalMetadata
+- Dataset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/sample_preparation.md
+++ b/schema/v1.1.0/metadata-docs/sample_preparation.md
@@ -1,6 +1,6 @@
 # Slot: sample_preparation
 
-URI: [cdp-meta:sample_preparation](https://cryoetdataportal.czscience.com/schema/metadata/sample_preparation)
+URI: [cdp-meta:sample_preparation](metadatasample_preparation)
 
 
 

--- a/schema/v1.1.0/metadata-docs/sample_type.md
+++ b/schema/v1.1.0/metadata-docs/sample_type.md
@@ -1,6 +1,6 @@
 # Slot: sample_type
 
-URI: [cdp-meta:sample_type](https://cryoetdataportal.czscience.com/schema/metadata/sample_type)
+URI: [cdp-meta:sample_type](metadatasample_type)
 
 
 

--- a/schema/v1.1.0/metadata-docs/sample_type.md
+++ b/schema/v1.1.0/metadata-docs/sample_type.md
@@ -1,0 +1,54 @@
+# Slot: sample_type
+
+URI: [cdp-meta:sample_type](https://cryoetdataportal.czscience.com/schema/metadata/sample_type)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
+[Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: sample_type
+alias: sample_type
+domain_of:
+- ExperimentalMetadata
+- Dataset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/shape.md
+++ b/schema/v1.1.0/metadata-docs/shape.md
@@ -1,0 +1,73 @@
+# Slot: shape
+
+
+_Describe whether this is a Point, OrientedPoint, or SegmentationMask file_
+
+
+
+URI: [cdp-meta:shape](https://cryoetdataportal.czscience.com/schema/metadata/shape)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[AnnotationFile](AnnotationFile.md) | Metadata describing a file containing an annotation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: shape
+description: Describe whether this is a Point, OrientedPoint, or SegmentationMask
+  file
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_file_shape_type
+rank: 1000
+alias: shape
+owner: AnnotationFile
+domain_of:
+- AnnotationFile
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/shape.md
+++ b/schema/v1.1.0/metadata-docs/shape.md
@@ -5,7 +5,7 @@ _Describe whether this is a Point, OrientedPoint, or SegmentationMask file_
 
 
 
-URI: [cdp-meta:shape](https://cryoetdataportal.czscience.com/schema/metadata/shape)
+URI: [cdp-meta:shape](metadatashape)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:shape](https://cryoetdataportal.czscience.com/schema/metadata/sha
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:shape](https://cryoetdataportal.czscience.com/schema/metadata/sha
 name: shape
 description: Describe whether this is a Point, OrientedPoint, or SegmentationMask
   file
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_file_shape_type
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/size.md
+++ b/schema/v1.1.0/metadata-docs/size.md
@@ -5,7 +5,7 @@ _The size of a tomogram in voxels in each dimension._
 
 
 
-URI: [cdp-meta:size](https://cryoetdataportal.czscience.com/schema/metadata/size)
+URI: [cdp-meta:size](metadatasize)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:size](https://cryoetdataportal.czscience.com/schema/metadata/size
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:size](https://cryoetdataportal.czscience.com/schema/metadata/size
 ```yaml
 name: size
 description: The size of a tomogram in voxels in each dimension.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: size
 owner: Tomogram

--- a/schema/v1.1.0/metadata-docs/size.md
+++ b/schema/v1.1.0/metadata-docs/size.md
@@ -1,0 +1,70 @@
+# Slot: size
+
+
+_The size of a tomogram in voxels in each dimension._
+
+
+
+URI: [cdp-meta:size](https://cryoetdataportal.czscience.com/schema/metadata/size)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [TomogramSize](TomogramSize.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: size
+description: The size of a tomogram in voxels in each dimension.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: size
+owner: Tomogram
+domain_of:
+- Tomogram
+range: TomogramSize
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/snapshot.md
+++ b/schema/v1.1.0/metadata-docs/snapshot.md
@@ -5,7 +5,7 @@ _Path to the dataset preview image relative to the dataset directory root._
 
 
 
-URI: [cdp-meta:snapshot](https://cryoetdataportal.czscience.com/schema/metadata/snapshot)
+URI: [cdp-meta:snapshot](metadatasnapshot)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:snapshot](https://cryoetdataportal.czscience.com/schema/metadata/
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:snapshot](https://cryoetdataportal.czscience.com/schema/metadata/
 ```yaml
 name: snapshot
 description: Path to the dataset preview image relative to the dataset directory root.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: snapshot
 owner: PicturePath

--- a/schema/v1.1.0/metadata-docs/snapshot.md
+++ b/schema/v1.1.0/metadata-docs/snapshot.md
@@ -1,0 +1,70 @@
+# Slot: snapshot
+
+
+_Path to the dataset preview image relative to the dataset directory root._
+
+
+
+URI: [cdp-meta:snapshot](https://cryoetdataportal.czscience.com/schema/metadata/snapshot)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[PicturePath](PicturePath.md) | A set of paths to representative images of a piece of data |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: snapshot
+description: Path to the dataset preview image relative to the dataset directory root.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: snapshot
+owner: PicturePath
+domain_of:
+- PicturePath
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/spherical_aberration_constant.md
+++ b/schema/v1.1.0/metadata-docs/spherical_aberration_constant.md
@@ -5,7 +5,7 @@ _Spherical Aberration Constant of the objective lens in millimeters_
 
 
 
-URI: [cdp-meta:spherical_aberration_constant](https://cryoetdataportal.czscience.com/schema/metadata/spherical_aberration_constant)
+URI: [cdp-meta:spherical_aberration_constant](metadataspherical_aberration_constant)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:spherical_aberration_constant](https://cryoetdataportal.czscience
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:spherical_aberration_constant](https://cryoetdataportal.czscience
 ```yaml
 name: spherical_aberration_constant
 description: Spherical Aberration Constant of the objective lens in millimeters
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_spherical_aberration_constant
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/spherical_aberration_constant.md
+++ b/schema/v1.1.0/metadata-docs/spherical_aberration_constant.md
@@ -1,0 +1,72 @@
+# Slot: spherical_aberration_constant
+
+
+_Spherical Aberration Constant of the objective lens in millimeters_
+
+
+
+URI: [cdp-meta:spherical_aberration_constant](https://cryoetdataportal.czscience.com/schema/metadata/spherical_aberration_constant)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: spherical_aberration_constant
+description: Spherical Aberration Constant of the objective lens in millimeters
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_spherical_aberration_constant
+rank: 1000
+alias: spherical_aberration_constant
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: float
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/state.md
+++ b/schema/v1.1.0/metadata-docs/state.md
@@ -1,0 +1,72 @@
+# Slot: state
+
+
+_Molecule state annotated (e.g. open, closed)_
+
+
+
+URI: [cdp-meta:state](https://cryoetdataportal.czscience.com/schema/metadata/state)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: state
+description: Molecule state annotated (e.g. open, closed)
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:annotation_object_state
+rank: 1000
+alias: state
+owner: AnnotationObject
+domain_of:
+- AnnotationObject
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/state.md
+++ b/schema/v1.1.0/metadata-docs/state.md
@@ -5,7 +5,7 @@ _Molecule state annotated (e.g. open, closed)_
 
 
 
-URI: [cdp-meta:state](https://cryoetdataportal.czscience.com/schema/metadata/state)
+URI: [cdp-meta:state](metadatastate)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:state](https://cryoetdataportal.czscience.com/schema/metadata/sta
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:state](https://cryoetdataportal.czscience.com/schema/metadata/sta
 ```yaml
 name: state
 description: Molecule state annotated (e.g. open, closed)
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:annotation_object_state
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/taxonomy_id.md
+++ b/schema/v1.1.0/metadata-docs/taxonomy_id.md
@@ -1,0 +1,72 @@
+# Slot: taxonomy_id
+
+
+_NCBI taxonomy identifier for the organism, e.g. 9606_
+
+
+
+URI: [cdp-meta:taxonomy_id](https://cryoetdataportal.czscience.com/schema/metadata/taxonomy_id)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Organism](Organism.md) | The species from which the sample was derived |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: taxonomy_id
+description: NCBI taxonomy identifier for the organism, e.g. 9606
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:organism_taxid
+rank: 1000
+alias: taxonomy_id
+owner: Organism
+domain_of:
+- Organism
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/taxonomy_id.md
+++ b/schema/v1.1.0/metadata-docs/taxonomy_id.md
@@ -5,7 +5,7 @@ _NCBI taxonomy identifier for the organism, e.g. 9606_
 
 
 
-URI: [cdp-meta:taxonomy_id](https://cryoetdataportal.czscience.com/schema/metadata/taxonomy_id)
+URI: [cdp-meta:taxonomy_id](metadatataxonomy_id)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:taxonomy_id](https://cryoetdataportal.czscience.com/schema/metada
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:taxonomy_id](https://cryoetdataportal.czscience.com/schema/metada
 ```yaml
 name: taxonomy_id
 description: NCBI taxonomy identifier for the organism, e.g. 9606
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:organism_taxid
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/thumbnail.md
+++ b/schema/v1.1.0/metadata-docs/thumbnail.md
@@ -1,0 +1,71 @@
+# Slot: thumbnail
+
+
+_Path to the thumbnail of preview image relative to the dataset directory root._
+
+
+
+URI: [cdp-meta:thumbnail](https://cryoetdataportal.czscience.com/schema/metadata/thumbnail)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[PicturePath](PicturePath.md) | A set of paths to representative images of a piece of data |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: thumbnail
+description: Path to the thumbnail of preview image relative to the dataset directory
+  root.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: thumbnail
+owner: PicturePath
+domain_of:
+- PicturePath
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/thumbnail.md
+++ b/schema/v1.1.0/metadata-docs/thumbnail.md
@@ -5,7 +5,7 @@ _Path to the thumbnail of preview image relative to the dataset directory root._
 
 
 
-URI: [cdp-meta:thumbnail](https://cryoetdataportal.czscience.com/schema/metadata/thumbnail)
+URI: [cdp-meta:thumbnail](metadatathumbnail)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:thumbnail](https://cryoetdataportal.czscience.com/schema/metadata
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:thumbnail](https://cryoetdataportal.czscience.com/schema/metadata
 name: thumbnail
 description: Path to the thumbnail of preview image relative to the dataset directory
   root.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: thumbnail
 owner: PicturePath

--- a/schema/v1.1.0/metadata-docs/tilt_axis.md
+++ b/schema/v1.1.0/metadata-docs/tilt_axis.md
@@ -5,7 +5,7 @@ _Rotation angle in degrees_
 
 
 
-URI: [cdp-meta:tilt_axis](https://cryoetdataportal.czscience.com/schema/metadata/tilt_axis)
+URI: [cdp-meta:tilt_axis](metadatatilt_axis)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:tilt_axis](https://cryoetdataportal.czscience.com/schema/metadata
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:tilt_axis](https://cryoetdataportal.czscience.com/schema/metadata
 ```yaml
 name: tilt_axis
 description: Rotation angle in degrees
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_tilt_axis
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/tilt_axis.md
+++ b/schema/v1.1.0/metadata-docs/tilt_axis.md
@@ -1,0 +1,72 @@
+# Slot: tilt_axis
+
+
+_Rotation angle in degrees_
+
+
+
+URI: [cdp-meta:tilt_axis](https://cryoetdataportal.czscience.com/schema/metadata/tilt_axis)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: tilt_axis
+description: Rotation angle in degrees
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_tilt_axis
+rank: 1000
+alias: tilt_axis
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: float
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/tilt_range.md
+++ b/schema/v1.1.0/metadata-docs/tilt_range.md
@@ -5,7 +5,7 @@ _The range of tilt angles in the tilt series._
 
 
 
-URI: [cdp-meta:tilt_range](https://cryoetdataportal.czscience.com/schema/metadata/tilt_range)
+URI: [cdp-meta:tilt_range](metadatatilt_range)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:tilt_range](https://cryoetdataportal.czscience.com/schema/metadat
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:tilt_range](https://cryoetdataportal.czscience.com/schema/metadat
 ```yaml
 name: tilt_range
 description: The range of tilt angles in the tilt series.
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 rank: 1000
 alias: tilt_range
 owner: TiltSeries

--- a/schema/v1.1.0/metadata-docs/tilt_range.md
+++ b/schema/v1.1.0/metadata-docs/tilt_range.md
@@ -1,0 +1,70 @@
+# Slot: tilt_range
+
+
+_The range of tilt angles in the tilt series._
+
+
+
+URI: [cdp-meta:tilt_range](https://cryoetdataportal.czscience.com/schema/metadata/tilt_range)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [TiltRange](TiltRange.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: tilt_range
+description: The range of tilt angles in the tilt series.
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+rank: 1000
+alias: tilt_range
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: TiltRange
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/tilt_series_quality.md
+++ b/schema/v1.1.0/metadata-docs/tilt_series_quality.md
@@ -1,0 +1,73 @@
+# Slot: tilt_series_quality
+
+
+_Author assessment of tilt series quality within the dataset (1-5, 5 is best)_
+
+
+
+URI: [cdp-meta:tilt_series_quality](https://cryoetdataportal.czscience.com/schema/metadata/tilt_series_quality)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:integer](http://www.w3.org/2001/XMLSchema#integer)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: tilt_series_quality
+description: Author assessment of tilt series quality within the dataset (1-5, 5 is
+  best)
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_tilt_series_quality
+rank: 1000
+alias: tilt_series_quality
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: integer
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/tilt_series_quality.md
+++ b/schema/v1.1.0/metadata-docs/tilt_series_quality.md
@@ -5,7 +5,7 @@ _Author assessment of tilt series quality within the dataset (1-5, 5 is best)_
 
 
 
-URI: [cdp-meta:tilt_series_quality](https://cryoetdataportal.czscience.com/schema/metadata/tilt_series_quality)
+URI: [cdp-meta:tilt_series_quality](metadatatilt_series_quality)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:tilt_series_quality](https://cryoetdataportal.czscience.com/schem
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:tilt_series_quality](https://cryoetdataportal.czscience.com/schem
 name: tilt_series_quality
 description: Author assessment of tilt series quality within the dataset (1-5, 5 is
   best)
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_tilt_series_quality
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/tilt_step.md
+++ b/schema/v1.1.0/metadata-docs/tilt_step.md
@@ -1,0 +1,72 @@
+# Slot: tilt_step
+
+
+_Tilt step in degrees_
+
+
+
+URI: [cdp-meta:tilt_step](https://cryoetdataportal.czscience.com/schema/metadata/tilt_step)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: tilt_step
+description: Tilt step in degrees
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_tilt_step
+rank: 1000
+alias: tilt_step
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: float
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/tilt_step.md
+++ b/schema/v1.1.0/metadata-docs/tilt_step.md
@@ -5,7 +5,7 @@ _Tilt step in degrees_
 
 
 
-URI: [cdp-meta:tilt_step](https://cryoetdataportal.czscience.com/schema/metadata/tilt_step)
+URI: [cdp-meta:tilt_step](metadatatilt_step)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:tilt_step](https://cryoetdataportal.czscience.com/schema/metadata
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:tilt_step](https://cryoetdataportal.czscience.com/schema/metadata
 ```yaml
 name: tilt_step
 description: Tilt step in degrees
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_tilt_step
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/tilting_scheme.md
+++ b/schema/v1.1.0/metadata-docs/tilting_scheme.md
@@ -1,0 +1,72 @@
+# Slot: tilting_scheme
+
+
+_The order of stage tilting during acquisition of the data_
+
+
+
+URI: [cdp-meta:tilting_scheme](https://cryoetdataportal.czscience.com/schema/metadata/tilting_scheme)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: tilting_scheme
+description: The order of stage tilting during acquisition of the data
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_tilting_scheme
+rank: 1000
+alias: tilting_scheme
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/tilting_scheme.md
+++ b/schema/v1.1.0/metadata-docs/tilting_scheme.md
@@ -5,7 +5,7 @@ _The order of stage tilting during acquisition of the data_
 
 
 
-URI: [cdp-meta:tilting_scheme](https://cryoetdataportal.czscience.com/schema/metadata/tilting_scheme)
+URI: [cdp-meta:tilting_scheme](metadatatilting_scheme)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:tilting_scheme](https://cryoetdataportal.czscience.com/schema/met
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:tilting_scheme](https://cryoetdataportal.czscience.com/schema/met
 ```yaml
 name: tilting_scheme
 description: The order of stage tilting during acquisition of the data
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_tilting_scheme
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/tomogram_version.md
+++ b/schema/v1.1.0/metadata-docs/tomogram_version.md
@@ -5,7 +5,7 @@ _Version of tomogram using the same software and post-processing. Version of tom
 
 
 
-URI: [cdp-meta:tomogram_version](https://cryoetdataportal.czscience.com/schema/metadata/tomogram_version)
+URI: [cdp-meta:tomogram_version](metadatatomogram_version)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:tomogram_version](https://cryoetdataportal.czscience.com/schema/m
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -58,7 +58,7 @@ name: tomogram_version
 description: Version of tomogram using the same software and post-processing. Version
   of tomogram using the same software and post-processing. This will be presented
   as the latest version
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tomogram_version
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/tomogram_version.md
+++ b/schema/v1.1.0/metadata-docs/tomogram_version.md
@@ -1,0 +1,74 @@
+# Slot: tomogram_version
+
+
+_Version of tomogram using the same software and post-processing. Version of tomogram using the same software and post-processing. This will be presented as the latest version_
+
+
+
+URI: [cdp-meta:tomogram_version](https://cryoetdataportal.czscience.com/schema/metadata/tomogram_version)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: tomogram_version
+description: Version of tomogram using the same software and post-processing. Version
+  of tomogram using the same software and post-processing. This will be presented
+  as the latest version
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tomogram_version
+rank: 1000
+alias: tomogram_version
+owner: Tomogram
+domain_of:
+- Tomogram
+range: string
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/total_flux.md
+++ b/schema/v1.1.0/metadata-docs/total_flux.md
@@ -5,7 +5,7 @@ _Number of Electrons reaching the specimen in a square Angstrom area for the ent
 
 
 
-URI: [cdp-meta:total_flux](https://cryoetdataportal.czscience.com/schema/metadata/total_flux)
+URI: [cdp-meta:total_flux](metadatatotal_flux)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:total_flux](https://cryoetdataportal.czscience.com/schema/metadat
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -57,7 +57,7 @@ URI: [cdp-meta:total_flux](https://cryoetdataportal.czscience.com/schema/metadat
 name: total_flux
 description: Number of Electrons reaching the specimen in a square Angstrom area for
   the entire tilt series
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tiltseries_total_flux
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/total_flux.md
+++ b/schema/v1.1.0/metadata-docs/total_flux.md
@@ -1,0 +1,73 @@
+# Slot: total_flux
+
+
+_Number of Electrons reaching the specimen in a square Angstrom area for the entire tilt series_
+
+
+
+URI: [cdp-meta:total_flux](https://cryoetdataportal.czscience.com/schema/metadata/total_flux)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TiltSeries](TiltSeries.md) | Metadata describing a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: total_flux
+description: Number of Electrons reaching the specimen in a square Angstrom area for
+  the entire tilt series
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tiltseries_total_flux
+rank: 1000
+alias: total_flux
+owner: TiltSeries
+domain_of:
+- TiltSeries
+range: float
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/types.md
+++ b/schema/v1.1.0/metadata-docs/types.md
@@ -1,0 +1,6 @@
+# types
+
+Shared type definitions for the core LinkML mode and metamodel
+
+URI: https://w3id.org/linkml/types
+

--- a/schema/v1.1.0/metadata-docs/voxel_spacing.md
+++ b/schema/v1.1.0/metadata-docs/voxel_spacing.md
@@ -5,7 +5,7 @@ _Voxel spacing equal in all three axes in angstroms_
 
 
 
-URI: [cdp-meta:voxel_spacing](https://cryoetdataportal.czscience.com/schema/metadata/voxel_spacing)
+URI: [cdp-meta:voxel_spacing](metadatavoxel_spacing)
 
 
 
@@ -45,7 +45,7 @@ URI: [cdp-meta:voxel_spacing](https://cryoetdataportal.czscience.com/schema/meta
 ### Schema Source
 
 
-* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+* from schema: metadata
 
 
 
@@ -56,7 +56,7 @@ URI: [cdp-meta:voxel_spacing](https://cryoetdataportal.czscience.com/schema/meta
 ```yaml
 name: voxel_spacing
 description: Voxel spacing equal in all three axes in angstroms
-from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+from_schema: metadata
 exact_mappings:
 - cdp-common:tomogram_voxel_spacing
 rank: 1000

--- a/schema/v1.1.0/metadata-docs/voxel_spacing.md
+++ b/schema/v1.1.0/metadata-docs/voxel_spacing.md
@@ -1,0 +1,72 @@
+# Slot: voxel_spacing
+
+
+_Voxel spacing equal in all three axes in angstroms_
+
+
+
+URI: [cdp-meta:voxel_spacing](https://cryoetdataportal.czscience.com/schema/metadata/voxel_spacing)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: voxel_spacing
+description: Voxel spacing equal in all three axes in angstroms
+from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+exact_mappings:
+- cdp-common:tomogram_voxel_spacing
+rank: 1000
+alias: voxel_spacing
+owner: Tomogram
+domain_of:
+- Tomogram
+range: float
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/x.md
+++ b/schema/v1.1.0/metadata-docs/x.md
@@ -1,0 +1,54 @@
+# Slot: x
+
+URI: [cdp-meta:x](https://cryoetdataportal.czscience.com/schema/metadata/x)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TomogramSize](TomogramSize.md) | The size of a tomogram in voxels in each dimension |  no  |
+[TomogramOffset](TomogramOffset.md) | The offset of a tomogram in voxels in each dimension relative to the canonica... |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: x
+alias: x
+domain_of:
+- TomogramSize
+- TomogramOffset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/x.md
+++ b/schema/v1.1.0/metadata-docs/x.md
@@ -1,6 +1,6 @@
 # Slot: x
 
-URI: [cdp-meta:x](https://cryoetdataportal.czscience.com/schema/metadata/x)
+URI: [cdp-meta:x](metadatax)
 
 
 

--- a/schema/v1.1.0/metadata-docs/y.md
+++ b/schema/v1.1.0/metadata-docs/y.md
@@ -1,0 +1,54 @@
+# Slot: y
+
+URI: [cdp-meta:y](https://cryoetdataportal.czscience.com/schema/metadata/y)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TomogramSize](TomogramSize.md) | The size of a tomogram in voxels in each dimension |  no  |
+[TomogramOffset](TomogramOffset.md) | The offset of a tomogram in voxels in each dimension relative to the canonica... |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: y
+alias: y
+domain_of:
+- TomogramSize
+- TomogramOffset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata-docs/y.md
+++ b/schema/v1.1.0/metadata-docs/y.md
@@ -1,6 +1,6 @@
 # Slot: y
 
-URI: [cdp-meta:y](https://cryoetdataportal.czscience.com/schema/metadata/y)
+URI: [cdp-meta:y](metadatay)
 
 
 

--- a/schema/v1.1.0/metadata-docs/z.md
+++ b/schema/v1.1.0/metadata-docs/z.md
@@ -1,6 +1,6 @@
 # Slot: z
 
-URI: [cdp-meta:z](https://cryoetdataportal.czscience.com/schema/metadata/z)
+URI: [cdp-meta:z](metadataz)
 
 
 

--- a/schema/v1.1.0/metadata-docs/z.md
+++ b/schema/v1.1.0/metadata-docs/z.md
@@ -1,0 +1,54 @@
+# Slot: z
+
+URI: [cdp-meta:z](https://cryoetdataportal.czscience.com/schema/metadata/z)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+[TomogramSize](TomogramSize.md) | The size of a tomogram in voxels in each dimension |  no  |
+[TomogramOffset](TomogramOffset.md) | The offset of a tomogram in voxels in each dimension relative to the canonica... |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: z
+alias: z
+domain_of:
+- TomogramSize
+- TomogramOffset
+range: string
+
+```
+</details>

--- a/schema/v1.1.0/metadata.yaml
+++ b/schema/v1.1.0/metadata.yaml
@@ -1,0 +1,328 @@
+id: https://cryoetdataportal.czscience.com/cetdp
+name: cdp-meta
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ORCID: https://orcid.org/
+  ROR: https://ror.org/
+  UBERON: http://purl.obolibrary.org/obo/UBERON_
+  CL: http://purl.obolibrary.org/obo/CL_
+  GO: http://purl.obolibrary.org/obo/GO_
+imports:
+  - linkml:types
+default_range: string
+
+slots:
+  # ============================================================================
+  # Common slots
+  # ============================================================================
+  ORCID:
+    description: An ORCID identifier.
+    range: string
+    pattern: '[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$'
+
+  affiliation_identifier:
+    description: A research organization registry identifier.
+    range: string
+    pattern: '^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$'
+
+enums:
+  # ============================================================================
+  # Controlled vocabularies
+  # ============================================================================
+
+  sample_type:
+    description: Type of sample imaged in a CryoET study.
+    permissible_values:
+      cell:
+        description: Tomographic data of whole cells or cell sections.
+      tissue:
+        description: Tomographic data of tissue sections.
+      organism:
+        description: Tomographic data of sections through multicellular organisms.
+      organelle:
+        description: Tomographic data of purified organelles.
+      virus:
+        description: Tomographic data of purified viruses or VLPs.
+      in vitro:
+        description: Tomographic data of in vitro reconstituted systems or mixtures of proteins.
+      in silico:
+        description: Simulated tomographic data.
+      other:
+        description: Other type of sample.
+
+classes:
+  # ============================================================================
+  # Author and Annotator information
+  # ============================================================================
+
+  Author:
+    description: An author of a scientific data entity.
+    attributes:
+      name:
+        range: string
+        required: true
+        description: The full name of the author.
+      email:
+        range: string
+        description: The email of the author.
+      affiliation_name:
+        range: string
+        description: The name of the author's affiliation.
+      affiliation_address:
+        range: string
+        description: The address of the author's affiliation.
+      is_corresponding:
+        range: boolean
+        description: Whether the author is the corresponding author.
+      is_primary_author:
+        range: boolean
+        description: Whether the author is the primary author.
+        alias: is_primary_annotator
+
+    slots:
+      - ORCID
+      - affiliation_identifier
+    slot_usage:
+      orcid:
+        recommended: true
+      affiliation_identifier:
+        recommended: true
+
+  # ============================================================================
+  # Funding source information
+  # ============================================================================
+
+  Funding:
+    description: A funding source for a scientific data entity.
+    attributes:
+      funding_agency_name:
+        range: string
+        recommended: true
+        description: The name of the funding source.
+      grant_id:
+        range: string
+        recommended: true
+        description: Grant identifier provided by the funding agency
+
+  # ============================================================================
+  # Deposition, release and last modified dates
+  # ============================================================================
+
+  Dates:
+    description: A set of dates.
+    attributes:
+      deposition_date:
+        range: date
+        required: true
+        description: The date a piece of data was deposited to the cryoET data portal.
+      release_date:
+        range: date
+        required: true
+        description: The date a piece of data was made public on the cryoET data portal.
+      last_modified_date:
+        range: date
+        required: true
+        description: The date a piece of data was last modified on the cryoET data portal.
+
+  # ============================================================================
+  # Snapshot / Thumbnail
+  # ============================================================================
+
+  PictureLocations:
+    description: A set of paths to representative images of a piece of data.
+    attributes:
+      snapshot:
+        range: string
+        description: Path to an associated (larger) snapshot image relative to the dataset directory root.
+      thumbnail:
+        range: string
+        description: Path to an associated (smaller) thumbnail image relative to the dataset directory root.
+
+
+  # ============================================================================
+  # Experimental metadata
+  # ============================================================================
+
+  Species:
+    description: The species from which the sample was derived.
+    attributes:
+      name:
+        range: string
+        recommended: true
+        description: The name of the species.
+      taxonomy_id:
+        range: integer
+        recommended: true
+        description: The NCBI taxonomy identifier for the species.
+
+  Tissue:
+    description: The type of tissue from which the sample was derived.
+    attributes:
+      name:
+        range: string
+        recommended: true
+        description: The name of the tissue.
+      id:
+        range: string
+        recommended: true
+        description: The UBERON identifier for the tissue.
+
+  CellType:
+    description: The cell type from which the sample was derived.
+    attributes:
+      name:
+        range: string
+        recommended: true
+        description: The name of the cell type.
+      id:
+        range: string
+        recommended: true
+        description: The CL identifier for the cell type.
+
+  CellStrain:
+    description: The strain or cell line from which the sample was derived.
+    attributes:
+      name:
+        range: string
+        recommended: true
+        description: The name of the cell line or strain.
+      id:
+        range: string
+        recommended: true
+        description: The CL identifier for the cell line or strain.
+
+  CellComponent:
+    description: The cellular component from which the sample was derived.
+    attributes:
+      name:
+        range: string
+        recommended: true
+        description: The name of the cellular component.
+      id:
+        range: string
+        recommended: true
+        description: The GO identifier for the cellular component.
+
+  ExperimentalMetadata:
+    description: Metadata describing sample and sample preparation methods used in a cryoET dataset.
+    attributes:
+      sample_type:
+        range: sample_type
+        required: true
+        description: The type of sample imaged in a CryoET study.
+      organism:
+        range: Species
+        description: The species from which the sample was derived.
+      tissue:
+        range: Tissue
+        description: The type of tissue from which the sample was derived.
+      cell_type:
+        range: CellType
+        description: The cell type from which the sample was derived.
+      cell_strain:
+        range: CellStrain
+        description: The strain or cell line from which the sample was derived.
+      cell_component:
+        range: CellComponent
+        description: The cellular component from which the sample was derived.
+      sample_preparation:
+        range: string
+        description: A description of the sample preparation.
+      grid_preparation:
+        range: string
+        description: A description of the grid preparation.
+      other_setup:
+        range: string
+        description: Any other experimental setup information not covered by the other fields.
+
+
+  # ============================================================================
+  # Dataset
+  # ============================================================================
+
+  CrossReferences:
+    description: A set of cross-references to other databases.
+    attributes:
+      dataset_publications:
+        range: string
+        description: Comma-separated list of DOIs for publications associated with the dataset.
+      related_database_entries:
+        range: string
+        description: Comma-separated list of related database entries for the dataset.
+      related_database_links:
+        range: string
+        description: Comma-separated list of related database links for the dataset.
+      dataset_citations:
+        range: string
+        description: Comma-separated list of DOIs for publications citing the dataset.
+
+  Dataset:
+    description: High-level description of a cryoET dataset.
+    mixins:
+      - TimestampedEntity
+      - AuthoredEntity
+      - FundedEntity
+      - PreviewableEntity
+      - ExperimentalMetadata
+    attributes:
+      dataset_identifier:
+        range: integer
+        required: true
+        description: The unique identifier of the dataset on the cryoET data portal.
+      dataset_title:
+        range: string
+        required: true
+        description: The title of the dataset.
+      dataset_description:
+        range: string
+        required: true
+        description: A short description of the CryoET dataset.
+      cross_references:
+        range: CrossReferences
+        description: A set of cross-references to other databases and publications.
+      snapshot:
+        range: string
+        description: Path to an associated snapshot image relative to the dataset directory root.
+      thumbnail:
+        range: string
+        description: Path to an associated thumbnail image relative to the dataset directory root.
+
+
+  # ============================================================================
+  # Meta-Mixins
+  # ============================================================================
+
+  TimestampedEntity:
+    description: An entity with associated deposition, release and last modified dates.
+    attributes:
+      dates:
+        range: Dates
+        required: true
+        description: The dates at which the entity was deposited, released and last modified.
+
+  AuthoredEntity:
+    description: An entity with associated authors.
+    attributes:
+      authors:
+        range: Author
+        required: true
+        description: An ordered list of authors of the entity.
+        multivalued: true
+        inlined_as_list : true
+
+  FundedEntity:
+    description: An entity with associated funding sources.
+    attributes:
+      funding:
+        range: Funding
+        recommended: true
+        description: An ordered list of funding sources for the entity.
+        multivalued: true
+
+  PreviewableEntity:
+    description: An entity with associated preview images.
+    attributes:
+      key_photos:
+        range: PictureLocations
+        description: A set of paths to representative images of the entity.
+        multivalued: false

--- a/schema/v1.1.0/metadata.yaml
+++ b/schema/v1.1.0/metadata.yaml
@@ -318,6 +318,7 @@ classes:
         recommended: true
         description: An ordered list of funding sources for the entity.
         multivalued: true
+        inlined_as_list : true
 
   PreviewableEntity:
     description: An entity with associated preview images.

--- a/schema/v1.1.0/metadata.yaml
+++ b/schema/v1.1.0/metadata.yaml
@@ -1,9 +1,9 @@
-id: https://cryoetdataportal.czscience.com/schema-docs/metadata
+id: metadata
 name: cdp-meta
 version: 1.1.0
 prefixes:
   linkml: https://w3id.org/linkml/
-  cdp-meta: https://cryoetdataportal.czscience.com/schema/metadata/
+  cdp-meta: metadata
   ORCID: https://orcid.org/
   ROR: https://ror.org/
   UBERON: http://purl.obolibrary.org/obo/UBERON_

--- a/schema/v1.1.0/metadata.yaml
+++ b/schema/v1.1.0/metadata.yaml
@@ -1,306 +1,153 @@
-id: https://cryoetdataportal.czscience.com/cetdp
+id: https://cryoetdataportal.czscience.com/schema-docs/metadata
 name: cdp-meta
+version: 1.1.0
 prefixes:
   linkml: https://w3id.org/linkml/
+  cdp-meta: https://cryoetdataportal.czscience.com/schema/metadata/
   ORCID: https://orcid.org/
   ROR: https://ror.org/
   UBERON: http://purl.obolibrary.org/obo/UBERON_
   CL: http://purl.obolibrary.org/obo/CL_
   GO: http://purl.obolibrary.org/obo/GO_
+  #cdp-common: common
 imports:
   - linkml:types
 default_range: string
-
-slots:
-  # ============================================================================
-  # Common slots
-  # ============================================================================
-  ORCID:
-    description: An ORCID identifier.
-    range: string
-    pattern: '[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$'
-
-  affiliation_identifier:
-    description: A research organization registry identifier.
-    range: string
-    pattern: '^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$'
-
-enums:
-  # ============================================================================
-  # Controlled vocabularies
-  # ============================================================================
-
-  sample_type:
-    description: Type of sample imaged in a CryoET study.
-    permissible_values:
-      cell:
-        description: Tomographic data of whole cells or cell sections.
-      tissue:
-        description: Tomographic data of tissue sections.
-      organism:
-        description: Tomographic data of sections through multicellular organisms.
-      organelle:
-        description: Tomographic data of purified organelles.
-      virus:
-        description: Tomographic data of purified viruses or VLPs.
-      in vitro:
-        description: Tomographic data of in vitro reconstituted systems or mixtures of proteins.
-      in silico:
-        description: Simulated tomographic data.
-      other:
-        description: Other type of sample.
+default_prefix: cdp-meta
 
 classes:
-  # ============================================================================
-  # Author and Annotator information
-  # ============================================================================
-
-  Author:
-    description: An author of a scientific data entity.
-    attributes:
-      name:
-        range: string
-        required: true
-        description: The full name of the author.
-      email:
-        range: string
-        description: The email of the author.
-      affiliation_name:
-        range: string
-        description: The name of the author's affiliation.
-      affiliation_address:
-        range: string
-        description: The address of the author's affiliation.
-      is_corresponding:
-        range: boolean
-        description: Whether the author is the corresponding author.
-      is_primary_author:
-        range: boolean
-        description: Whether the author is the primary author.
-        alias: is_primary_annotator
-
-    slots:
-      - ORCID
-      - affiliation_identifier
-    slot_usage:
-      orcid:
-        recommended: true
-      affiliation_identifier:
-        recommended: true
-
-  # ============================================================================
-  # Funding source information
-  # ============================================================================
-
-  Funding:
-    description: A funding source for a scientific data entity.
-    attributes:
-      funding_agency_name:
-        range: string
-        recommended: true
-        description: The name of the funding source.
-      grant_id:
-        range: string
-        recommended: true
-        description: Grant identifier provided by the funding agency
-
-  # ============================================================================
-  # Deposition, release and last modified dates
-  # ============================================================================
-
-  Dates:
-    description: A set of dates.
-    attributes:
-      deposition_date:
-        range: date
-        required: true
-        description: The date a piece of data was deposited to the cryoET data portal.
-      release_date:
-        range: date
-        required: true
-        description: The date a piece of data was made public on the cryoET data portal.
-      last_modified_date:
-        range: date
-        required: true
-        description: The date a piece of data was last modified on the cryoET data portal.
-
   # ============================================================================
   # Snapshot / Thumbnail
   # ============================================================================
 
-  PictureLocations:
+  PicturePath:
     description: A set of paths to representative images of a piece of data.
+
     attributes:
       snapshot:
         range: string
-        description: Path to an associated (larger) snapshot image relative to the dataset directory root.
+        description: Path to the dataset preview image relative to the dataset directory root.
       thumbnail:
         range: string
-        description: Path to an associated (smaller) thumbnail image relative to the dataset directory root.
+        description: Path to the thumbnail of preview image relative to the dataset directory root.
+
+  # ============================================================================
+
+  # ============================================================================
+  # Author / Annotator
+  # ============================================================================
+  Author:
+    description: >-
+      Author of a scientific data entity.
+    attributes:
+      name:
+        exact_mappings:
+          - cdp-common:author_name
+      email:
+        exact_mappings:
+          - cdp-common:author_email
+      affiliation_name:
+        exact_mappings:
+          - cdp-common:author_affiliation_name
+      affiliation_address:
+        exact_mappings:
+          - cdp-common:author_affiliation_address
+      affiliation_identifier:
+        exact_mappings:
+          - cdp-common:affiliation_identifier
+        recommended: true
+      is_corresponding:
+        exact_mappings:
+          - cdp-common:author_corresponding_author_status
+      is_primary_author:
+        exact_mappings:
+          - cdp-common:author_primary_author_status
+      ORCID:
+        exact_mappings:
+          - cdp-common:orcid
+        recommended: true
+
+  Annotator:
+    description: >-
+      Annotator of a scientific data entity.
+    attributes:
+      name:
+        exact_mappings:
+          - cdp-common:author_name
+      email:
+        exact_mappings:
+          - cdp-common:author_email
+      affiliation_name:
+        exact_mappings:
+          - cdp-common:author_affiliation_name
+      affiliation_address:
+        exact_mappings:
+          - cdp-common:author_affiliation_address
+      affiliation_identifier:
+        exact_mappings:
+          - cdp-common:affiliation_identifier
+        recommended: true
+      is_corresponding:
+        exact_mappings:
+          - cdp-common:author_corresponding_author_status
+      is_primary_annotator:
+        exact_mappings:
+          - cdp-common:author_primary_author_status
+      ORCID:
+        exact_mappings:
+          - cdp-common:orcid
+        recommended: true
+  # ============================================================================
+
 
 
   # ============================================================================
-  # Experimental metadata
+  # Funding source information
+  # ============================================================================
+  Funding:
+    description: A funding source for a scientific data entity (base for JSON and DB representation).
+    attributes:
+      funding_agency_name:
+        exact_mappings:
+          - cdp-common:funding_agency_name
+      grant_id:
+        exact_mappings:
+          - cdp-common:funding_grant_id
   # ============================================================================
 
-  Species:
-    description: The species from which the sample was derived.
-    attributes:
-      name:
-        range: string
-        recommended: true
-        description: The name of the species.
-      taxonomy_id:
-        range: integer
-        recommended: true
-        description: The NCBI taxonomy identifier for the species.
-
-  Tissue:
-    description: The type of tissue from which the sample was derived.
-    attributes:
-      name:
-        range: string
-        recommended: true
-        description: The name of the tissue.
-      id:
-        range: string
-        recommended: true
-        description: The UBERON identifier for the tissue.
-
-  CellType:
-    description: The cell type from which the sample was derived.
-    attributes:
-      name:
-        range: string
-        recommended: true
-        description: The name of the cell type.
-      id:
-        range: string
-        recommended: true
-        description: The CL identifier for the cell type.
-
-  CellStrain:
-    description: The strain or cell line from which the sample was derived.
-    attributes:
-      name:
-        range: string
-        recommended: true
-        description: The name of the cell line or strain.
-      id:
-        range: string
-        recommended: true
-        description: The CL identifier for the cell line or strain.
-
-  CellComponent:
-    description: The cellular component from which the sample was derived.
-    attributes:
-      name:
-        range: string
-        recommended: true
-        description: The name of the cellular component.
-      id:
-        range: string
-        recommended: true
-        description: The GO identifier for the cellular component.
-
-  ExperimentalMetadata:
-    description: Metadata describing sample and sample preparation methods used in a cryoET dataset.
-    attributes:
-      sample_type:
-        range: sample_type
-        required: true
-        description: The type of sample imaged in a CryoET study.
-      organism:
-        range: Species
-        description: The species from which the sample was derived.
-      tissue:
-        range: Tissue
-        description: The type of tissue from which the sample was derived.
-      cell_type:
-        range: CellType
-        description: The cell type from which the sample was derived.
-      cell_strain:
-        range: CellStrain
-        description: The strain or cell line from which the sample was derived.
-      cell_component:
-        range: CellComponent
-        description: The cellular component from which the sample was derived.
-      sample_preparation:
-        range: string
-        description: A description of the sample preparation.
-      grid_preparation:
-        range: string
-        description: A description of the grid preparation.
-      other_setup:
-        range: string
-        description: Any other experimental setup information not covered by the other fields.
-
-
   # ============================================================================
-  # Dataset
+  # Deposition, release and last modified dates
   # ============================================================================
-
-  CrossReferences:
-    description: A set of cross-references to other databases.
+  DateStamp:
+    abstract: true
+    description: A set of dates at which a data item was deposited, published and last modified.
     attributes:
-      dataset_publications:
-        range: string
-        description: Comma-separated list of DOIs for publications associated with the dataset.
-      related_database_entries:
-        range: string
-        description: Comma-separated list of related database entries for the dataset.
-      related_database_links:
-        range: string
-        description: Comma-separated list of related database links for the dataset.
-      dataset_citations:
-        range: string
-        description: Comma-separated list of DOIs for publications citing the dataset.
-
-  Dataset:
-    description: High-level description of a cryoET dataset.
-    mixins:
-      - TimestampedEntity
-      - AuthoredEntity
-      - FundedEntity
-      - PreviewableEntity
-      - ExperimentalMetadata
-    attributes:
-      dataset_identifier:
-        range: integer
+      deposition_date:
         required: true
-        description: The unique identifier of the dataset on the cryoET data portal.
-      dataset_title:
-        range: string
-        required: true
-        description: The title of the dataset.
-      dataset_description:
-        range: string
-        required: true
-        description: A short description of the CryoET dataset.
-      cross_references:
-        range: CrossReferences
-        description: A set of cross-references to other databases and publications.
-      snapshot:
-        range: string
-        description: Path to an associated snapshot image relative to the dataset directory root.
-      thumbnail:
-        range: string
-        description: Path to an associated thumbnail image relative to the dataset directory root.
-
+        exact_mappings:
+          - cdp-common:deposition_date
+      release_date:
+        recommended: true
+        exact_mappings:
+          - cdp-common:release_date
+      last_modified_date:
+        recommended: true
+        exact_mappings:
+          - cdp-common:last_modified_date
 
   # ============================================================================
   # Meta-Mixins
   # ============================================================================
-
-  TimestampedEntity:
+  DatestampedEntity:
+    abstract: true
     description: An entity with associated deposition, release and last modified dates.
     attributes:
       dates:
-        range: Dates
+        range: DateStamp
         required: true
-        description: The dates at which the entity was deposited, released and last modified.
 
   AuthoredEntity:
+    abstract: true
     description: An entity with associated authors.
     attributes:
       authors:
@@ -308,9 +155,23 @@ classes:
         required: true
         description: An ordered list of authors of the entity.
         multivalued: true
-        inlined_as_list : true
+        inlined_as_list: true
+        list_elements_ordered: true
+
+  AnnotatoredEntity:
+    abstract: true
+    description: An entity with associated annotation authors.
+    attributes:
+      authors:
+        range: Annotator
+        required: true
+        description: An ordered list of annotation authors of the entity.
+        multivalued: true
+        inlined_as_list: true
+        list_elements_ordered: true
 
   FundedEntity:
+    abstract: true
     description: An entity with associated funding sources.
     attributes:
       funding:
@@ -318,12 +179,410 @@ classes:
         recommended: true
         description: An ordered list of funding sources for the entity.
         multivalued: true
-        inlined_as_list : true
+        inlined_as_list: true
+        list_elements_ordered: true
 
-  PreviewableEntity:
+  CrossReferencedEntity:
+    abstract: true
+    description: An entity with associated cross-references to other databases and publications.
+    attributes:
+      cross_references:
+        range: CrossReferences
+
+  PicturedEntity:
+    abstract: true
     description: An entity with associated preview images.
     attributes:
       key_photos:
-        range: PictureLocations
+        range: PicturePath
         description: A set of paths to representative images of the entity.
-        multivalued: false
+        required: true
+  # ============================================================================
+
+  # ============================================================================
+  # Experimental metadata
+  # ============================================================================
+  Organism:
+    description: &desc_Organism The species from which the sample was derived.
+    attributes:
+      name:
+        exact_mappings:
+          -  cdp-common:organism_name
+      taxonomy_id:
+        exact_mappings:
+          - cdp-common:organism_taxid
+
+  Tissue:
+    description: &desc_Tissue The type of tissue from which the sample was derived.
+    attributes:
+      name:
+        exact_mappings:
+          - cdp-common:tissue_name
+      id:
+        exact_mappings:
+          - cdp-common:tissue_id
+
+  CellType:
+    description: &desc_CellType The cell type from which the sample was derived.
+    attributes:
+      name:
+        exact_mappings:
+          - cdp-common:cell_name
+      id:
+        exact_mappings:
+          - cdp-common:cell_type_id
+
+  CellStrain:
+    description: &desc_CellStrain The strain or cell line from which the sample was derived.
+    attributes:
+      name:
+        exact_mappings:
+          - cdp-common:cell_strain_name
+      id:
+        exact_mappings:
+          - cdp-common:cell_strain_id
+
+  CellComponent:
+    description: &desc_CellComponent The cellular component from which the sample was derived.
+    attributes:
+      name:
+        exact_mappings:
+          - cdp-common:cell_component_name
+      id:
+        exact_mappings:
+          - cdp-common:cell_component_id
+
+  ExperimentalMetadata:
+    abstract: true
+    description: Metadata describing sample and sample preparation methods used in a cryoET dataset.
+    attributes:
+      sample_type:
+        exact_mappings:
+          - cdp-common:preparation_sample_type
+      sample_preparation:
+        exact_mappings:
+          - cdp-common:sample_preparation
+      grid_preparation:
+        exact_mappings:
+          - cdp-common:grid_preparation
+      other_setup:
+        exact_mappings:
+          - cdp-common:preparation_other_setup
+      organism:
+        description: *desc_Organism
+        range: Organism
+      tissue:
+        description: *desc_Tissue
+        range: Tissue
+      cell_type:
+        description: *desc_CellType
+        range: CellType
+      cell_strain:
+        description: *desc_CellStrain
+        range: CellStrain
+      cell_component:
+        description: *desc_CellComponent
+        range: CellComponent
+  # ============================================================================
+
+  # ============================================================================
+  # dataset_metadata.json
+  # ============================================================================
+  Dataset:
+    description: High-level description of a cryoET dataset.
+    mixins:
+      - DatestampedEntity
+      - AuthoredEntity
+      - FundedEntity
+      - PicturedEntity
+      - CrossReferencedEntity
+      - ExperimentalMetadata
+
+    attributes:
+      dataset_identifier:
+        exact_mappings:
+        - cdp-common:dataset_identifier
+      dataset_title:
+        exact_mappings:
+        - cdp-common:dataset_title
+      dataset_description:
+        exact_mappings:
+        - cdp-common:dataset_description
+
+  # ============================================================================
+
+  # ============================================================================
+  # TiltSeries metadata
+  # ============================================================================
+  Camera:
+    description: &desc_camera The camera used to collect the tilt series.
+    attributes:
+      manufacturer:
+        exact_mappings:
+          - cdp-common:tiltseries_camera_manufacturer
+      model:
+        exact_mappings:
+          - cdp-common:tiltseries_camera_model
+
+  Microscope:
+    description: &desc_microscope The microscope used to collect the tilt series.
+    attributes:
+      manufacturer:
+        exact_mappings:
+          - cdp-common:tiltseries_microscope_manufacturer
+      model:
+        exact_mappings:
+          - cdp-common:tiltseries_microscope_model
+
+  MicroscopeOpticalSetup:
+    description: &desc_microscope_optical_setup The optical setup of the microscope used to collect the tilt series.
+    attributes:
+      energy_filter:
+        exact_mappings:
+          - cdp-common:tiltseries_microscope_energy_filter
+      phase_plate:
+        exact_mappings:
+          - cdp-common:tiltseries_microscope_phase_plate
+      image_corrector:
+        exact_mappings:
+          - cdp-common:tiltseries_microscope_image_corrector
+
+  TiltRange:
+    description: &desc_tilt_range The range of tilt angles in the tilt series.
+    attributes:
+      min:
+        exact_mappings:
+          - cdp-common:tiltseries_tilt_min
+      max:
+        exact_mappings:
+          - cdp-common:tiltseries_tilt_max
+  # ============================================================================
+
+  # ============================================================================
+  # tiltseries_metadata.json
+  # ============================================================================
+  TiltSeries:
+    description: Metadata describing a tilt series.
+
+    attributes:
+      acceleration_voltage:
+        exact_mappings:
+          - cdp-common:tiltseries_acceleration_voltage
+      spherical_aberration_constant:
+        exact_mappings:
+          - cdp-common:tiltseries_spherical_aberration_constant
+      microscope_additional_info:
+        exact_mappings:
+          - cdp-common:tiltseries_microscope_additional_info
+      tilt_axis:
+        exact_mappings:
+          - cdp-common:tiltseries_tilt_axis
+      tilt_step:
+        exact_mappings:
+          - cdp-common:tiltseries_tilt_step
+      tilting_scheme:
+        exact_mappings:
+          - cdp-common:tiltseries_tilting_scheme
+      total_flux:
+        exact_mappings:
+          - cdp-common:tiltseries_total_flux
+      data_acquisition_software:
+        exact_mappings:
+          - cdp-common:tiltseries_data_acquisition_software
+      binning_from_frames:
+        exact_mappings:
+          - cdp-common:tiltseries_binning_from_frames
+      tilt_series_quality:
+        exact_mappings:
+          - cdp-common:tiltseries_tilt_series_quality
+      pixel_spacing:
+        exact_mappings:
+          - cdp-common:tiltseries_pixel_spacing
+      aligned_tiltseries_binning:
+        exact_mappings:
+          - cdp-common:tiltseries_aligned_tiltseries_binning
+      frames_count:
+        exact_mappings:
+          - cdp-common:tiltseries_frames_count
+      camera:
+        description: *desc_camera
+        range: Camera
+      microscope:
+        description: *desc_microscope
+        range: Microscope
+      microscope_optical_setup:
+        description: *desc_microscope_optical_setup
+        range: MicroscopeOpticalSetup
+      tilt_range:
+        description: *desc_tilt_range
+        range: TiltRange
+  # ============================================================================
+
+  # ============================================================================
+  # Tomogram metadata
+  # ============================================================================
+  TomogramSize:
+    description: &desc_tomogram_size The size of a tomogram in voxels in each dimension.
+    attributes:
+      x:
+        exact_mappings:
+          - cdp-common:tomogram_size_x
+      y:
+        exact_mappings:
+          - cdp-common:tomogram_size_y
+      z:
+        exact_mappings:
+          - cdp-common:tomogram_size_z
+
+  TomogramOffset:
+    description: &desc_tomogram_offset The offset of a tomogram in voxels in each dimension relative to the canonical tomogram.
+    attributes:
+      x:
+        exact_mappings:
+          - cdp-common:tomogram_offset_x
+      y:
+        exact_mappings:
+          - cdp-common:tomogram_offset_y
+      z:
+        exact_mappings:
+          - cdp-common:tomogram_offset_z
+  # ============================================================================
+
+  # ============================================================================
+  # tomogram_metadata.json
+  # ============================================================================
+  Tomogram:
+    description: Metadata describing a tomogram.
+    mixins:
+      - AuthoredEntity
+      - PicturedEntity
+
+    attributes:
+      voxel_spacing:
+        exact_mappings:
+          - cdp-common:tomogram_voxel_spacing
+      fiducial_alignment_status:
+        exact_mappings:
+          - cdp-common:tomogram_fiducial_alignment_status
+      ctf_corrected:
+        exact_mappings:
+          - cdp-common:tomogram_ctf_corrected
+      reconstruction_method:
+        exact_mappings:
+          - cdp-common:tomogram_reconstruction_method
+      reconstruction_software:
+        exact_mappings:
+          - cdp-common:tomogram_reconstruction_software
+      processing:
+        exact_mappings:
+          - cdp-common:tomogram_processing
+      processing_software:
+        exact_mappings:
+          - cdp-common:tomogram_processing_software
+      tomogram_version:
+        exact_mappings:
+          - cdp-common:tomogram_version
+      affine_transformation_matrix:
+        exact_mappings:
+          - cdp-common:tomogram_affine_transformation_matrix
+      size:
+        description: *desc_tomogram_size
+        range: TomogramSize
+      offset:
+        description: *desc_tomogram_offset
+        range: TomogramOffset
+  # ============================================================================
+
+  # ============================================================================
+  # Annotation metadata
+  # ============================================================================
+  AnnotationFile:
+    description: &desc_annotation_file Metadata describing a file containing an annotation.
+    attributes:
+      format:
+        exact_mappings:
+          - cdp-common:annotation_file_format
+      shape:
+        exact_mappings:
+          - cdp-common:annotation_file_shape_type
+      path:
+        exact_mappings:
+          - cdp-common:annotation_file_path
+      is_visualization_default:
+        exact_mappings:
+          - cdp-common:annotation_file_is_visualization_default
+
+  AnnotationConfidence:
+    description: &desc_annotation_confidence Metadata describing the confidence of an annotation.
+    attributes:
+      precision:
+        exact_mappings:
+          - cdp-common:annotation_confidence_precision
+      recall:
+        exact_mappings:
+          - cdp-common:annotation_confidence_recall
+      ground_truth_used:
+        exact_mappings:
+          - cdp-common:annotation_ground_truth_used
+
+  AnnotationObject:
+    description: &desc_annotation_object Metadata describing the object being annotated.
+    attributes:
+      id:
+        exact_mappings:
+          - cdp-common:annotation_object_id
+      name:
+        exact_mappings:
+          - cdp-common:annotation_object_name
+      description:
+        exact_mappings:
+          - cdp-common:annotation_object_description
+      state:
+        exact_mappings:
+          - cdp-common:annotation_object_state
+  # ============================================================================
+
+  # ============================================================================
+  # annotation_metadata.json
+  # ============================================================================
+  Annotation:
+    description: Metadata describing an annotation.
+    mixins:
+    - DatestampedEntity
+    - AnnotatoredEntity
+
+    attributes:
+      annotation_method:
+        exact_mappings:
+          - cdp-common:annotation_method
+      annotation_method_type:
+        exact_mappings:
+          - cdp-common:annotation_method_type
+      annotation_publications:
+        exact_mappings:
+          - cdp-common:annotation_publication
+      annotation_software:
+        exact_mappings:
+          - cdp-common:annotation_software
+      ground_truth_status:
+        exact_mappings:
+          - cdp-common:annotation_ground_truth_status
+      object_count:
+        exact_mappings:
+          - cdp-common:annotation_object_count
+      is_curator_recommended:
+        exact_mappings:
+          - cdp-common:annotation_is_curator_recommended
+      files:
+        description: *desc_annotation_file
+        range: AnnotationFile
+        multivalued: true
+        inlined_as_list: true
+        list_elements_ordered: true
+      confidence:
+        description: *desc_annotation_confidence
+        range: AnnotationConfidence
+      annotation_object:
+        description: *desc_annotation_object
+        range: AnnotationObject
+  # ============================================================================

--- a/schema/v1.1.0/metadata_materialized.yaml
+++ b/schema/v1.1.0/metadata_materialized.yaml
@@ -1,5 +1,5 @@
 name: cdp-meta
-id: https://cryoetdataportal.czscience.com/schema-docs/metadata
+id: metadata
 version: 1.1.0
 imports:
 - linkml:types
@@ -9,7 +9,7 @@ prefixes:
     prefix_reference: https://w3id.org/linkml/
   cdp-meta:
     prefix_prefix: cdp-meta
-    prefix_reference: https://cryoetdataportal.czscience.com/schema/metadata/
+    prefix_reference: metadata
   ORCID:
     prefix_prefix: ORCID
     prefix_reference: https://orcid.org/
@@ -31,7 +31,7 @@ enums:
   sample_type_enum:
     name: sample_type_enum
     description: Type of sample imaged in a CryoET study.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     permissible_values:
       cell:
         text: cell
@@ -61,7 +61,7 @@ enums:
   fiducial_alignment_status_enum:
     name: fiducial_alignment_status_enum
     description: Fiducial Alignment method
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     permissible_values:
       FIDUCIAL:
         text: FIDUCIAL
@@ -72,7 +72,7 @@ enums:
   tomogram_type_enum:
     name: tomogram_type_enum
     description: Tomogram type
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     permissible_values:
       CANONICAL:
         text: CANONICAL
@@ -80,7 +80,7 @@ enums:
   annotation_method_type_enum:
     name: annotation_method_type_enum
     description: Describes how the annotations were generated.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     permissible_values:
       manual:
         text: manual
@@ -94,7 +94,7 @@ enums:
   annotation_shape_enum:
     name: annotation_shape_enum
     description: Annotation shape types available on the data portal.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     permissible_values:
       Point:
         text: Point
@@ -109,13 +109,13 @@ classes:
   PicturePath:
     name: PicturePath
     description: A set of paths to representative images of a piece of data.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       snapshot:
         name: snapshot
         description: Path to the dataset preview image relative to the dataset directory
           root.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: snapshot
         owner: PicturePath
         domain_of:
@@ -127,7 +127,7 @@ classes:
         name: thumbnail
         description: Path to the thumbnail of preview image relative to the dataset
           directory root.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: thumbnail
         owner: PicturePath
         domain_of:
@@ -138,12 +138,12 @@ classes:
   Author:
     name: Author
     description: Author of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       name:
         name: name
         description: The full name of the author.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_name
         alias: name
@@ -163,7 +163,7 @@ classes:
       email:
         name: email
         description: The email address of the author.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_email
         alias: email
@@ -177,7 +177,7 @@ classes:
       affiliation_name:
         name: affiliation_name
         description: The name of the author's affiliation.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_affiliation_name
         alias: affiliation_name
@@ -191,7 +191,7 @@ classes:
       affiliation_address:
         name: affiliation_address
         description: The address of the author's affiliation.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_affiliation_address
         alias: affiliation_address
@@ -205,7 +205,7 @@ classes:
       affiliation_identifier:
         name: affiliation_identifier
         description: A Research Organization Registry (ROR) identifier.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:affiliation_identifier
         alias: affiliation_identifier
@@ -221,7 +221,7 @@ classes:
       is_corresponding:
         name: is_corresponding
         description: Whether the author is a corresponding author.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_corresponding_author_status
         alias: is_corresponding
@@ -235,7 +235,7 @@ classes:
       is_primary_author:
         name: is_primary_author
         description: Whether the author is a primary author.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_primary_author_status
         alias: is_primary_author
@@ -249,7 +249,7 @@ classes:
         name: ORCID
         description: A unique, persistent identifier for researchers, provided by
           ORCID.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:orcid
         alias: ORCID
@@ -265,11 +265,11 @@ classes:
   Annotator:
     name: Annotator
     description: Annotator of a scientific data entity.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       name:
         name: name
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_name
         alias: name
@@ -288,7 +288,7 @@ classes:
         inlined_as_list: true
       email:
         name: email
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_email
         alias: email
@@ -301,7 +301,7 @@ classes:
         inlined_as_list: true
       affiliation_name:
         name: affiliation_name
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_affiliation_name
         alias: affiliation_name
@@ -314,7 +314,7 @@ classes:
         inlined_as_list: true
       affiliation_address:
         name: affiliation_address
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_affiliation_address
         alias: affiliation_address
@@ -327,7 +327,7 @@ classes:
         inlined_as_list: true
       affiliation_identifier:
         name: affiliation_identifier
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:affiliation_identifier
         alias: affiliation_identifier
@@ -341,7 +341,7 @@ classes:
         inlined_as_list: true
       is_corresponding:
         name: is_corresponding
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_corresponding_author_status
         alias: is_corresponding
@@ -355,7 +355,7 @@ classes:
       is_primary_annotator:
         name: is_primary_annotator
         description: Whether the author is a primary author.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:author_primary_author_status
         alias: is_primary_annotator
@@ -367,7 +367,7 @@ classes:
         inlined_as_list: true
       ORCID:
         name: ORCID
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:orcid
         alias: ORCID
@@ -383,12 +383,12 @@ classes:
     name: Funding
     description: A funding source for a scientific data entity (base for JSON and
       DB representation).
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       funding_agency_name:
         name: funding_agency_name
         description: The name of the funding source.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:funding_agency_name
         alias: funding_agency_name
@@ -401,7 +401,7 @@ classes:
       grant_id:
         name: grant_id
         description: Grant identifier provided by the funding agency
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:funding_grant_id
         alias: grant_id
@@ -415,7 +415,7 @@ classes:
     name: DateStamp
     description: A set of dates at which a data item was deposited, published and
       last modified.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     abstract: true
     slots:
     - deposition_date
@@ -441,7 +441,7 @@ classes:
       deposition_date:
         name: deposition_date
         description: The date a data item was received by the cryoET data portal.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: deposition_date
         owner: DateStamp
         domain_of:
@@ -453,7 +453,7 @@ classes:
       release_date:
         name: release_date
         description: The date a data item was received by the cryoET data portal.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: release_date
         owner: DateStamp
         domain_of:
@@ -467,7 +467,7 @@ classes:
         name: last_modified_date
         description: The date a piece of data was last modified on the cryoET data
           portal.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: last_modified_date
         owner: DateStamp
         domain_of:
@@ -480,14 +480,14 @@ classes:
   DatestampedEntity:
     name: DatestampedEntity
     description: An entity with associated deposition, release and last modified dates.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     abstract: true
     attributes:
       dates:
         name: dates
         description: A set of dates at which a data item was deposited, published
           and last modified.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: dates
         owner: DatestampedEntity
         domain_of:
@@ -499,13 +499,13 @@ classes:
   AuthoredEntity:
     name: AuthoredEntity
     description: An entity with associated authors.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     abstract: true
     attributes:
       authors:
         name: authors
         description: Author of a scientific data entity.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         multivalued: true
         list_elements_ordered: true
         alias: authors
@@ -520,13 +520,13 @@ classes:
   AnnotatoredEntity:
     name: AnnotatoredEntity
     description: An entity with associated annotation authors.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     abstract: true
     attributes:
       authors:
         name: authors
         description: Annotator of a scientific data entity.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         multivalued: true
         list_elements_ordered: true
         alias: authors
@@ -541,14 +541,14 @@ classes:
   FundedEntity:
     name: FundedEntity
     description: An entity with associated funding sources.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     abstract: true
     attributes:
       funding:
         name: funding
         description: A funding source for a scientific data entity (base for JSON
           and DB representation).
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         multivalued: true
         list_elements_ordered: true
         alias: funding
@@ -563,13 +563,13 @@ classes:
     name: CrossReferencedEntity
     description: An entity with associated cross-references to other databases and
       publications.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     abstract: true
     attributes:
       cross_references:
         name: cross_references
         description: A set of cross-references to other databases and publications.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: cross_references
         owner: CrossReferencedEntity
         domain_of:
@@ -580,13 +580,13 @@ classes:
   PicturedEntity:
     name: PicturedEntity
     description: An entity with associated preview images.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     abstract: true
     attributes:
       key_photos:
         name: key_photos
         description: A set of paths to representative images of a piece of data.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: key_photos
         owner: PicturedEntity
         domain_of:
@@ -598,11 +598,11 @@ classes:
   Organism:
     name: Organism
     description: The species from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       name:
         name: name
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:organism_name
         alias: name
@@ -622,7 +622,7 @@ classes:
       taxonomy_id:
         name: taxonomy_id
         description: NCBI taxonomy identifier for the organism, e.g. 9606
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:organism_taxid
         alias: taxonomy_id
@@ -635,11 +635,11 @@ classes:
   Tissue:
     name: Tissue
     description: The type of tissue from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       name:
         name: name
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tissue_name
         alias: name
@@ -659,7 +659,7 @@ classes:
       id:
         name: id
         description: The UBERON identifier for the tissue.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tissue_id
         alias: id
@@ -676,11 +676,11 @@ classes:
   CellType:
     name: CellType
     description: The cell type from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       name:
         name: name
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:cell_name
         alias: name
@@ -699,7 +699,7 @@ classes:
         inlined_as_list: true
       id:
         name: id
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:cell_type_id
         alias: id
@@ -716,11 +716,11 @@ classes:
   CellStrain:
     name: CellStrain
     description: The strain or cell line from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       name:
         name: name
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:cell_strain_name
         alias: name
@@ -739,7 +739,7 @@ classes:
         inlined_as_list: true
       id:
         name: id
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:cell_strain_id
         alias: id
@@ -756,11 +756,11 @@ classes:
   CellComponent:
     name: CellComponent
     description: The cellular component from which the sample was derived.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       name:
         name: name
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:cell_component_name
         alias: name
@@ -779,7 +779,7 @@ classes:
         inlined_as_list: true
       id:
         name: id
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:cell_component_id
         alias: id
@@ -797,13 +797,13 @@ classes:
     name: ExperimentalMetadata
     description: Metadata describing sample and sample preparation methods used in
       a cryoET dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     abstract: true
     attributes:
       sample_type:
         name: sample_type
         description: Type of sample imaged in a CryoET study.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:preparation_sample_type
         alias: sample_type
@@ -816,7 +816,7 @@ classes:
       sample_preparation:
         name: sample_preparation
         description: Describes how the sample was prepared.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:sample_preparation
         alias: sample_preparation
@@ -829,7 +829,7 @@ classes:
       grid_preparation:
         name: grid_preparation
         description: Describes Cryo-ET grid preparation.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:grid_preparation
         alias: grid_preparation
@@ -843,7 +843,7 @@ classes:
         name: other_setup
         description: Describes other setup not covered by sample preparation or grid
           preparation that may make this dataset unique in   the same publication.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:preparation_other_setup
         alias: other_setup
@@ -856,7 +856,7 @@ classes:
       organism:
         name: organism
         description: The species from which the sample was derived.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: organism
         owner: ExperimentalMetadata
         domain_of:
@@ -867,7 +867,7 @@ classes:
       tissue:
         name: tissue
         description: The type of tissue from which the sample was derived.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: tissue
         owner: ExperimentalMetadata
         domain_of:
@@ -878,7 +878,7 @@ classes:
       cell_type:
         name: cell_type
         description: The cell type from which the sample was derived.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: cell_type
         owner: ExperimentalMetadata
         domain_of:
@@ -889,7 +889,7 @@ classes:
       cell_strain:
         name: cell_strain
         description: The strain or cell line from which the sample was derived.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: cell_strain
         owner: ExperimentalMetadata
         domain_of:
@@ -900,7 +900,7 @@ classes:
       cell_component:
         name: cell_component
         description: The cellular component from which the sample was derived.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: cell_component
         owner: ExperimentalMetadata
         domain_of:
@@ -911,7 +911,7 @@ classes:
   Dataset:
     name: Dataset
     description: High-level description of a cryoET dataset.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     mixins:
     - DatestampedEntity
     - AuthoredEntity
@@ -924,7 +924,7 @@ classes:
         name: dataset_identifier
         description: An identifier for a CryoET dataset, assigned by the Data Portal.
           Used to identify the dataset as the directory  name in data tree.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:dataset_identifier
         alias: dataset_identifier
@@ -937,7 +937,7 @@ classes:
       dataset_title:
         name: dataset_title
         description: Title of a CryoET dataset.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:dataset_title
         alias: dataset_title
@@ -951,7 +951,7 @@ classes:
         name: dataset_description
         description: A short description of a CryoET dataset, similar to an abstract
           for a journal article or dataset.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:dataset_description
         alias: dataset_description
@@ -965,7 +965,7 @@ classes:
         name: dates
         description: A set of dates at which a data item was deposited, published
           and last modified.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: dates
         owner: Dataset
         domain_of:
@@ -977,7 +977,7 @@ classes:
       authors:
         name: authors
         description: Author of a scientific data entity.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         multivalued: true
         list_elements_ordered: true
         alias: authors
@@ -993,7 +993,7 @@ classes:
         name: funding
         description: A funding source for a scientific data entity (base for JSON
           and DB representation).
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         multivalued: true
         list_elements_ordered: true
         alias: funding
@@ -1007,7 +1007,7 @@ classes:
       key_photos:
         name: key_photos
         description: A set of paths to representative images of a piece of data.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: key_photos
         owner: Dataset
         domain_of:
@@ -1019,7 +1019,7 @@ classes:
       cross_references:
         name: cross_references
         description: A set of cross-references to other databases and publications.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: cross_references
         owner: Dataset
         domain_of:
@@ -1030,7 +1030,7 @@ classes:
       sample_type:
         name: sample_type
         description: Type of sample imaged in a CryoET study.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:preparation_sample_type
         alias: sample_type
@@ -1043,7 +1043,7 @@ classes:
       sample_preparation:
         name: sample_preparation
         description: Describes how the sample was prepared.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:sample_preparation
         alias: sample_preparation
@@ -1056,7 +1056,7 @@ classes:
       grid_preparation:
         name: grid_preparation
         description: Describes Cryo-ET grid preparation.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:grid_preparation
         alias: grid_preparation
@@ -1070,7 +1070,7 @@ classes:
         name: other_setup
         description: Describes other setup not covered by sample preparation or grid
           preparation that may make this dataset unique in   the same publication.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:preparation_other_setup
         alias: other_setup
@@ -1083,7 +1083,7 @@ classes:
       organism:
         name: organism
         description: The species from which the sample was derived.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: organism
         owner: Dataset
         domain_of:
@@ -1094,7 +1094,7 @@ classes:
       tissue:
         name: tissue
         description: The type of tissue from which the sample was derived.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: tissue
         owner: Dataset
         domain_of:
@@ -1105,7 +1105,7 @@ classes:
       cell_type:
         name: cell_type
         description: The cell type from which the sample was derived.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: cell_type
         owner: Dataset
         domain_of:
@@ -1116,7 +1116,7 @@ classes:
       cell_strain:
         name: cell_strain
         description: The strain or cell line from which the sample was derived.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: cell_strain
         owner: Dataset
         domain_of:
@@ -1127,7 +1127,7 @@ classes:
       cell_component:
         name: cell_component
         description: The cellular component from which the sample was derived.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: cell_component
         owner: Dataset
         domain_of:
@@ -1138,12 +1138,12 @@ classes:
   Camera:
     name: Camera
     description: The camera used to collect the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       manufacturer:
         name: manufacturer
         description: Name of the camera manufacturer
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_camera_manufacturer
         alias: manufacturer
@@ -1157,7 +1157,7 @@ classes:
       model:
         name: model
         description: Camera model name
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_camera_model
         alias: model
@@ -1171,11 +1171,11 @@ classes:
   Microscope:
     name: Microscope
     description: The microscope used to collect the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       manufacturer:
         name: manufacturer
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_microscope_manufacturer
         alias: manufacturer
@@ -1188,7 +1188,7 @@ classes:
         inlined_as_list: true
       model:
         name: model
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_microscope_model
         alias: model
@@ -1202,12 +1202,12 @@ classes:
   MicroscopeOpticalSetup:
     name: MicroscopeOpticalSetup
     description: The optical setup of the microscope used to collect the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       energy_filter:
         name: energy_filter
         description: Energy filter setup used
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_microscope_energy_filter
         alias: energy_filter
@@ -1220,7 +1220,7 @@ classes:
       phase_plate:
         name: phase_plate
         description: Phase plate configuration
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_microscope_phase_plate
         alias: phase_plate
@@ -1233,7 +1233,7 @@ classes:
       image_corrector:
         name: image_corrector
         description: Image corrector setup
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_microscope_image_corrector
         alias: image_corrector
@@ -1246,12 +1246,12 @@ classes:
   TiltRange:
     name: TiltRange
     description: The range of tilt angles in the tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       min:
         name: min
         description: Minimal tilt angle in degrees
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_tilt_min
         alias: min
@@ -1264,7 +1264,7 @@ classes:
       max:
         name: max
         description: Maximal tilt angle in degrees
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_tilt_max
         alias: max
@@ -1277,12 +1277,12 @@ classes:
   TiltSeries:
     name: TiltSeries
     description: Metadata describing a tilt series.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       acceleration_voltage:
         name: acceleration_voltage
         description: Electron Microscope Accelerator voltage in volts
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_acceleration_voltage
         alias: acceleration_voltage
@@ -1295,7 +1295,7 @@ classes:
       spherical_aberration_constant:
         name: spherical_aberration_constant
         description: Spherical Aberration Constant of the objective lens in millimeters
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_spherical_aberration_constant
         alias: spherical_aberration_constant
@@ -1309,7 +1309,7 @@ classes:
         name: microscope_additional_info
         description: Other microscope optical setup information, in addition to energy
           filter, phase plate and image corrector
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_microscope_additional_info
         alias: microscope_additional_info
@@ -1322,7 +1322,7 @@ classes:
       tilt_axis:
         name: tilt_axis
         description: Rotation angle in degrees
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_tilt_axis
         alias: tilt_axis
@@ -1335,7 +1335,7 @@ classes:
       tilt_step:
         name: tilt_step
         description: Tilt step in degrees
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_tilt_step
         alias: tilt_step
@@ -1348,7 +1348,7 @@ classes:
       tilting_scheme:
         name: tilting_scheme
         description: The order of stage tilting during acquisition of the data
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_tilting_scheme
         alias: tilting_scheme
@@ -1362,7 +1362,7 @@ classes:
         name: total_flux
         description: Number of Electrons reaching the specimen in a square Angstrom
           area for the entire tilt series
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_total_flux
         alias: total_flux
@@ -1375,7 +1375,7 @@ classes:
       data_acquisition_software:
         name: data_acquisition_software
         description: Software used to collect data
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_data_acquisition_software
         alias: data_acquisition_software
@@ -1388,7 +1388,7 @@ classes:
       binning_from_frames:
         name: binning_from_frames
         description: Describes the binning factor from frames to tilt series file
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_binning_from_frames
         alias: binning_from_frames
@@ -1402,7 +1402,7 @@ classes:
         name: tilt_series_quality
         description: Author assessment of tilt series quality within the dataset (1-5,
           5 is best)
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_tilt_series_quality
         alias: tilt_series_quality
@@ -1415,7 +1415,7 @@ classes:
       pixel_spacing:
         name: pixel_spacing
         description: Pixel spacing for the tilt series
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_pixel_spacing
         alias: pixel_spacing
@@ -1428,7 +1428,7 @@ classes:
       aligned_tiltseries_binning:
         name: aligned_tiltseries_binning
         description: Binning factor of the aligned tilt series
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_aligned_tiltseries_binning
         alias: aligned_tiltseries_binning
@@ -1441,7 +1441,7 @@ classes:
       frames_count:
         name: frames_count
         description: Number of frames associated with this tiltseries
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tiltseries_frames_count
         alias: frames_count
@@ -1454,7 +1454,7 @@ classes:
       camera:
         name: camera
         description: The camera used to collect the tilt series.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: camera
         owner: TiltSeries
         domain_of:
@@ -1465,7 +1465,7 @@ classes:
       microscope:
         name: microscope
         description: The microscope used to collect the tilt series.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: microscope
         owner: TiltSeries
         domain_of:
@@ -1477,7 +1477,7 @@ classes:
         name: microscope_optical_setup
         description: The optical setup of the microscope used to collect the tilt
           series.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: microscope_optical_setup
         owner: TiltSeries
         domain_of:
@@ -1488,7 +1488,7 @@ classes:
       tilt_range:
         name: tilt_range
         description: The range of tilt angles in the tilt series.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: tilt_range
         owner: TiltSeries
         domain_of:
@@ -1499,12 +1499,12 @@ classes:
   TomogramSize:
     name: TomogramSize
     description: The size of a tomogram in voxels in each dimension.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       x:
         name: x
         description: Number of pixels in the 3D data fast axis
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_size_x
         alias: x
@@ -1518,7 +1518,7 @@ classes:
       y:
         name: y
         description: Number of pixels in the 3D data medium axis
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_size_y
         alias: y
@@ -1533,7 +1533,7 @@ classes:
         name: z
         description: Number of pixels in the 3D data slow axis.  This is the image
           projection direction at zero stage tilt
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_size_z
         alias: z
@@ -1548,11 +1548,11 @@ classes:
     name: TomogramOffset
     description: The offset of a tomogram in voxels in each dimension relative to
       the canonical tomogram.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       x:
         name: x
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_offset_x
         alias: x
@@ -1565,7 +1565,7 @@ classes:
         inlined_as_list: true
       y:
         name: y
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_offset_y
         alias: y
@@ -1578,7 +1578,7 @@ classes:
         inlined_as_list: true
       z:
         name: z
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_offset_z
         alias: z
@@ -1592,7 +1592,7 @@ classes:
   Tomogram:
     name: Tomogram
     description: Metadata describing a tomogram.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     mixins:
     - AuthoredEntity
     - PicturedEntity
@@ -1600,7 +1600,7 @@ classes:
       voxel_spacing:
         name: voxel_spacing
         description: Voxel spacing equal in all three axes in angstroms
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_voxel_spacing
         alias: voxel_spacing
@@ -1614,7 +1614,7 @@ classes:
         name: fiducial_alignment_status
         description: Whether the tomographic alignment was computed based on fiducial
           markers.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_fiducial_alignment_status
         alias: fiducial_alignment_status
@@ -1627,7 +1627,7 @@ classes:
       ctf_corrected:
         name: ctf_corrected
         description: Whether this tomogram is CTF corrected
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_ctf_corrected
         alias: ctf_corrected
@@ -1641,7 +1641,7 @@ classes:
         name: reconstruction_method
         description: Describe reconstruction method (Weighted back-projection, SART,
           SIRT)
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_reconstruction_method
         alias: reconstruction_method
@@ -1654,7 +1654,7 @@ classes:
       reconstruction_software:
         name: reconstruction_software
         description: Name of software used for reconstruction
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_reconstruction_software
         alias: reconstruction_software
@@ -1667,7 +1667,7 @@ classes:
       processing:
         name: processing
         description: Describe additional processing used to derive the tomogram
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_processing
         alias: processing
@@ -1680,7 +1680,7 @@ classes:
       processing_software:
         name: processing_software
         description: Processing software used to derive the tomogram
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_processing_software
         alias: processing_software
@@ -1695,7 +1695,7 @@ classes:
         description: Version of tomogram using the same software and post-processing.
           Version of tomogram using the same software and post-processing. This will
           be presented as the latest version
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_version
         alias: tomogram_version
@@ -1709,7 +1709,7 @@ classes:
         name: affine_transformation_matrix
         description: The flip or rotation transformation of this author submitted
           tomogram is indicated here
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:tomogram_affine_transformation_matrix
         alias: affine_transformation_matrix
@@ -1722,7 +1722,7 @@ classes:
       size:
         name: size
         description: The size of a tomogram in voxels in each dimension.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: size
         owner: Tomogram
         domain_of:
@@ -1734,7 +1734,7 @@ classes:
         name: offset
         description: The offset of a tomogram in voxels in each dimension relative
           to the canonical tomogram.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: offset
         owner: Tomogram
         domain_of:
@@ -1745,7 +1745,7 @@ classes:
       authors:
         name: authors
         description: Author of a scientific data entity.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         multivalued: true
         list_elements_ordered: true
         alias: authors
@@ -1760,7 +1760,7 @@ classes:
       key_photos:
         name: key_photos
         description: A set of paths to representative images of a piece of data.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: key_photos
         owner: Tomogram
         domain_of:
@@ -1772,12 +1772,12 @@ classes:
   AnnotationFile:
     name: AnnotationFile
     description: Metadata describing a file containing an annotation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       format:
         name: format
         description: File format for this file
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_file_format
         alias: format
@@ -1791,7 +1791,7 @@ classes:
         name: shape
         description: Describe whether this is a Point, OrientedPoint, or SegmentationMask
           file
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_file_shape_type
         alias: shape
@@ -1804,7 +1804,7 @@ classes:
       path:
         name: path
         description: Path to the annotation file relative to the dataset root.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_file_path
         alias: path
@@ -1817,7 +1817,7 @@ classes:
       is_visualization_default:
         name: is_visualization_default
         description: This annotation will be rendered in neuroglancer by default.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_file_is_visualization_default
         alias: is_visualization_default
@@ -1830,13 +1830,13 @@ classes:
   AnnotationConfidence:
     name: AnnotationConfidence
     description: Metadata describing the confidence of an annotation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       precision:
         name: precision
         description: Describe the confidence level of the annotation. Precision is
           defined as the % of annotation objects being true positive
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_confidence_precision
         alias: precision
@@ -1850,7 +1850,7 @@ classes:
         name: recall
         description: Describe the confidence level of the annotation. Recall is defined
           as the % of true positives being annotated correctly
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_confidence_recall
         alias: recall
@@ -1863,7 +1863,7 @@ classes:
       ground_truth_used:
         name: ground_truth_used
         description: Annotation filename used as ground truth for precision and recall
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_ground_truth_used
         alias: ground_truth_used
@@ -1876,11 +1876,11 @@ classes:
   AnnotationObject:
     name: AnnotationObject
     description: Metadata describing the object being annotated.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       id:
         name: id
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_object_id
         alias: id
@@ -1896,7 +1896,7 @@ classes:
         inlined_as_list: true
       name:
         name: name
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_object_name
         alias: name
@@ -1918,7 +1918,7 @@ classes:
         description: A textual description of the annotation object, can be a longer
           description to include additional information not covered by the Annotation
           object name and state.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_object_description
         alias: description
@@ -1931,7 +1931,7 @@ classes:
       state:
         name: state
         description: Molecule state annotated (e.g. open, closed)
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_object_state
         alias: state
@@ -1944,7 +1944,7 @@ classes:
   Annotation:
     name: Annotation
     description: Metadata describing an annotation.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     mixins:
     - DatestampedEntity
     - AnnotatoredEntity
@@ -1953,7 +1953,7 @@ classes:
         name: annotation_method
         description: Describe how the annotation is made (e.g. Manual, crYoLO, Positive
           Unlabeled Learning, template matching)
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_method
         alias: annotation_method
@@ -1966,7 +1966,7 @@ classes:
       annotation_method_type:
         name: annotation_method_type
         description: Classification of the annotation method based on supervision.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_method_type
         alias: annotation_method_type
@@ -1980,7 +1980,7 @@ classes:
         name: annotation_publications
         description: DOIs for publications that describe the dataset. Use a comma
           to separate multiple DOIs.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_publication
         alias: annotation_publications
@@ -1993,7 +1993,7 @@ classes:
       annotation_software:
         name: annotation_software
         description: Software used for generating this annotation
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_software
         alias: annotation_software
@@ -2007,7 +2007,7 @@ classes:
         name: ground_truth_status
         description: Whether an annotation is considered ground truth, as determined
           by the annotator.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_ground_truth_status
         alias: ground_truth_status
@@ -2020,7 +2020,7 @@ classes:
       object_count:
         name: object_count
         description: Number of objects identified
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_object_count
         alias: object_count
@@ -2034,7 +2034,7 @@ classes:
         name: is_curator_recommended
         description: This annotation is recommended by the curator to be preferred
           for this object type.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         exact_mappings:
         - cdp-common:annotation_is_curator_recommended
         alias: is_curator_recommended
@@ -2047,7 +2047,7 @@ classes:
       files:
         name: files
         description: Metadata describing a file containing an annotation.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         multivalued: true
         list_elements_ordered: true
         alias: files
@@ -2060,7 +2060,7 @@ classes:
       confidence:
         name: confidence
         description: Metadata describing the confidence of an annotation.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: confidence
         owner: Annotation
         domain_of:
@@ -2071,7 +2071,7 @@ classes:
       annotation_object:
         name: annotation_object
         description: Metadata describing the object being annotated.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: annotation_object
         owner: Annotation
         domain_of:
@@ -2083,7 +2083,7 @@ classes:
         name: dates
         description: A set of dates at which a data item was deposited, published
           and last modified.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: dates
         owner: Annotation
         domain_of:
@@ -2095,7 +2095,7 @@ classes:
       authors:
         name: authors
         description: Annotator of a scientific data entity.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         multivalued: true
         list_elements_ordered: true
         alias: authors
@@ -2110,13 +2110,13 @@ classes:
   CrossReferences:
     name: CrossReferences
     description: A set of cross-references to other databases and publications.
-    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    from_schema: metadata
     attributes:
       dataset_publications:
         name: dataset_publications
         description: Comma-separated list of DOIs for publications associated with
           the dataset.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: dataset_publications
         owner: CrossReferences
         domain_of:
@@ -2128,7 +2128,7 @@ classes:
       related_database_entries:
         name: related_database_entries
         description: Comma-separated list of related database entries for the dataset.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: related_database_entries
         owner: CrossReferences
         domain_of:
@@ -2140,7 +2140,7 @@ classes:
       related_database_links:
         name: related_database_links
         description: Comma-separated list of related database links for the dataset.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: related_database_links
         owner: CrossReferences
         domain_of:
@@ -2151,7 +2151,7 @@ classes:
       dataset_citations:
         name: dataset_citations
         description: Comma-separated list of DOIs for publications citing the dataset.
-        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        from_schema: metadata
         alias: dataset_citations
         owner: CrossReferences
         domain_of:

--- a/schema/v1.1.0/metadata_materialized.yaml
+++ b/schema/v1.1.0/metadata_materialized.yaml
@@ -1,0 +1,2162 @@
+name: cdp-meta
+id: https://cryoetdataportal.czscience.com/schema-docs/metadata
+version: 1.1.0
+imports:
+- linkml:types
+prefixes:
+  linkml:
+    prefix_prefix: linkml
+    prefix_reference: https://w3id.org/linkml/
+  cdp-meta:
+    prefix_prefix: cdp-meta
+    prefix_reference: https://cryoetdataportal.czscience.com/schema/metadata/
+  ORCID:
+    prefix_prefix: ORCID
+    prefix_reference: https://orcid.org/
+  ROR:
+    prefix_prefix: ROR
+    prefix_reference: https://ror.org/
+  UBERON:
+    prefix_prefix: UBERON
+    prefix_reference: http://purl.obolibrary.org/obo/UBERON_
+  CL:
+    prefix_prefix: CL
+    prefix_reference: http://purl.obolibrary.org/obo/CL_
+  GO:
+    prefix_prefix: GO
+    prefix_reference: http://purl.obolibrary.org/obo/GO_
+default_prefix: cdp-meta
+default_range: string
+enums:
+  sample_type_enum:
+    name: sample_type_enum
+    description: Type of sample imaged in a CryoET study.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    permissible_values:
+      cell:
+        text: cell
+        description: Tomographic data of whole cells or cell sections.
+      tissue:
+        text: tissue
+        description: Tomographic data of tissue sections.
+      organism:
+        text: organism
+        description: Tomographic data of sections through multicellular organisms.
+      organelle:
+        text: organelle
+        description: Tomographic data of purified organelles.
+      virus:
+        text: virus
+        description: Tomographic data of purified viruses or VLPs.
+      in_vitro:
+        text: in_vitro
+        description: Tomographic data of in vitro reconstituted systems or mixtures
+          of proteins.
+      in_silico:
+        text: in_silico
+        description: Simulated tomographic data.
+      other:
+        text: other
+        description: Other type of sample.
+  fiducial_alignment_status_enum:
+    name: fiducial_alignment_status_enum
+    description: Fiducial Alignment method
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    permissible_values:
+      FIDUCIAL:
+        text: FIDUCIAL
+        description: Alignment computed based on fiducial markers
+      NON_FIDUCIAL:
+        text: NON_FIDUCIAL
+        description: Alignment computed without fiducial markers
+  tomogram_type_enum:
+    name: tomogram_type_enum
+    description: Tomogram type
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    permissible_values:
+      CANONICAL:
+        text: CANONICAL
+        description: Canonical tomogram (basis geometry for all annotations)
+  annotation_method_type_enum:
+    name: annotation_method_type_enum
+    description: Describes how the annotations were generated.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    permissible_values:
+      manual:
+        text: manual
+        description: Annotations were generated manually.
+      automated:
+        text: automated
+        description: Annotations were generated semi-automatically.
+      hybrid:
+        text: hybrid
+        description: Annotations were generated automatically.
+  annotation_shape_enum:
+    name: annotation_shape_enum
+    description: Annotation shape types available on the data portal.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    permissible_values:
+      Point:
+        text: Point
+        description: Annotations were generated manually.
+      OrientedPoint:
+        text: OrientedPoint
+        description: Annotations were generated semi-automatically.
+      SegmentationMask:
+        text: SegmentationMask
+        description: Annotations were generated automatically.
+classes:
+  PicturePath:
+    name: PicturePath
+    description: A set of paths to representative images of a piece of data.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      snapshot:
+        name: snapshot
+        description: Path to the dataset preview image relative to the dataset directory
+          root.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: snapshot
+        owner: PicturePath
+        domain_of:
+        - PicturePath
+        range: string
+        inlined: true
+        inlined_as_list: true
+      thumbnail:
+        name: thumbnail
+        description: Path to the thumbnail of preview image relative to the dataset
+          directory root.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: thumbnail
+        owner: PicturePath
+        domain_of:
+        - PicturePath
+        range: string
+        inlined: true
+        inlined_as_list: true
+  Author:
+    name: Author
+    description: Author of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      name:
+        name: name
+        description: The full name of the author.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_name
+        alias: name
+        owner: Author
+        domain_of:
+        - Author
+        - Annotator
+        - Organism
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+      email:
+        name: email
+        description: The email address of the author.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_email
+        alias: email
+        owner: Author
+        domain_of:
+        - Author
+        - Annotator
+        range: string
+        inlined: true
+        inlined_as_list: true
+      affiliation_name:
+        name: affiliation_name
+        description: The name of the author's affiliation.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_affiliation_name
+        alias: affiliation_name
+        owner: Author
+        domain_of:
+        - Author
+        - Annotator
+        range: string
+        inlined: true
+        inlined_as_list: true
+      affiliation_address:
+        name: affiliation_address
+        description: The address of the author's affiliation.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_affiliation_address
+        alias: affiliation_address
+        owner: Author
+        domain_of:
+        - Author
+        - Annotator
+        range: string
+        inlined: true
+        inlined_as_list: true
+      affiliation_identifier:
+        name: affiliation_identifier
+        description: A Research Organization Registry (ROR) identifier.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:affiliation_identifier
+        alias: affiliation_identifier
+        owner: Author
+        domain_of:
+        - Author
+        - Annotator
+        range: string
+        recommended: true
+        inlined: true
+        inlined_as_list: true
+        pattern: ^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$
+      is_corresponding:
+        name: is_corresponding
+        description: Whether the author is a corresponding author.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_corresponding_author_status
+        alias: is_corresponding
+        owner: Author
+        domain_of:
+        - Author
+        - Annotator
+        range: boolean
+        inlined: true
+        inlined_as_list: true
+      is_primary_author:
+        name: is_primary_author
+        description: Whether the author is a primary author.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_primary_author_status
+        alias: is_primary_author
+        owner: Author
+        domain_of:
+        - Author
+        range: boolean
+        inlined: true
+        inlined_as_list: true
+      ORCID:
+        name: ORCID
+        description: A unique, persistent identifier for researchers, provided by
+          ORCID.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:orcid
+        alias: ORCID
+        owner: Author
+        domain_of:
+        - Author
+        - Annotator
+        range: string
+        recommended: true
+        inlined: true
+        inlined_as_list: true
+        pattern: '[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$'
+  Annotator:
+    name: Annotator
+    description: Annotator of a scientific data entity.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      name:
+        name: name
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_name
+        alias: name
+        owner: Annotator
+        domain_of:
+        - Author
+        - Annotator
+        - Organism
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+      email:
+        name: email
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_email
+        alias: email
+        owner: Annotator
+        domain_of:
+        - Author
+        - Annotator
+        range: string
+        inlined: true
+        inlined_as_list: true
+      affiliation_name:
+        name: affiliation_name
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_affiliation_name
+        alias: affiliation_name
+        owner: Annotator
+        domain_of:
+        - Author
+        - Annotator
+        range: string
+        inlined: true
+        inlined_as_list: true
+      affiliation_address:
+        name: affiliation_address
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_affiliation_address
+        alias: affiliation_address
+        owner: Annotator
+        domain_of:
+        - Author
+        - Annotator
+        range: string
+        inlined: true
+        inlined_as_list: true
+      affiliation_identifier:
+        name: affiliation_identifier
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:affiliation_identifier
+        alias: affiliation_identifier
+        owner: Annotator
+        domain_of:
+        - Author
+        - Annotator
+        range: string
+        recommended: true
+        inlined: true
+        inlined_as_list: true
+      is_corresponding:
+        name: is_corresponding
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_corresponding_author_status
+        alias: is_corresponding
+        owner: Annotator
+        domain_of:
+        - Author
+        - Annotator
+        range: string
+        inlined: true
+        inlined_as_list: true
+      is_primary_annotator:
+        name: is_primary_annotator
+        description: Whether the author is a primary author.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:author_primary_author_status
+        alias: is_primary_annotator
+        owner: Annotator
+        domain_of:
+        - Annotator
+        range: boolean
+        inlined: true
+        inlined_as_list: true
+      ORCID:
+        name: ORCID
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:orcid
+        alias: ORCID
+        owner: Annotator
+        domain_of:
+        - Author
+        - Annotator
+        range: string
+        recommended: true
+        inlined: true
+        inlined_as_list: true
+  Funding:
+    name: Funding
+    description: A funding source for a scientific data entity (base for JSON and
+      DB representation).
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      funding_agency_name:
+        name: funding_agency_name
+        description: The name of the funding source.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:funding_agency_name
+        alias: funding_agency_name
+        owner: Funding
+        domain_of:
+        - Funding
+        range: string
+        inlined: true
+        inlined_as_list: true
+      grant_id:
+        name: grant_id
+        description: Grant identifier provided by the funding agency
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:funding_grant_id
+        alias: grant_id
+        owner: Funding
+        domain_of:
+        - Funding
+        range: string
+        inlined: true
+        inlined_as_list: true
+  DateStamp:
+    name: DateStamp
+    description: A set of dates at which a data item was deposited, published and
+      last modified.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    abstract: true
+    slots:
+    - deposition_date
+    - release_date
+    - last_modified_date
+    slot_usage:
+      deposition_date:
+        name: deposition_date
+        domain_of:
+        - DateStamp
+        required: true
+      release_date:
+        name: release_date
+        domain_of:
+        - DateStamp
+        recommended: true
+      last_modified_date:
+        name: last_modified_date
+        domain_of:
+        - DateStamp
+        recommended: true
+    attributes:
+      deposition_date:
+        name: deposition_date
+        description: The date a data item was received by the cryoET data portal.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: deposition_date
+        owner: DateStamp
+        domain_of:
+        - DateStamp
+        range: date
+        required: true
+        inlined: true
+        inlined_as_list: true
+      release_date:
+        name: release_date
+        description: The date a data item was received by the cryoET data portal.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: release_date
+        owner: DateStamp
+        domain_of:
+        - DateStamp
+        range: date
+        required: true
+        recommended: true
+        inlined: true
+        inlined_as_list: true
+      last_modified_date:
+        name: last_modified_date
+        description: The date a piece of data was last modified on the cryoET data
+          portal.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: last_modified_date
+        owner: DateStamp
+        domain_of:
+        - DateStamp
+        range: date
+        required: true
+        recommended: true
+        inlined: true
+        inlined_as_list: true
+  DatestampedEntity:
+    name: DatestampedEntity
+    description: An entity with associated deposition, release and last modified dates.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    abstract: true
+    attributes:
+      dates:
+        name: dates
+        description: A set of dates at which a data item was deposited, published
+          and last modified.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: dates
+        owner: DatestampedEntity
+        domain_of:
+        - DatestampedEntity
+        range: DateStamp
+        required: true
+        inlined: true
+        inlined_as_list: true
+  AuthoredEntity:
+    name: AuthoredEntity
+    description: An entity with associated authors.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    abstract: true
+    attributes:
+      authors:
+        name: authors
+        description: Author of a scientific data entity.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        multivalued: true
+        list_elements_ordered: true
+        alias: authors
+        owner: AuthoredEntity
+        domain_of:
+        - AuthoredEntity
+        - AnnotatoredEntity
+        range: Author
+        required: true
+        inlined: true
+        inlined_as_list: true
+  AnnotatoredEntity:
+    name: AnnotatoredEntity
+    description: An entity with associated annotation authors.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    abstract: true
+    attributes:
+      authors:
+        name: authors
+        description: Annotator of a scientific data entity.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        multivalued: true
+        list_elements_ordered: true
+        alias: authors
+        owner: AnnotatoredEntity
+        domain_of:
+        - AuthoredEntity
+        - AnnotatoredEntity
+        range: Annotator
+        required: true
+        inlined: true
+        inlined_as_list: true
+  FundedEntity:
+    name: FundedEntity
+    description: An entity with associated funding sources.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    abstract: true
+    attributes:
+      funding:
+        name: funding
+        description: A funding source for a scientific data entity (base for JSON
+          and DB representation).
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        multivalued: true
+        list_elements_ordered: true
+        alias: funding
+        owner: FundedEntity
+        domain_of:
+        - FundedEntity
+        range: Funding
+        recommended: true
+        inlined: true
+        inlined_as_list: true
+  CrossReferencedEntity:
+    name: CrossReferencedEntity
+    description: An entity with associated cross-references to other databases and
+      publications.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    abstract: true
+    attributes:
+      cross_references:
+        name: cross_references
+        description: A set of cross-references to other databases and publications.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: cross_references
+        owner: CrossReferencedEntity
+        domain_of:
+        - CrossReferencedEntity
+        range: CrossReferences
+        inlined: true
+        inlined_as_list: true
+  PicturedEntity:
+    name: PicturedEntity
+    description: An entity with associated preview images.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    abstract: true
+    attributes:
+      key_photos:
+        name: key_photos
+        description: A set of paths to representative images of a piece of data.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: key_photos
+        owner: PicturedEntity
+        domain_of:
+        - PicturedEntity
+        range: PicturePath
+        required: true
+        inlined: true
+        inlined_as_list: true
+  Organism:
+    name: Organism
+    description: The species from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      name:
+        name: name
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:organism_name
+        alias: name
+        owner: Organism
+        domain_of:
+        - Author
+        - Annotator
+        - Organism
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+      taxonomy_id:
+        name: taxonomy_id
+        description: NCBI taxonomy identifier for the organism, e.g. 9606
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:organism_taxid
+        alias: taxonomy_id
+        owner: Organism
+        domain_of:
+        - Organism
+        range: string
+        inlined: true
+        inlined_as_list: true
+  Tissue:
+    name: Tissue
+    description: The type of tissue from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      name:
+        name: name
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tissue_name
+        alias: name
+        owner: Tissue
+        domain_of:
+        - Author
+        - Annotator
+        - Organism
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+      id:
+        name: id
+        description: The UBERON identifier for the tissue.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tissue_id
+        alias: id
+        owner: Tissue
+        domain_of:
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+  CellType:
+    name: CellType
+    description: The cell type from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      name:
+        name: name
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:cell_name
+        alias: name
+        owner: CellType
+        domain_of:
+        - Author
+        - Annotator
+        - Organism
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+      id:
+        name: id
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:cell_type_id
+        alias: id
+        owner: CellType
+        domain_of:
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+  CellStrain:
+    name: CellStrain
+    description: The strain or cell line from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      name:
+        name: name
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:cell_strain_name
+        alias: name
+        owner: CellStrain
+        domain_of:
+        - Author
+        - Annotator
+        - Organism
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+      id:
+        name: id
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:cell_strain_id
+        alias: id
+        owner: CellStrain
+        domain_of:
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+  CellComponent:
+    name: CellComponent
+    description: The cellular component from which the sample was derived.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      name:
+        name: name
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:cell_component_name
+        alias: name
+        owner: CellComponent
+        domain_of:
+        - Author
+        - Annotator
+        - Organism
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+      id:
+        name: id
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:cell_component_id
+        alias: id
+        owner: CellComponent
+        domain_of:
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+  ExperimentalMetadata:
+    name: ExperimentalMetadata
+    description: Metadata describing sample and sample preparation methods used in
+      a cryoET dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    abstract: true
+    attributes:
+      sample_type:
+        name: sample_type
+        description: Type of sample imaged in a CryoET study.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:preparation_sample_type
+        alias: sample_type
+        owner: ExperimentalMetadata
+        domain_of:
+        - ExperimentalMetadata
+        range: sample_type_enum
+        inlined: true
+        inlined_as_list: true
+      sample_preparation:
+        name: sample_preparation
+        description: Describes how the sample was prepared.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:sample_preparation
+        alias: sample_preparation
+        owner: ExperimentalMetadata
+        domain_of:
+        - ExperimentalMetadata
+        range: string
+        inlined: true
+        inlined_as_list: true
+      grid_preparation:
+        name: grid_preparation
+        description: Describes Cryo-ET grid preparation.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:grid_preparation
+        alias: grid_preparation
+        owner: ExperimentalMetadata
+        domain_of:
+        - ExperimentalMetadata
+        range: string
+        inlined: true
+        inlined_as_list: true
+      other_setup:
+        name: other_setup
+        description: Describes other setup not covered by sample preparation or grid
+          preparation that may make this dataset unique in   the same publication.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:preparation_other_setup
+        alias: other_setup
+        owner: ExperimentalMetadata
+        domain_of:
+        - ExperimentalMetadata
+        range: string
+        inlined: true
+        inlined_as_list: true
+      organism:
+        name: organism
+        description: The species from which the sample was derived.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: organism
+        owner: ExperimentalMetadata
+        domain_of:
+        - ExperimentalMetadata
+        range: Organism
+        inlined: true
+        inlined_as_list: true
+      tissue:
+        name: tissue
+        description: The type of tissue from which the sample was derived.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: tissue
+        owner: ExperimentalMetadata
+        domain_of:
+        - ExperimentalMetadata
+        range: Tissue
+        inlined: true
+        inlined_as_list: true
+      cell_type:
+        name: cell_type
+        description: The cell type from which the sample was derived.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: cell_type
+        owner: ExperimentalMetadata
+        domain_of:
+        - ExperimentalMetadata
+        range: CellType
+        inlined: true
+        inlined_as_list: true
+      cell_strain:
+        name: cell_strain
+        description: The strain or cell line from which the sample was derived.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: cell_strain
+        owner: ExperimentalMetadata
+        domain_of:
+        - ExperimentalMetadata
+        range: CellStrain
+        inlined: true
+        inlined_as_list: true
+      cell_component:
+        name: cell_component
+        description: The cellular component from which the sample was derived.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: cell_component
+        owner: ExperimentalMetadata
+        domain_of:
+        - ExperimentalMetadata
+        range: CellComponent
+        inlined: true
+        inlined_as_list: true
+  Dataset:
+    name: Dataset
+    description: High-level description of a cryoET dataset.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    mixins:
+    - DatestampedEntity
+    - AuthoredEntity
+    - FundedEntity
+    - PicturedEntity
+    - CrossReferencedEntity
+    - ExperimentalMetadata
+    attributes:
+      dataset_identifier:
+        name: dataset_identifier
+        description: An identifier for a CryoET dataset, assigned by the Data Portal.
+          Used to identify the dataset as the directory  name in data tree.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:dataset_identifier
+        alias: dataset_identifier
+        owner: Dataset
+        domain_of:
+        - Dataset
+        range: integer
+        inlined: true
+        inlined_as_list: true
+      dataset_title:
+        name: dataset_title
+        description: Title of a CryoET dataset.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:dataset_title
+        alias: dataset_title
+        owner: Dataset
+        domain_of:
+        - Dataset
+        range: string
+        inlined: true
+        inlined_as_list: true
+      dataset_description:
+        name: dataset_description
+        description: A short description of a CryoET dataset, similar to an abstract
+          for a journal article or dataset.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:dataset_description
+        alias: dataset_description
+        owner: Dataset
+        domain_of:
+        - Dataset
+        range: string
+        inlined: true
+        inlined_as_list: true
+      dates:
+        name: dates
+        description: A set of dates at which a data item was deposited, published
+          and last modified.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: dates
+        owner: Dataset
+        domain_of:
+        - DatestampedEntity
+        range: DateStamp
+        required: true
+        inlined: true
+        inlined_as_list: true
+      authors:
+        name: authors
+        description: Author of a scientific data entity.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        multivalued: true
+        list_elements_ordered: true
+        alias: authors
+        owner: Dataset
+        domain_of:
+        - AuthoredEntity
+        - AnnotatoredEntity
+        range: Author
+        required: true
+        inlined: true
+        inlined_as_list: true
+      funding:
+        name: funding
+        description: A funding source for a scientific data entity (base for JSON
+          and DB representation).
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        multivalued: true
+        list_elements_ordered: true
+        alias: funding
+        owner: Dataset
+        domain_of:
+        - FundedEntity
+        range: Funding
+        recommended: true
+        inlined: true
+        inlined_as_list: true
+      key_photos:
+        name: key_photos
+        description: A set of paths to representative images of a piece of data.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: key_photos
+        owner: Dataset
+        domain_of:
+        - PicturedEntity
+        range: PicturePath
+        required: true
+        inlined: true
+        inlined_as_list: true
+      cross_references:
+        name: cross_references
+        description: A set of cross-references to other databases and publications.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: cross_references
+        owner: Dataset
+        domain_of:
+        - CrossReferencedEntity
+        range: CrossReferences
+        inlined: true
+        inlined_as_list: true
+      sample_type:
+        name: sample_type
+        description: Type of sample imaged in a CryoET study.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:preparation_sample_type
+        alias: sample_type
+        owner: Dataset
+        domain_of:
+        - ExperimentalMetadata
+        range: string
+        inlined: true
+        inlined_as_list: true
+      sample_preparation:
+        name: sample_preparation
+        description: Describes how the sample was prepared.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:sample_preparation
+        alias: sample_preparation
+        owner: Dataset
+        domain_of:
+        - ExperimentalMetadata
+        range: string
+        inlined: true
+        inlined_as_list: true
+      grid_preparation:
+        name: grid_preparation
+        description: Describes Cryo-ET grid preparation.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:grid_preparation
+        alias: grid_preparation
+        owner: Dataset
+        domain_of:
+        - ExperimentalMetadata
+        range: string
+        inlined: true
+        inlined_as_list: true
+      other_setup:
+        name: other_setup
+        description: Describes other setup not covered by sample preparation or grid
+          preparation that may make this dataset unique in   the same publication.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:preparation_other_setup
+        alias: other_setup
+        owner: Dataset
+        domain_of:
+        - ExperimentalMetadata
+        range: string
+        inlined: true
+        inlined_as_list: true
+      organism:
+        name: organism
+        description: The species from which the sample was derived.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: organism
+        owner: Dataset
+        domain_of:
+        - ExperimentalMetadata
+        range: Organism
+        inlined: true
+        inlined_as_list: true
+      tissue:
+        name: tissue
+        description: The type of tissue from which the sample was derived.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: tissue
+        owner: Dataset
+        domain_of:
+        - ExperimentalMetadata
+        range: Tissue
+        inlined: true
+        inlined_as_list: true
+      cell_type:
+        name: cell_type
+        description: The cell type from which the sample was derived.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: cell_type
+        owner: Dataset
+        domain_of:
+        - ExperimentalMetadata
+        range: CellType
+        inlined: true
+        inlined_as_list: true
+      cell_strain:
+        name: cell_strain
+        description: The strain or cell line from which the sample was derived.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: cell_strain
+        owner: Dataset
+        domain_of:
+        - ExperimentalMetadata
+        range: CellStrain
+        inlined: true
+        inlined_as_list: true
+      cell_component:
+        name: cell_component
+        description: The cellular component from which the sample was derived.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: cell_component
+        owner: Dataset
+        domain_of:
+        - ExperimentalMetadata
+        range: CellComponent
+        inlined: true
+        inlined_as_list: true
+  Camera:
+    name: Camera
+    description: The camera used to collect the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      manufacturer:
+        name: manufacturer
+        description: Name of the camera manufacturer
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_camera_manufacturer
+        alias: manufacturer
+        owner: Camera
+        domain_of:
+        - Camera
+        - Microscope
+        range: string
+        inlined: true
+        inlined_as_list: true
+      model:
+        name: model
+        description: Camera model name
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_camera_model
+        alias: model
+        owner: Camera
+        domain_of:
+        - Camera
+        - Microscope
+        range: string
+        inlined: true
+        inlined_as_list: true
+  Microscope:
+    name: Microscope
+    description: The microscope used to collect the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      manufacturer:
+        name: manufacturer
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_microscope_manufacturer
+        alias: manufacturer
+        owner: Microscope
+        domain_of:
+        - Camera
+        - Microscope
+        range: string
+        inlined: true
+        inlined_as_list: true
+      model:
+        name: model
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_microscope_model
+        alias: model
+        owner: Microscope
+        domain_of:
+        - Camera
+        - Microscope
+        range: string
+        inlined: true
+        inlined_as_list: true
+  MicroscopeOpticalSetup:
+    name: MicroscopeOpticalSetup
+    description: The optical setup of the microscope used to collect the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      energy_filter:
+        name: energy_filter
+        description: Energy filter setup used
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_microscope_energy_filter
+        alias: energy_filter
+        owner: MicroscopeOpticalSetup
+        domain_of:
+        - MicroscopeOpticalSetup
+        range: string
+        inlined: true
+        inlined_as_list: true
+      phase_plate:
+        name: phase_plate
+        description: Phase plate configuration
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_microscope_phase_plate
+        alias: phase_plate
+        owner: MicroscopeOpticalSetup
+        domain_of:
+        - MicroscopeOpticalSetup
+        range: string
+        inlined: true
+        inlined_as_list: true
+      image_corrector:
+        name: image_corrector
+        description: Image corrector setup
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_microscope_image_corrector
+        alias: image_corrector
+        owner: MicroscopeOpticalSetup
+        domain_of:
+        - MicroscopeOpticalSetup
+        range: string
+        inlined: true
+        inlined_as_list: true
+  TiltRange:
+    name: TiltRange
+    description: The range of tilt angles in the tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      min:
+        name: min
+        description: Minimal tilt angle in degrees
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_tilt_min
+        alias: min
+        owner: TiltRange
+        domain_of:
+        - TiltRange
+        range: float
+        inlined: true
+        inlined_as_list: true
+      max:
+        name: max
+        description: Maximal tilt angle in degrees
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_tilt_max
+        alias: max
+        owner: TiltRange
+        domain_of:
+        - TiltRange
+        range: float
+        inlined: true
+        inlined_as_list: true
+  TiltSeries:
+    name: TiltSeries
+    description: Metadata describing a tilt series.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      acceleration_voltage:
+        name: acceleration_voltage
+        description: Electron Microscope Accelerator voltage in volts
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_acceleration_voltage
+        alias: acceleration_voltage
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: integer
+        inlined: true
+        inlined_as_list: true
+      spherical_aberration_constant:
+        name: spherical_aberration_constant
+        description: Spherical Aberration Constant of the objective lens in millimeters
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_spherical_aberration_constant
+        alias: spherical_aberration_constant
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: float
+        inlined: true
+        inlined_as_list: true
+      microscope_additional_info:
+        name: microscope_additional_info
+        description: Other microscope optical setup information, in addition to energy
+          filter, phase plate and image corrector
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_microscope_additional_info
+        alias: microscope_additional_info
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: string
+        inlined: true
+        inlined_as_list: true
+      tilt_axis:
+        name: tilt_axis
+        description: Rotation angle in degrees
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_tilt_axis
+        alias: tilt_axis
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: float
+        inlined: true
+        inlined_as_list: true
+      tilt_step:
+        name: tilt_step
+        description: Tilt step in degrees
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_tilt_step
+        alias: tilt_step
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: float
+        inlined: true
+        inlined_as_list: true
+      tilting_scheme:
+        name: tilting_scheme
+        description: The order of stage tilting during acquisition of the data
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_tilting_scheme
+        alias: tilting_scheme
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: string
+        inlined: true
+        inlined_as_list: true
+      total_flux:
+        name: total_flux
+        description: Number of Electrons reaching the specimen in a square Angstrom
+          area for the entire tilt series
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_total_flux
+        alias: total_flux
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: float
+        inlined: true
+        inlined_as_list: true
+      data_acquisition_software:
+        name: data_acquisition_software
+        description: Software used to collect data
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_data_acquisition_software
+        alias: data_acquisition_software
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: string
+        inlined: true
+        inlined_as_list: true
+      binning_from_frames:
+        name: binning_from_frames
+        description: Describes the binning factor from frames to tilt series file
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_binning_from_frames
+        alias: binning_from_frames
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: float
+        inlined: true
+        inlined_as_list: true
+      tilt_series_quality:
+        name: tilt_series_quality
+        description: Author assessment of tilt series quality within the dataset (1-5,
+          5 is best)
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_tilt_series_quality
+        alias: tilt_series_quality
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: integer
+        inlined: true
+        inlined_as_list: true
+      pixel_spacing:
+        name: pixel_spacing
+        description: Pixel spacing for the tilt series
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_pixel_spacing
+        alias: pixel_spacing
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: float
+        inlined: true
+        inlined_as_list: true
+      aligned_tiltseries_binning:
+        name: aligned_tiltseries_binning
+        description: Binning factor of the aligned tilt series
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_aligned_tiltseries_binning
+        alias: aligned_tiltseries_binning
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: integer
+        inlined: true
+        inlined_as_list: true
+      frames_count:
+        name: frames_count
+        description: Number of frames associated with this tiltseries
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tiltseries_frames_count
+        alias: frames_count
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: integer
+        inlined: true
+        inlined_as_list: true
+      camera:
+        name: camera
+        description: The camera used to collect the tilt series.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: camera
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: Camera
+        inlined: true
+        inlined_as_list: true
+      microscope:
+        name: microscope
+        description: The microscope used to collect the tilt series.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: microscope
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: Microscope
+        inlined: true
+        inlined_as_list: true
+      microscope_optical_setup:
+        name: microscope_optical_setup
+        description: The optical setup of the microscope used to collect the tilt
+          series.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: microscope_optical_setup
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: MicroscopeOpticalSetup
+        inlined: true
+        inlined_as_list: true
+      tilt_range:
+        name: tilt_range
+        description: The range of tilt angles in the tilt series.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: tilt_range
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: TiltRange
+        inlined: true
+        inlined_as_list: true
+  TomogramSize:
+    name: TomogramSize
+    description: The size of a tomogram in voxels in each dimension.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      x:
+        name: x
+        description: Number of pixels in the 3D data fast axis
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_size_x
+        alias: x
+        owner: TomogramSize
+        domain_of:
+        - TomogramSize
+        - TomogramOffset
+        range: integer
+        inlined: true
+        inlined_as_list: true
+      y:
+        name: y
+        description: Number of pixels in the 3D data medium axis
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_size_y
+        alias: y
+        owner: TomogramSize
+        domain_of:
+        - TomogramSize
+        - TomogramOffset
+        range: integer
+        inlined: true
+        inlined_as_list: true
+      z:
+        name: z
+        description: Number of pixels in the 3D data slow axis.  This is the image
+          projection direction at zero stage tilt
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_size_z
+        alias: z
+        owner: TomogramSize
+        domain_of:
+        - TomogramSize
+        - TomogramOffset
+        range: integer
+        inlined: true
+        inlined_as_list: true
+  TomogramOffset:
+    name: TomogramOffset
+    description: The offset of a tomogram in voxels in each dimension relative to
+      the canonical tomogram.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      x:
+        name: x
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_offset_x
+        alias: x
+        owner: TomogramOffset
+        domain_of:
+        - TomogramSize
+        - TomogramOffset
+        range: string
+        inlined: true
+        inlined_as_list: true
+      y:
+        name: y
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_offset_y
+        alias: y
+        owner: TomogramOffset
+        domain_of:
+        - TomogramSize
+        - TomogramOffset
+        range: string
+        inlined: true
+        inlined_as_list: true
+      z:
+        name: z
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_offset_z
+        alias: z
+        owner: TomogramOffset
+        domain_of:
+        - TomogramSize
+        - TomogramOffset
+        range: string
+        inlined: true
+        inlined_as_list: true
+  Tomogram:
+    name: Tomogram
+    description: Metadata describing a tomogram.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    mixins:
+    - AuthoredEntity
+    - PicturedEntity
+    attributes:
+      voxel_spacing:
+        name: voxel_spacing
+        description: Voxel spacing equal in all three axes in angstroms
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_voxel_spacing
+        alias: voxel_spacing
+        owner: Tomogram
+        domain_of:
+        - Tomogram
+        range: float
+        inlined: true
+        inlined_as_list: true
+      fiducial_alignment_status:
+        name: fiducial_alignment_status
+        description: Whether the tomographic alignment was computed based on fiducial
+          markers.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_fiducial_alignment_status
+        alias: fiducial_alignment_status
+        owner: Tomogram
+        domain_of:
+        - Tomogram
+        range: fiducial_alignment_status_enum
+        inlined: true
+        inlined_as_list: true
+      ctf_corrected:
+        name: ctf_corrected
+        description: Whether this tomogram is CTF corrected
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_ctf_corrected
+        alias: ctf_corrected
+        owner: Tomogram
+        domain_of:
+        - Tomogram
+        range: boolean
+        inlined: true
+        inlined_as_list: true
+      reconstruction_method:
+        name: reconstruction_method
+        description: Describe reconstruction method (Weighted back-projection, SART,
+          SIRT)
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_reconstruction_method
+        alias: reconstruction_method
+        owner: Tomogram
+        domain_of:
+        - Tomogram
+        range: string
+        inlined: true
+        inlined_as_list: true
+      reconstruction_software:
+        name: reconstruction_software
+        description: Name of software used for reconstruction
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_reconstruction_software
+        alias: reconstruction_software
+        owner: Tomogram
+        domain_of:
+        - Tomogram
+        range: string
+        inlined: true
+        inlined_as_list: true
+      processing:
+        name: processing
+        description: Describe additional processing used to derive the tomogram
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_processing
+        alias: processing
+        owner: Tomogram
+        domain_of:
+        - Tomogram
+        range: string
+        inlined: true
+        inlined_as_list: true
+      processing_software:
+        name: processing_software
+        description: Processing software used to derive the tomogram
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_processing_software
+        alias: processing_software
+        owner: Tomogram
+        domain_of:
+        - Tomogram
+        range: string
+        inlined: true
+        inlined_as_list: true
+      tomogram_version:
+        name: tomogram_version
+        description: Version of tomogram using the same software and post-processing.
+          Version of tomogram using the same software and post-processing. This will
+          be presented as the latest version
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_version
+        alias: tomogram_version
+        owner: Tomogram
+        domain_of:
+        - Tomogram
+        range: string
+        inlined: true
+        inlined_as_list: true
+      affine_transformation_matrix:
+        name: affine_transformation_matrix
+        description: The flip or rotation transformation of this author submitted
+          tomogram is indicated here
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:tomogram_affine_transformation_matrix
+        alias: affine_transformation_matrix
+        owner: Tomogram
+        domain_of:
+        - Tomogram
+        range: string
+        inlined: true
+        inlined_as_list: true
+      size:
+        name: size
+        description: The size of a tomogram in voxels in each dimension.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: size
+        owner: Tomogram
+        domain_of:
+        - Tomogram
+        range: TomogramSize
+        inlined: true
+        inlined_as_list: true
+      offset:
+        name: offset
+        description: The offset of a tomogram in voxels in each dimension relative
+          to the canonical tomogram.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: offset
+        owner: Tomogram
+        domain_of:
+        - Tomogram
+        range: TomogramOffset
+        inlined: true
+        inlined_as_list: true
+      authors:
+        name: authors
+        description: Author of a scientific data entity.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        multivalued: true
+        list_elements_ordered: true
+        alias: authors
+        owner: Tomogram
+        domain_of:
+        - AuthoredEntity
+        - AnnotatoredEntity
+        range: Author
+        required: true
+        inlined: true
+        inlined_as_list: true
+      key_photos:
+        name: key_photos
+        description: A set of paths to representative images of a piece of data.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: key_photos
+        owner: Tomogram
+        domain_of:
+        - PicturedEntity
+        range: PicturePath
+        required: true
+        inlined: true
+        inlined_as_list: true
+  AnnotationFile:
+    name: AnnotationFile
+    description: Metadata describing a file containing an annotation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      format:
+        name: format
+        description: File format for this file
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_file_format
+        alias: format
+        owner: AnnotationFile
+        domain_of:
+        - AnnotationFile
+        range: string
+        inlined: true
+        inlined_as_list: true
+      shape:
+        name: shape
+        description: Describe whether this is a Point, OrientedPoint, or SegmentationMask
+          file
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_file_shape_type
+        alias: shape
+        owner: AnnotationFile
+        domain_of:
+        - AnnotationFile
+        range: string
+        inlined: true
+        inlined_as_list: true
+      path:
+        name: path
+        description: Path to the annotation file relative to the dataset root.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_file_path
+        alias: path
+        owner: AnnotationFile
+        domain_of:
+        - AnnotationFile
+        range: string
+        inlined: true
+        inlined_as_list: true
+      is_visualization_default:
+        name: is_visualization_default
+        description: This annotation will be rendered in neuroglancer by default.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_file_is_visualization_default
+        alias: is_visualization_default
+        owner: AnnotationFile
+        domain_of:
+        - AnnotationFile
+        range: boolean
+        inlined: true
+        inlined_as_list: true
+  AnnotationConfidence:
+    name: AnnotationConfidence
+    description: Metadata describing the confidence of an annotation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      precision:
+        name: precision
+        description: Describe the confidence level of the annotation. Precision is
+          defined as the % of annotation objects being true positive
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_confidence_precision
+        alias: precision
+        owner: AnnotationConfidence
+        domain_of:
+        - AnnotationConfidence
+        range: float
+        inlined: true
+        inlined_as_list: true
+      recall:
+        name: recall
+        description: Describe the confidence level of the annotation. Recall is defined
+          as the % of true positives being annotated correctly
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_confidence_recall
+        alias: recall
+        owner: AnnotationConfidence
+        domain_of:
+        - AnnotationConfidence
+        range: float
+        inlined: true
+        inlined_as_list: true
+      ground_truth_used:
+        name: ground_truth_used
+        description: Annotation filename used as ground truth for precision and recall
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_ground_truth_used
+        alias: ground_truth_used
+        owner: AnnotationConfidence
+        domain_of:
+        - AnnotationConfidence
+        range: string
+        inlined: true
+        inlined_as_list: true
+  AnnotationObject:
+    name: AnnotationObject
+    description: Metadata describing the object being annotated.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      id:
+        name: id
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_object_id
+        alias: id
+        owner: AnnotationObject
+        domain_of:
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+      name:
+        name: name
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_object_name
+        alias: name
+        owner: AnnotationObject
+        domain_of:
+        - Author
+        - Annotator
+        - Organism
+        - Tissue
+        - CellType
+        - CellStrain
+        - CellComponent
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+      description:
+        name: description
+        description: A textual description of the annotation object, can be a longer
+          description to include additional information not covered by the Annotation
+          object name and state.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_object_description
+        alias: description
+        owner: AnnotationObject
+        domain_of:
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+      state:
+        name: state
+        description: Molecule state annotated (e.g. open, closed)
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_object_state
+        alias: state
+        owner: AnnotationObject
+        domain_of:
+        - AnnotationObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+  Annotation:
+    name: Annotation
+    description: Metadata describing an annotation.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    mixins:
+    - DatestampedEntity
+    - AnnotatoredEntity
+    attributes:
+      annotation_method:
+        name: annotation_method
+        description: Describe how the annotation is made (e.g. Manual, crYoLO, Positive
+          Unlabeled Learning, template matching)
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_method
+        alias: annotation_method
+        owner: Annotation
+        domain_of:
+        - Annotation
+        range: string
+        inlined: true
+        inlined_as_list: true
+      annotation_method_type:
+        name: annotation_method_type
+        description: Classification of the annotation method based on supervision.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_method_type
+        alias: annotation_method_type
+        owner: Annotation
+        domain_of:
+        - Annotation
+        range: annotation_method_type_enum
+        inlined: true
+        inlined_as_list: true
+      annotation_publications:
+        name: annotation_publications
+        description: DOIs for publications that describe the dataset. Use a comma
+          to separate multiple DOIs.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_publication
+        alias: annotation_publications
+        owner: Annotation
+        domain_of:
+        - Annotation
+        range: string
+        inlined: true
+        inlined_as_list: true
+      annotation_software:
+        name: annotation_software
+        description: Software used for generating this annotation
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_software
+        alias: annotation_software
+        owner: Annotation
+        domain_of:
+        - Annotation
+        range: string
+        inlined: true
+        inlined_as_list: true
+      ground_truth_status:
+        name: ground_truth_status
+        description: Whether an annotation is considered ground truth, as determined
+          by the annotator.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_ground_truth_status
+        alias: ground_truth_status
+        owner: Annotation
+        domain_of:
+        - Annotation
+        range: boolean
+        inlined: true
+        inlined_as_list: true
+      object_count:
+        name: object_count
+        description: Number of objects identified
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_object_count
+        alias: object_count
+        owner: Annotation
+        domain_of:
+        - Annotation
+        range: integer
+        inlined: true
+        inlined_as_list: true
+      is_curator_recommended:
+        name: is_curator_recommended
+        description: This annotation is recommended by the curator to be preferred
+          for this object type.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        exact_mappings:
+        - cdp-common:annotation_is_curator_recommended
+        alias: is_curator_recommended
+        owner: Annotation
+        domain_of:
+        - Annotation
+        range: boolean
+        inlined: true
+        inlined_as_list: true
+      files:
+        name: files
+        description: Metadata describing a file containing an annotation.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        multivalued: true
+        list_elements_ordered: true
+        alias: files
+        owner: Annotation
+        domain_of:
+        - Annotation
+        range: AnnotationFile
+        inlined: true
+        inlined_as_list: true
+      confidence:
+        name: confidence
+        description: Metadata describing the confidence of an annotation.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: confidence
+        owner: Annotation
+        domain_of:
+        - Annotation
+        range: AnnotationConfidence
+        inlined: true
+        inlined_as_list: true
+      annotation_object:
+        name: annotation_object
+        description: Metadata describing the object being annotated.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: annotation_object
+        owner: Annotation
+        domain_of:
+        - Annotation
+        range: AnnotationObject
+        inlined: true
+        inlined_as_list: true
+      dates:
+        name: dates
+        description: A set of dates at which a data item was deposited, published
+          and last modified.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: dates
+        owner: Annotation
+        domain_of:
+        - DatestampedEntity
+        range: DateStamp
+        required: true
+        inlined: true
+        inlined_as_list: true
+      authors:
+        name: authors
+        description: Annotator of a scientific data entity.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        multivalued: true
+        list_elements_ordered: true
+        alias: authors
+        owner: Annotation
+        domain_of:
+        - AuthoredEntity
+        - AnnotatoredEntity
+        range: Annotator
+        required: true
+        inlined: true
+        inlined_as_list: true
+  CrossReferences:
+    name: CrossReferences
+    description: A set of cross-references to other databases and publications.
+    from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+    attributes:
+      dataset_publications:
+        name: dataset_publications
+        description: Comma-separated list of DOIs for publications associated with
+          the dataset.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: dataset_publications
+        owner: CrossReferences
+        domain_of:
+        - CrossReferences
+        range: string
+        recommended: true
+        inlined: true
+        inlined_as_list: true
+      related_database_entries:
+        name: related_database_entries
+        description: Comma-separated list of related database entries for the dataset.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: related_database_entries
+        owner: CrossReferences
+        domain_of:
+        - CrossReferences
+        range: string
+        recommended: true
+        inlined: true
+        inlined_as_list: true
+      related_database_links:
+        name: related_database_links
+        description: Comma-separated list of related database links for the dataset.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: related_database_links
+        owner: CrossReferences
+        domain_of:
+        - CrossReferences
+        range: string
+        inlined: true
+        inlined_as_list: true
+      dataset_citations:
+        name: dataset_citations
+        description: Comma-separated list of DOIs for publications citing the dataset.
+        from_schema: https://cryoetdataportal.czscience.com/schema-docs/metadata
+        alias: dataset_citations
+        owner: CrossReferences
+        domain_of:
+        - CrossReferences
+        range: string
+        inlined: true
+        inlined_as_list: true
+source_file: metadata.yaml

--- a/schema/v1.1.0/metadata_models.py
+++ b/schema/v1.1.0/metadata_models.py
@@ -4,9 +4,10 @@ from enum import Enum
 
 from decimal import Decimal
 from typing import List, Dict, Optional, Any, Union
-from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
+from pydantic import BaseModel as BaseModel, ConfigDict, Field, field_validator
 import re
 import sys
+
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
@@ -16,22 +17,24 @@ else:
 metamodel_version = "None"
 version = "1.1.0"
 
+
 class ConfiguredBaseModel(BaseModel):
     model_config = ConfigDict(
         validate_assignment=True,
         validate_default=True,
-        extra = 'forbid',
+        extra="forbid",
         arbitrary_types_allowed=True,
-        use_enum_values = True)
+        use_enum_values=True,
+    )
 
     pass
 
-        
 
 class SampleTypeEnum(str, Enum):
     """
     Type of sample imaged in a CryoET study.
     """
+
     # Tomographic data of whole cells or cell sections.
     cell = "cell"
     # Tomographic data of tissue sections.
@@ -48,432 +51,712 @@ class SampleTypeEnum(str, Enum):
     in_silico = "in_silico"
     # Other type of sample.
     other = "other"
-    
-    
+
 
 class FiducialAlignmentStatusEnum(str, Enum):
     """
     Fiducial Alignment method
     """
+
     # Alignment computed based on fiducial markers
     FIDUCIAL = "FIDUCIAL"
     # Alignment computed without fiducial markers
     NON_FIDUCIAL = "NON_FIDUCIAL"
-    
-    
+
 
 class TomogramTypeEnum(str, Enum):
     """
     Tomogram type
     """
+
     # Canonical tomogram (basis geometry for all annotations)
     CANONICAL = "CANONICAL"
-    
-    
+
 
 class AnnotationMethodTypeEnum(str, Enum):
     """
     Describes how the annotations were generated.
     """
+
     # Annotations were generated manually.
     manual = "manual"
     # Annotations were generated semi-automatically.
     automated = "automated"
     # Annotations were generated automatically.
     hybrid = "hybrid"
-    
-    
+
 
 class AnnotationShapeEnum(str, Enum):
     """
     Annotation shape types available on the data portal.
     """
+
     # Annotations were generated manually.
     Point = "Point"
     # Annotations were generated semi-automatically.
     OrientedPoint = "OrientedPoint"
     # Annotations were generated automatically.
     SegmentationMask = "SegmentationMask"
-    
-    
+
 
 class PicturePath(ConfiguredBaseModel):
     """
     A set of paths to representative images of a piece of data.
     """
-    snapshot: Optional[str] = Field(None, description="""Path to the dataset preview image relative to the dataset directory root.""")
-    thumbnail: Optional[str] = Field(None, description="""Path to the thumbnail of preview image relative to the dataset directory root.""")
-    
-    
+
+    snapshot: Optional[str] = Field(
+        None,
+        description="""Path to the dataset preview image relative to the dataset directory root.""",
+    )
+    thumbnail: Optional[str] = Field(
+        None,
+        description="""Path to the thumbnail of preview image relative to the dataset directory root.""",
+    )
+
 
 class Author(ConfiguredBaseModel):
     """
     Author of a scientific data entity.
     """
+
     name: Optional[str] = Field(None, description="""The full name of the author.""")
-    email: Optional[str] = Field(None, description="""The email address of the author.""")
-    affiliation_name: Optional[str] = Field(None, description="""The name of the author's affiliation.""")
-    affiliation_address: Optional[str] = Field(None, description="""The address of the author's affiliation.""")
-    affiliation_identifier: Optional[str] = Field(None, description="""A Research Organization Registry (ROR) identifier.""")
-    is_corresponding: Optional[bool] = Field(None, description="""Whether the author is a corresponding author.""")
-    is_primary_author: Optional[bool] = Field(None, description="""Whether the author is a primary author.""")
-    ORCID: Optional[str] = Field(None, description="""A unique, persistent identifier for researchers, provided by ORCID.""")
-    
-    
-    @field_validator('affiliation_identifier')
+    email: Optional[str] = Field(
+        None, description="""The email address of the author."""
+    )
+    affiliation_name: Optional[str] = Field(
+        None, description="""The name of the author's affiliation."""
+    )
+    affiliation_address: Optional[str] = Field(
+        None, description="""The address of the author's affiliation."""
+    )
+    affiliation_identifier: Optional[str] = Field(
+        None, description="""A Research Organization Registry (ROR) identifier."""
+    )
+    is_corresponding: Optional[bool] = Field(
+        None, description="""Whether the author is a corresponding author."""
+    )
+    is_primary_author: Optional[bool] = Field(
+        None, description="""Whether the author is a primary author."""
+    )
+    ORCID: Optional[str] = Field(
+        None,
+        description="""A unique, persistent identifier for researchers, provided by ORCID.""",
+    )
+
+    @field_validator("affiliation_identifier")
     def pattern_affiliation_identifier(cls, v):
-        pattern=re.compile(r"^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$")
-        if isinstance(v,list):
+        pattern = re.compile(r"^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$")
+        if isinstance(v, list):
             for element in v:
                 if not pattern.match(element):
-                    raise ValueError(f"Invalid affiliation_identifier format: {element}")
-        elif isinstance(v,str):
+                    raise ValueError(
+                        f"Invalid affiliation_identifier format: {element}"
+                    )
+        elif isinstance(v, str):
             if not pattern.match(v):
                 raise ValueError(f"Invalid affiliation_identifier format: {v}")
         return v
-    
-    @field_validator('ORCID')
+
+    @field_validator("ORCID")
     def pattern_ORCID(cls, v):
-        pattern=re.compile(r"[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$")
-        if isinstance(v,list):
+        pattern = re.compile(r"[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$")
+        if isinstance(v, list):
             for element in v:
                 if not pattern.match(element):
                     raise ValueError(f"Invalid ORCID format: {element}")
-        elif isinstance(v,str):
+        elif isinstance(v, str):
             if not pattern.match(v):
                 raise ValueError(f"Invalid ORCID format: {v}")
         return v
-    
+
 
 class Annotator(ConfiguredBaseModel):
     """
     Annotator of a scientific data entity.
     """
+
     name: Optional[str] = Field(None)
     email: Optional[str] = Field(None)
     affiliation_name: Optional[str] = Field(None)
     affiliation_address: Optional[str] = Field(None)
     affiliation_identifier: Optional[str] = Field(None)
     is_corresponding: Optional[str] = Field(None)
-    is_primary_annotator: Optional[bool] = Field(None, description="""Whether the author is a primary author.""")
+    is_primary_annotator: Optional[bool] = Field(
+        None, description="""Whether the author is a primary author."""
+    )
     ORCID: Optional[str] = Field(None)
-    
-    
+
 
 class Funding(ConfiguredBaseModel):
     """
     A funding source for a scientific data entity (base for JSON and DB representation).
     """
-    funding_agency_name: Optional[str] = Field(None, description="""The name of the funding source.""")
-    grant_id: Optional[str] = Field(None, description="""Grant identifier provided by the funding agency""")
-    
-    
+
+    funding_agency_name: Optional[str] = Field(
+        None, description="""The name of the funding source."""
+    )
+    grant_id: Optional[str] = Field(
+        None, description="""Grant identifier provided by the funding agency"""
+    )
+
 
 class DateStamp(ConfiguredBaseModel):
     """
     A set of dates at which a data item was deposited, published and last modified.
     """
-    deposition_date: date = Field(..., description="""The date a data item was received by the cryoET data portal.""")
-    release_date: date = Field(..., description="""The date a data item was received by the cryoET data portal.""")
-    last_modified_date: date = Field(..., description="""The date a piece of data was last modified on the cryoET data portal.""")
-    
-    
+
+    deposition_date: date = Field(
+        ...,
+        description="""The date a data item was received by the cryoET data portal.""",
+    )
+    release_date: date = Field(
+        ...,
+        description="""The date a data item was received by the cryoET data portal.""",
+    )
+    last_modified_date: date = Field(
+        ...,
+        description="""The date a piece of data was last modified on the cryoET data portal.""",
+    )
+
 
 class DatestampedEntity(ConfiguredBaseModel):
     """
     An entity with associated deposition, release and last modified dates.
     """
-    dates: DateStamp = Field(..., description="""A set of dates at which a data item was deposited, published and last modified.""")
-    
-    
+
+    dates: DateStamp = Field(
+        ...,
+        description="""A set of dates at which a data item was deposited, published and last modified.""",
+    )
+
 
 class AuthoredEntity(ConfiguredBaseModel):
     """
     An entity with associated authors.
     """
-    authors: List[Author] = Field(default_factory=list, description="""Author of a scientific data entity.""")
-    
-    
+
+    authors: List[Author] = Field(
+        default_factory=list, description="""Author of a scientific data entity."""
+    )
+
 
 class AnnotatoredEntity(ConfiguredBaseModel):
     """
     An entity with associated annotation authors.
     """
-    authors: List[Annotator] = Field(default_factory=list, description="""Annotator of a scientific data entity.""")
-    
-    
+
+    authors: List[Annotator] = Field(
+        default_factory=list, description="""Annotator of a scientific data entity."""
+    )
+
 
 class FundedEntity(ConfiguredBaseModel):
     """
     An entity with associated funding sources.
     """
-    funding: Optional[List[Funding]] = Field(default_factory=list, description="""A funding source for a scientific data entity (base for JSON and DB representation).""")
-    
-    
+
+    funding: Optional[List[Funding]] = Field(
+        default_factory=list,
+        description="""A funding source for a scientific data entity (base for JSON and DB representation).""",
+    )
+
 
 class CrossReferencedEntity(ConfiguredBaseModel):
     """
     An entity with associated cross-references to other databases and publications.
     """
-    cross_references: Optional[CrossReferences] = Field(None, description="""A set of cross-references to other databases and publications.""")
-    
-    
+
+    cross_references: Optional[CrossReferences] = Field(
+        None,
+        description="""A set of cross-references to other databases and publications.""",
+    )
+
 
 class PicturedEntity(ConfiguredBaseModel):
     """
     An entity with associated preview images.
     """
-    key_photos: PicturePath = Field(..., description="""A set of paths to representative images of a piece of data.""")
-    
-    
+
+    key_photos: PicturePath = Field(
+        ...,
+        description="""A set of paths to representative images of a piece of data.""",
+    )
+
 
 class Organism(ConfiguredBaseModel):
     """
     The species from which the sample was derived.
     """
+
     name: Optional[str] = Field(None)
-    taxonomy_id: Optional[str] = Field(None, description="""NCBI taxonomy identifier for the organism, e.g. 9606""")
-    
-    
+    taxonomy_id: Optional[str] = Field(
+        None, description="""NCBI taxonomy identifier for the organism, e.g. 9606"""
+    )
+
 
 class Tissue(ConfiguredBaseModel):
     """
     The type of tissue from which the sample was derived.
     """
+
     name: Optional[str] = Field(None)
-    id: Optional[str] = Field(None, description="""The UBERON identifier for the tissue.""")
-    
-    
+    id: Optional[str] = Field(
+        None, description="""The UBERON identifier for the tissue."""
+    )
+
 
 class CellType(ConfiguredBaseModel):
     """
     The cell type from which the sample was derived.
     """
+
     name: Optional[str] = Field(None)
     id: Optional[str] = Field(None)
-    
-    
+
 
 class CellStrain(ConfiguredBaseModel):
     """
     The strain or cell line from which the sample was derived.
     """
+
     name: Optional[str] = Field(None)
     id: Optional[str] = Field(None)
-    
-    
+
 
 class CellComponent(ConfiguredBaseModel):
     """
     The cellular component from which the sample was derived.
     """
+
     name: Optional[str] = Field(None)
     id: Optional[str] = Field(None)
-    
-    
+
 
 class ExperimentalMetadata(ConfiguredBaseModel):
     """
     Metadata describing sample and sample preparation methods used in a cryoET dataset.
     """
-    sample_type: Optional[SampleTypeEnum] = Field(None, description="""Type of sample imaged in a CryoET study.""")
-    sample_preparation: Optional[str] = Field(None, description="""Describes how the sample was prepared.""")
-    grid_preparation: Optional[str] = Field(None, description="""Describes Cryo-ET grid preparation.""")
-    other_setup: Optional[str] = Field(None, description="""Describes other setup not covered by sample preparation or grid preparation that may make this dataset unique in   the same publication.""")
-    organism: Optional[Organism] = Field(None, description="""The species from which the sample was derived.""")
-    tissue: Optional[Tissue] = Field(None, description="""The type of tissue from which the sample was derived.""")
-    cell_type: Optional[CellType] = Field(None, description="""The cell type from which the sample was derived.""")
-    cell_strain: Optional[CellStrain] = Field(None, description="""The strain or cell line from which the sample was derived.""")
-    cell_component: Optional[CellComponent] = Field(None, description="""The cellular component from which the sample was derived.""")
-    
-    
 
-class Dataset(ExperimentalMetadata, PicturedEntity, CrossReferencedEntity, FundedEntity, AuthoredEntity, DatestampedEntity):
+    sample_type: Optional[SampleTypeEnum] = Field(
+        None, description="""Type of sample imaged in a CryoET study."""
+    )
+    sample_preparation: Optional[str] = Field(
+        None, description="""Describes how the sample was prepared."""
+    )
+    grid_preparation: Optional[str] = Field(
+        None, description="""Describes Cryo-ET grid preparation."""
+    )
+    other_setup: Optional[str] = Field(
+        None,
+        description="""Describes other setup not covered by sample preparation or grid preparation that may make this dataset unique in   the same publication.""",
+    )
+    organism: Optional[Organism] = Field(
+        None, description="""The species from which the sample was derived."""
+    )
+    tissue: Optional[Tissue] = Field(
+        None, description="""The type of tissue from which the sample was derived."""
+    )
+    cell_type: Optional[CellType] = Field(
+        None, description="""The cell type from which the sample was derived."""
+    )
+    cell_strain: Optional[CellStrain] = Field(
+        None,
+        description="""The strain or cell line from which the sample was derived.""",
+    )
+    cell_component: Optional[CellComponent] = Field(
+        None,
+        description="""The cellular component from which the sample was derived.""",
+    )
+
+
+class Dataset(
+    ExperimentalMetadata,
+    PicturedEntity,
+    CrossReferencedEntity,
+    FundedEntity,
+    AuthoredEntity,
+    DatestampedEntity,
+):
     """
     High-level description of a cryoET dataset.
     """
-    dataset_identifier: Optional[int] = Field(None, description="""An identifier for a CryoET dataset, assigned by the Data Portal. Used to identify the dataset as the directory  name in data tree.""")
-    dataset_title: Optional[str] = Field(None, description="""Title of a CryoET dataset.""")
-    dataset_description: Optional[str] = Field(None, description="""A short description of a CryoET dataset, similar to an abstract for a journal article or dataset.""")
-    dates: DateStamp = Field(..., description="""A set of dates at which a data item was deposited, published and last modified.""")
-    authors: List[Author] = Field(default_factory=list, description="""Author of a scientific data entity.""")
-    funding: Optional[List[Funding]] = Field(default_factory=list, description="""A funding source for a scientific data entity (base for JSON and DB representation).""")
-    key_photos: PicturePath = Field(..., description="""A set of paths to representative images of a piece of data.""")
-    cross_references: Optional[CrossReferences] = Field(None, description="""A set of cross-references to other databases and publications.""")
-    sample_type: Optional[str] = Field(None, description="""Type of sample imaged in a CryoET study.""")
-    sample_preparation: Optional[str] = Field(None, description="""Describes how the sample was prepared.""")
-    grid_preparation: Optional[str] = Field(None, description="""Describes Cryo-ET grid preparation.""")
-    other_setup: Optional[str] = Field(None, description="""Describes other setup not covered by sample preparation or grid preparation that may make this dataset unique in   the same publication.""")
-    organism: Optional[Organism] = Field(None, description="""The species from which the sample was derived.""")
-    tissue: Optional[Tissue] = Field(None, description="""The type of tissue from which the sample was derived.""")
-    cell_type: Optional[CellType] = Field(None, description="""The cell type from which the sample was derived.""")
-    cell_strain: Optional[CellStrain] = Field(None, description="""The strain or cell line from which the sample was derived.""")
-    cell_component: Optional[CellComponent] = Field(None, description="""The cellular component from which the sample was derived.""")
-    
-    
+
+    dataset_identifier: Optional[int] = Field(
+        None,
+        description="""An identifier for a CryoET dataset, assigned by the Data Portal. Used to identify the dataset as the directory  name in data tree.""",
+    )
+    dataset_title: Optional[str] = Field(
+        None, description="""Title of a CryoET dataset."""
+    )
+    dataset_description: Optional[str] = Field(
+        None,
+        description="""A short description of a CryoET dataset, similar to an abstract for a journal article or dataset.""",
+    )
+    dates: DateStamp = Field(
+        ...,
+        description="""A set of dates at which a data item was deposited, published and last modified.""",
+    )
+    authors: List[Author] = Field(
+        default_factory=list, description="""Author of a scientific data entity."""
+    )
+    funding: Optional[List[Funding]] = Field(
+        default_factory=list,
+        description="""A funding source for a scientific data entity (base for JSON and DB representation).""",
+    )
+    key_photos: PicturePath = Field(
+        ...,
+        description="""A set of paths to representative images of a piece of data.""",
+    )
+    cross_references: Optional[CrossReferences] = Field(
+        None,
+        description="""A set of cross-references to other databases and publications.""",
+    )
+    sample_type: Optional[str] = Field(
+        None, description="""Type of sample imaged in a CryoET study."""
+    )
+    sample_preparation: Optional[str] = Field(
+        None, description="""Describes how the sample was prepared."""
+    )
+    grid_preparation: Optional[str] = Field(
+        None, description="""Describes Cryo-ET grid preparation."""
+    )
+    other_setup: Optional[str] = Field(
+        None,
+        description="""Describes other setup not covered by sample preparation or grid preparation that may make this dataset unique in   the same publication.""",
+    )
+    organism: Optional[Organism] = Field(
+        None, description="""The species from which the sample was derived."""
+    )
+    tissue: Optional[Tissue] = Field(
+        None, description="""The type of tissue from which the sample was derived."""
+    )
+    cell_type: Optional[CellType] = Field(
+        None, description="""The cell type from which the sample was derived."""
+    )
+    cell_strain: Optional[CellStrain] = Field(
+        None,
+        description="""The strain or cell line from which the sample was derived.""",
+    )
+    cell_component: Optional[CellComponent] = Field(
+        None,
+        description="""The cellular component from which the sample was derived.""",
+    )
+
 
 class Camera(ConfiguredBaseModel):
     """
     The camera used to collect the tilt series.
     """
-    manufacturer: Optional[str] = Field(None, description="""Name of the camera manufacturer""")
+
+    manufacturer: Optional[str] = Field(
+        None, description="""Name of the camera manufacturer"""
+    )
     model: Optional[str] = Field(None, description="""Camera model name""")
-    
-    
+
 
 class Microscope(ConfiguredBaseModel):
     """
     The microscope used to collect the tilt series.
     """
+
     manufacturer: Optional[str] = Field(None)
     model: Optional[str] = Field(None)
-    
-    
+
 
 class MicroscopeOpticalSetup(ConfiguredBaseModel):
     """
     The optical setup of the microscope used to collect the tilt series.
     """
-    energy_filter: Optional[str] = Field(None, description="""Energy filter setup used""")
-    phase_plate: Optional[str] = Field(None, description="""Phase plate configuration""")
-    image_corrector: Optional[str] = Field(None, description="""Image corrector setup""")
-    
-    
+
+    energy_filter: Optional[str] = Field(
+        None, description="""Energy filter setup used"""
+    )
+    phase_plate: Optional[str] = Field(
+        None, description="""Phase plate configuration"""
+    )
+    image_corrector: Optional[str] = Field(
+        None, description="""Image corrector setup"""
+    )
+
 
 class TiltRange(ConfiguredBaseModel):
     """
     The range of tilt angles in the tilt series.
     """
+
     min: Optional[float] = Field(None, description="""Minimal tilt angle in degrees""")
     max: Optional[float] = Field(None, description="""Maximal tilt angle in degrees""")
-    
-    
+
 
 class TiltSeries(ConfiguredBaseModel):
     """
     Metadata describing a tilt series.
     """
-    acceleration_voltage: Optional[int] = Field(None, description="""Electron Microscope Accelerator voltage in volts""")
-    spherical_aberration_constant: Optional[float] = Field(None, description="""Spherical Aberration Constant of the objective lens in millimeters""")
-    microscope_additional_info: Optional[str] = Field(None, description="""Other microscope optical setup information, in addition to energy filter, phase plate and image corrector""")
-    tilt_axis: Optional[float] = Field(None, description="""Rotation angle in degrees""")
+
+    acceleration_voltage: Optional[int] = Field(
+        None, description="""Electron Microscope Accelerator voltage in volts"""
+    )
+    spherical_aberration_constant: Optional[float] = Field(
+        None,
+        description="""Spherical Aberration Constant of the objective lens in millimeters""",
+    )
+    microscope_additional_info: Optional[str] = Field(
+        None,
+        description="""Other microscope optical setup information, in addition to energy filter, phase plate and image corrector""",
+    )
+    tilt_axis: Optional[float] = Field(
+        None, description="""Rotation angle in degrees"""
+    )
     tilt_step: Optional[float] = Field(None, description="""Tilt step in degrees""")
-    tilting_scheme: Optional[str] = Field(None, description="""The order of stage tilting during acquisition of the data""")
-    total_flux: Optional[float] = Field(None, description="""Number of Electrons reaching the specimen in a square Angstrom area for the entire tilt series""")
-    data_acquisition_software: Optional[str] = Field(None, description="""Software used to collect data""")
-    binning_from_frames: Optional[float] = Field(None, description="""Describes the binning factor from frames to tilt series file""")
-    tilt_series_quality: Optional[int] = Field(None, description="""Author assessment of tilt series quality within the dataset (1-5, 5 is best)""")
-    pixel_spacing: Optional[float] = Field(None, description="""Pixel spacing for the tilt series""")
-    aligned_tiltseries_binning: Optional[int] = Field(None, description="""Binning factor of the aligned tilt series""")
-    frames_count: Optional[int] = Field(None, description="""Number of frames associated with this tiltseries""")
-    camera: Optional[Camera] = Field(None, description="""The camera used to collect the tilt series.""")
-    microscope: Optional[Microscope] = Field(None, description="""The microscope used to collect the tilt series.""")
-    microscope_optical_setup: Optional[MicroscopeOpticalSetup] = Field(None, description="""The optical setup of the microscope used to collect the tilt series.""")
-    tilt_range: Optional[TiltRange] = Field(None, description="""The range of tilt angles in the tilt series.""")
-    
-    
+    tilting_scheme: Optional[str] = Field(
+        None,
+        description="""The order of stage tilting during acquisition of the data""",
+    )
+    total_flux: Optional[float] = Field(
+        None,
+        description="""Number of Electrons reaching the specimen in a square Angstrom area for the entire tilt series""",
+    )
+    data_acquisition_software: Optional[str] = Field(
+        None, description="""Software used to collect data"""
+    )
+    binning_from_frames: Optional[float] = Field(
+        None,
+        description="""Describes the binning factor from frames to tilt series file""",
+    )
+    tilt_series_quality: Optional[int] = Field(
+        None,
+        description="""Author assessment of tilt series quality within the dataset (1-5, 5 is best)""",
+    )
+    pixel_spacing: Optional[float] = Field(
+        None, description="""Pixel spacing for the tilt series"""
+    )
+    aligned_tiltseries_binning: Optional[int] = Field(
+        None, description="""Binning factor of the aligned tilt series"""
+    )
+    frames_count: Optional[int] = Field(
+        None, description="""Number of frames associated with this tiltseries"""
+    )
+    camera: Optional[Camera] = Field(
+        None, description="""The camera used to collect the tilt series."""
+    )
+    microscope: Optional[Microscope] = Field(
+        None, description="""The microscope used to collect the tilt series."""
+    )
+    microscope_optical_setup: Optional[MicroscopeOpticalSetup] = Field(
+        None,
+        description="""The optical setup of the microscope used to collect the tilt series.""",
+    )
+    tilt_range: Optional[TiltRange] = Field(
+        None, description="""The range of tilt angles in the tilt series."""
+    )
+
 
 class TomogramSize(ConfiguredBaseModel):
     """
     The size of a tomogram in voxels in each dimension.
     """
-    x: Optional[int] = Field(None, description="""Number of pixels in the 3D data fast axis""")
-    y: Optional[int] = Field(None, description="""Number of pixels in the 3D data medium axis""")
-    z: Optional[int] = Field(None, description="""Number of pixels in the 3D data slow axis.  This is the image projection direction at zero stage tilt""")
-    
-    
+
+    x: Optional[int] = Field(
+        None, description="""Number of pixels in the 3D data fast axis"""
+    )
+    y: Optional[int] = Field(
+        None, description="""Number of pixels in the 3D data medium axis"""
+    )
+    z: Optional[int] = Field(
+        None,
+        description="""Number of pixels in the 3D data slow axis.  This is the image projection direction at zero stage tilt""",
+    )
+
 
 class TomogramOffset(ConfiguredBaseModel):
     """
     The offset of a tomogram in voxels in each dimension relative to the canonical tomogram.
     """
+
     x: Optional[str] = Field(None)
     y: Optional[str] = Field(None)
     z: Optional[str] = Field(None)
-    
-    
+
 
 class Tomogram(PicturedEntity, AuthoredEntity):
     """
     Metadata describing a tomogram.
     """
-    voxel_spacing: Optional[float] = Field(None, description="""Voxel spacing equal in all three axes in angstroms""")
-    fiducial_alignment_status: Optional[FiducialAlignmentStatusEnum] = Field(None, description="""Whether the tomographic alignment was computed based on fiducial markers.""")
-    ctf_corrected: Optional[bool] = Field(None, description="""Whether this tomogram is CTF corrected""")
-    reconstruction_method: Optional[str] = Field(None, description="""Describe reconstruction method (Weighted back-projection, SART, SIRT)""")
-    reconstruction_software: Optional[str] = Field(None, description="""Name of software used for reconstruction""")
-    processing: Optional[str] = Field(None, description="""Describe additional processing used to derive the tomogram""")
-    processing_software: Optional[str] = Field(None, description="""Processing software used to derive the tomogram""")
-    tomogram_version: Optional[str] = Field(None, description="""Version of tomogram using the same software and post-processing. Version of tomogram using the same software and post-processing. This will be presented as the latest version""")
-    affine_transformation_matrix: Optional[str] = Field(None, description="""The flip or rotation transformation of this author submitted tomogram is indicated here""")
-    size: Optional[TomogramSize] = Field(None, description="""The size of a tomogram in voxels in each dimension.""")
-    offset: Optional[TomogramOffset] = Field(None, description="""The offset of a tomogram in voxels in each dimension relative to the canonical tomogram.""")
-    authors: List[Author] = Field(default_factory=list, description="""Author of a scientific data entity.""")
-    key_photos: PicturePath = Field(..., description="""A set of paths to representative images of a piece of data.""")
-    
-    
+
+    voxel_spacing: Optional[float] = Field(
+        None, description="""Voxel spacing equal in all three axes in angstroms"""
+    )
+    fiducial_alignment_status: Optional[FiducialAlignmentStatusEnum] = Field(
+        None,
+        description="""Whether the tomographic alignment was computed based on fiducial markers.""",
+    )
+    ctf_corrected: Optional[bool] = Field(
+        None, description="""Whether this tomogram is CTF corrected"""
+    )
+    reconstruction_method: Optional[str] = Field(
+        None,
+        description="""Describe reconstruction method (Weighted back-projection, SART, SIRT)""",
+    )
+    reconstruction_software: Optional[str] = Field(
+        None, description="""Name of software used for reconstruction"""
+    )
+    processing: Optional[str] = Field(
+        None,
+        description="""Describe additional processing used to derive the tomogram""",
+    )
+    processing_software: Optional[str] = Field(
+        None, description="""Processing software used to derive the tomogram"""
+    )
+    tomogram_version: Optional[str] = Field(
+        None,
+        description="""Version of tomogram using the same software and post-processing. Version of tomogram using the same software and post-processing. This will be presented as the latest version""",
+    )
+    affine_transformation_matrix: Optional[str] = Field(
+        None,
+        description="""The flip or rotation transformation of this author submitted tomogram is indicated here""",
+    )
+    size: Optional[TomogramSize] = Field(
+        None, description="""The size of a tomogram in voxels in each dimension."""
+    )
+    offset: Optional[TomogramOffset] = Field(
+        None,
+        description="""The offset of a tomogram in voxels in each dimension relative to the canonical tomogram.""",
+    )
+    authors: List[Author] = Field(
+        default_factory=list, description="""Author of a scientific data entity."""
+    )
+    key_photos: PicturePath = Field(
+        ...,
+        description="""A set of paths to representative images of a piece of data.""",
+    )
+
 
 class AnnotationFile(ConfiguredBaseModel):
     """
     Metadata describing a file containing an annotation.
     """
+
     format: Optional[str] = Field(None, description="""File format for this file""")
-    shape: Optional[str] = Field(None, description="""Describe whether this is a Point, OrientedPoint, or SegmentationMask file""")
-    path: Optional[str] = Field(None, description="""Path to the annotation file relative to the dataset root.""")
-    is_visualization_default: Optional[bool] = Field(None, description="""This annotation will be rendered in neuroglancer by default.""")
-    
-    
+    shape: Optional[str] = Field(
+        None,
+        description="""Describe whether this is a Point, OrientedPoint, or SegmentationMask file""",
+    )
+    path: Optional[str] = Field(
+        None,
+        description="""Path to the annotation file relative to the dataset root.""",
+    )
+    is_visualization_default: Optional[bool] = Field(
+        None,
+        description="""This annotation will be rendered in neuroglancer by default.""",
+    )
+
 
 class AnnotationConfidence(ConfiguredBaseModel):
     """
     Metadata describing the confidence of an annotation.
     """
-    precision: Optional[float] = Field(None, description="""Describe the confidence level of the annotation. Precision is defined as the % of annotation objects being true positive""")
-    recall: Optional[float] = Field(None, description="""Describe the confidence level of the annotation. Recall is defined as the % of true positives being annotated correctly""")
-    ground_truth_used: Optional[str] = Field(None, description="""Annotation filename used as ground truth for precision and recall""")
-    
-    
+
+    precision: Optional[float] = Field(
+        None,
+        description="""Describe the confidence level of the annotation. Precision is defined as the % of annotation objects being true positive""",
+    )
+    recall: Optional[float] = Field(
+        None,
+        description="""Describe the confidence level of the annotation. Recall is defined as the % of true positives being annotated correctly""",
+    )
+    ground_truth_used: Optional[str] = Field(
+        None,
+        description="""Annotation filename used as ground truth for precision and recall""",
+    )
+
 
 class AnnotationObject(ConfiguredBaseModel):
     """
     Metadata describing the object being annotated.
     """
+
     id: Optional[str] = Field(None)
     name: Optional[str] = Field(None)
-    description: Optional[str] = Field(None, description="""A textual description of the annotation object, can be a longer description to include additional information not covered by the Annotation object name and state.""")
-    state: Optional[str] = Field(None, description="""Molecule state annotated (e.g. open, closed)""")
-    
-    
+    description: Optional[str] = Field(
+        None,
+        description="""A textual description of the annotation object, can be a longer description to include additional information not covered by the Annotation object name and state.""",
+    )
+    state: Optional[str] = Field(
+        None, description="""Molecule state annotated (e.g. open, closed)"""
+    )
+
 
 class Annotation(AnnotatoredEntity, DatestampedEntity):
     """
     Metadata describing an annotation.
     """
-    annotation_method: Optional[str] = Field(None, description="""Describe how the annotation is made (e.g. Manual, crYoLO, Positive Unlabeled Learning, template matching)""")
-    annotation_method_type: Optional[AnnotationMethodTypeEnum] = Field(None, description="""Classification of the annotation method based on supervision.""")
-    annotation_publications: Optional[str] = Field(None, description="""DOIs for publications that describe the dataset. Use a comma to separate multiple DOIs.""")
-    annotation_software: Optional[str] = Field(None, description="""Software used for generating this annotation""")
-    ground_truth_status: Optional[bool] = Field(None, description="""Whether an annotation is considered ground truth, as determined by the annotator.""")
-    object_count: Optional[int] = Field(None, description="""Number of objects identified""")
-    is_curator_recommended: Optional[bool] = Field(None, description="""This annotation is recommended by the curator to be preferred for this object type.""")
-    files: Optional[List[AnnotationFile]] = Field(default_factory=list, description="""Metadata describing a file containing an annotation.""")
-    confidence: Optional[AnnotationConfidence] = Field(None, description="""Metadata describing the confidence of an annotation.""")
-    annotation_object: Optional[AnnotationObject] = Field(None, description="""Metadata describing the object being annotated.""")
-    dates: DateStamp = Field(..., description="""A set of dates at which a data item was deposited, published and last modified.""")
-    authors: List[Annotator] = Field(default_factory=list, description="""Annotator of a scientific data entity.""")
-    
-    
+
+    annotation_method: Optional[str] = Field(
+        None,
+        description="""Describe how the annotation is made (e.g. Manual, crYoLO, Positive Unlabeled Learning, template matching)""",
+    )
+    annotation_method_type: Optional[AnnotationMethodTypeEnum] = Field(
+        None,
+        description="""Classification of the annotation method based on supervision.""",
+    )
+    annotation_publications: Optional[str] = Field(
+        None,
+        description="""DOIs for publications that describe the dataset. Use a comma to separate multiple DOIs.""",
+    )
+    annotation_software: Optional[str] = Field(
+        None, description="""Software used for generating this annotation"""
+    )
+    ground_truth_status: Optional[bool] = Field(
+        None,
+        description="""Whether an annotation is considered ground truth, as determined by the annotator.""",
+    )
+    object_count: Optional[int] = Field(
+        None, description="""Number of objects identified"""
+    )
+    is_curator_recommended: Optional[bool] = Field(
+        None,
+        description="""This annotation is recommended by the curator to be preferred for this object type.""",
+    )
+    files: Optional[List[AnnotationFile]] = Field(
+        default_factory=list,
+        description="""Metadata describing a file containing an annotation.""",
+    )
+    confidence: Optional[AnnotationConfidence] = Field(
+        None, description="""Metadata describing the confidence of an annotation."""
+    )
+    annotation_object: Optional[AnnotationObject] = Field(
+        None, description="""Metadata describing the object being annotated."""
+    )
+    dates: DateStamp = Field(
+        ...,
+        description="""A set of dates at which a data item was deposited, published and last modified.""",
+    )
+    authors: List[Annotator] = Field(
+        default_factory=list, description="""Annotator of a scientific data entity."""
+    )
+
 
 class CrossReferences(ConfiguredBaseModel):
     """
     A set of cross-references to other databases and publications.
     """
-    dataset_publications: Optional[str] = Field(None, description="""Comma-separated list of DOIs for publications associated with the dataset.""")
-    related_database_entries: Optional[str] = Field(None, description="""Comma-separated list of related database entries for the dataset.""")
-    related_database_links: Optional[str] = Field(None, description="""Comma-separated list of related database links for the dataset.""")
-    dataset_citations: Optional[str] = Field(None, description="""Comma-separated list of DOIs for publications citing the dataset.""")
-    
-    
+
+    dataset_publications: Optional[str] = Field(
+        None,
+        description="""Comma-separated list of DOIs for publications associated with the dataset.""",
+    )
+    related_database_entries: Optional[str] = Field(
+        None,
+        description="""Comma-separated list of related database entries for the dataset.""",
+    )
+    related_database_links: Optional[str] = Field(
+        None,
+        description="""Comma-separated list of related database links for the dataset.""",
+    )
+    dataset_citations: Optional[str] = Field(
+        None,
+        description="""Comma-separated list of DOIs for publications citing the dataset.""",
+    )
 
 
 # Model rebuild
@@ -509,4 +792,3 @@ AnnotationConfidence.model_rebuild()
 AnnotationObject.model_rebuild()
 Annotation.model_rebuild()
 CrossReferences.model_rebuild()
-

--- a/schema/v1.1.0/metadata_models.py
+++ b/schema/v1.1.0/metadata_models.py
@@ -1,0 +1,512 @@
+from __future__ import annotations
+from datetime import datetime, date
+from enum import Enum
+
+from decimal import Decimal
+from typing import List, Dict, Optional, Any, Union
+from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
+import re
+import sys
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+
+metamodel_version = "None"
+version = "1.1.0"
+
+class ConfiguredBaseModel(BaseModel):
+    model_config = ConfigDict(
+        validate_assignment=True,
+        validate_default=True,
+        extra = 'forbid',
+        arbitrary_types_allowed=True,
+        use_enum_values = True)
+
+    pass
+
+        
+
+class SampleTypeEnum(str, Enum):
+    """
+    Type of sample imaged in a CryoET study.
+    """
+    # Tomographic data of whole cells or cell sections.
+    cell = "cell"
+    # Tomographic data of tissue sections.
+    tissue = "tissue"
+    # Tomographic data of sections through multicellular organisms.
+    organism = "organism"
+    # Tomographic data of purified organelles.
+    organelle = "organelle"
+    # Tomographic data of purified viruses or VLPs.
+    virus = "virus"
+    # Tomographic data of in vitro reconstituted systems or mixtures of proteins.
+    in_vitro = "in_vitro"
+    # Simulated tomographic data.
+    in_silico = "in_silico"
+    # Other type of sample.
+    other = "other"
+    
+    
+
+class FiducialAlignmentStatusEnum(str, Enum):
+    """
+    Fiducial Alignment method
+    """
+    # Alignment computed based on fiducial markers
+    FIDUCIAL = "FIDUCIAL"
+    # Alignment computed without fiducial markers
+    NON_FIDUCIAL = "NON_FIDUCIAL"
+    
+    
+
+class TomogramTypeEnum(str, Enum):
+    """
+    Tomogram type
+    """
+    # Canonical tomogram (basis geometry for all annotations)
+    CANONICAL = "CANONICAL"
+    
+    
+
+class AnnotationMethodTypeEnum(str, Enum):
+    """
+    Describes how the annotations were generated.
+    """
+    # Annotations were generated manually.
+    manual = "manual"
+    # Annotations were generated semi-automatically.
+    automated = "automated"
+    # Annotations were generated automatically.
+    hybrid = "hybrid"
+    
+    
+
+class AnnotationShapeEnum(str, Enum):
+    """
+    Annotation shape types available on the data portal.
+    """
+    # Annotations were generated manually.
+    Point = "Point"
+    # Annotations were generated semi-automatically.
+    OrientedPoint = "OrientedPoint"
+    # Annotations were generated automatically.
+    SegmentationMask = "SegmentationMask"
+    
+    
+
+class PicturePath(ConfiguredBaseModel):
+    """
+    A set of paths to representative images of a piece of data.
+    """
+    snapshot: Optional[str] = Field(None, description="""Path to the dataset preview image relative to the dataset directory root.""")
+    thumbnail: Optional[str] = Field(None, description="""Path to the thumbnail of preview image relative to the dataset directory root.""")
+    
+    
+
+class Author(ConfiguredBaseModel):
+    """
+    Author of a scientific data entity.
+    """
+    name: Optional[str] = Field(None, description="""The full name of the author.""")
+    email: Optional[str] = Field(None, description="""The email address of the author.""")
+    affiliation_name: Optional[str] = Field(None, description="""The name of the author's affiliation.""")
+    affiliation_address: Optional[str] = Field(None, description="""The address of the author's affiliation.""")
+    affiliation_identifier: Optional[str] = Field(None, description="""A Research Organization Registry (ROR) identifier.""")
+    is_corresponding: Optional[bool] = Field(None, description="""Whether the author is a corresponding author.""")
+    is_primary_author: Optional[bool] = Field(None, description="""Whether the author is a primary author.""")
+    ORCID: Optional[str] = Field(None, description="""A unique, persistent identifier for researchers, provided by ORCID.""")
+    
+    
+    @field_validator('affiliation_identifier')
+    def pattern_affiliation_identifier(cls, v):
+        pattern=re.compile(r"^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$")
+        if isinstance(v,list):
+            for element in v:
+                if not pattern.match(element):
+                    raise ValueError(f"Invalid affiliation_identifier format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid affiliation_identifier format: {v}")
+        return v
+    
+    @field_validator('ORCID')
+    def pattern_ORCID(cls, v):
+        pattern=re.compile(r"[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$")
+        if isinstance(v,list):
+            for element in v:
+                if not pattern.match(element):
+                    raise ValueError(f"Invalid ORCID format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid ORCID format: {v}")
+        return v
+    
+
+class Annotator(ConfiguredBaseModel):
+    """
+    Annotator of a scientific data entity.
+    """
+    name: Optional[str] = Field(None)
+    email: Optional[str] = Field(None)
+    affiliation_name: Optional[str] = Field(None)
+    affiliation_address: Optional[str] = Field(None)
+    affiliation_identifier: Optional[str] = Field(None)
+    is_corresponding: Optional[str] = Field(None)
+    is_primary_annotator: Optional[bool] = Field(None, description="""Whether the author is a primary author.""")
+    ORCID: Optional[str] = Field(None)
+    
+    
+
+class Funding(ConfiguredBaseModel):
+    """
+    A funding source for a scientific data entity (base for JSON and DB representation).
+    """
+    funding_agency_name: Optional[str] = Field(None, description="""The name of the funding source.""")
+    grant_id: Optional[str] = Field(None, description="""Grant identifier provided by the funding agency""")
+    
+    
+
+class DateStamp(ConfiguredBaseModel):
+    """
+    A set of dates at which a data item was deposited, published and last modified.
+    """
+    deposition_date: date = Field(..., description="""The date a data item was received by the cryoET data portal.""")
+    release_date: date = Field(..., description="""The date a data item was received by the cryoET data portal.""")
+    last_modified_date: date = Field(..., description="""The date a piece of data was last modified on the cryoET data portal.""")
+    
+    
+
+class DatestampedEntity(ConfiguredBaseModel):
+    """
+    An entity with associated deposition, release and last modified dates.
+    """
+    dates: DateStamp = Field(..., description="""A set of dates at which a data item was deposited, published and last modified.""")
+    
+    
+
+class AuthoredEntity(ConfiguredBaseModel):
+    """
+    An entity with associated authors.
+    """
+    authors: List[Author] = Field(default_factory=list, description="""Author of a scientific data entity.""")
+    
+    
+
+class AnnotatoredEntity(ConfiguredBaseModel):
+    """
+    An entity with associated annotation authors.
+    """
+    authors: List[Annotator] = Field(default_factory=list, description="""Annotator of a scientific data entity.""")
+    
+    
+
+class FundedEntity(ConfiguredBaseModel):
+    """
+    An entity with associated funding sources.
+    """
+    funding: Optional[List[Funding]] = Field(default_factory=list, description="""A funding source for a scientific data entity (base for JSON and DB representation).""")
+    
+    
+
+class CrossReferencedEntity(ConfiguredBaseModel):
+    """
+    An entity with associated cross-references to other databases and publications.
+    """
+    cross_references: Optional[CrossReferences] = Field(None, description="""A set of cross-references to other databases and publications.""")
+    
+    
+
+class PicturedEntity(ConfiguredBaseModel):
+    """
+    An entity with associated preview images.
+    """
+    key_photos: PicturePath = Field(..., description="""A set of paths to representative images of a piece of data.""")
+    
+    
+
+class Organism(ConfiguredBaseModel):
+    """
+    The species from which the sample was derived.
+    """
+    name: Optional[str] = Field(None)
+    taxonomy_id: Optional[str] = Field(None, description="""NCBI taxonomy identifier for the organism, e.g. 9606""")
+    
+    
+
+class Tissue(ConfiguredBaseModel):
+    """
+    The type of tissue from which the sample was derived.
+    """
+    name: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""The UBERON identifier for the tissue.""")
+    
+    
+
+class CellType(ConfiguredBaseModel):
+    """
+    The cell type from which the sample was derived.
+    """
+    name: Optional[str] = Field(None)
+    id: Optional[str] = Field(None)
+    
+    
+
+class CellStrain(ConfiguredBaseModel):
+    """
+    The strain or cell line from which the sample was derived.
+    """
+    name: Optional[str] = Field(None)
+    id: Optional[str] = Field(None)
+    
+    
+
+class CellComponent(ConfiguredBaseModel):
+    """
+    The cellular component from which the sample was derived.
+    """
+    name: Optional[str] = Field(None)
+    id: Optional[str] = Field(None)
+    
+    
+
+class ExperimentalMetadata(ConfiguredBaseModel):
+    """
+    Metadata describing sample and sample preparation methods used in a cryoET dataset.
+    """
+    sample_type: Optional[SampleTypeEnum] = Field(None, description="""Type of sample imaged in a CryoET study.""")
+    sample_preparation: Optional[str] = Field(None, description="""Describes how the sample was prepared.""")
+    grid_preparation: Optional[str] = Field(None, description="""Describes Cryo-ET grid preparation.""")
+    other_setup: Optional[str] = Field(None, description="""Describes other setup not covered by sample preparation or grid preparation that may make this dataset unique in   the same publication.""")
+    organism: Optional[Organism] = Field(None, description="""The species from which the sample was derived.""")
+    tissue: Optional[Tissue] = Field(None, description="""The type of tissue from which the sample was derived.""")
+    cell_type: Optional[CellType] = Field(None, description="""The cell type from which the sample was derived.""")
+    cell_strain: Optional[CellStrain] = Field(None, description="""The strain or cell line from which the sample was derived.""")
+    cell_component: Optional[CellComponent] = Field(None, description="""The cellular component from which the sample was derived.""")
+    
+    
+
+class Dataset(ExperimentalMetadata, PicturedEntity, CrossReferencedEntity, FundedEntity, AuthoredEntity, DatestampedEntity):
+    """
+    High-level description of a cryoET dataset.
+    """
+    dataset_identifier: Optional[int] = Field(None, description="""An identifier for a CryoET dataset, assigned by the Data Portal. Used to identify the dataset as the directory  name in data tree.""")
+    dataset_title: Optional[str] = Field(None, description="""Title of a CryoET dataset.""")
+    dataset_description: Optional[str] = Field(None, description="""A short description of a CryoET dataset, similar to an abstract for a journal article or dataset.""")
+    dates: DateStamp = Field(..., description="""A set of dates at which a data item was deposited, published and last modified.""")
+    authors: List[Author] = Field(default_factory=list, description="""Author of a scientific data entity.""")
+    funding: Optional[List[Funding]] = Field(default_factory=list, description="""A funding source for a scientific data entity (base for JSON and DB representation).""")
+    key_photos: PicturePath = Field(..., description="""A set of paths to representative images of a piece of data.""")
+    cross_references: Optional[CrossReferences] = Field(None, description="""A set of cross-references to other databases and publications.""")
+    sample_type: Optional[str] = Field(None, description="""Type of sample imaged in a CryoET study.""")
+    sample_preparation: Optional[str] = Field(None, description="""Describes how the sample was prepared.""")
+    grid_preparation: Optional[str] = Field(None, description="""Describes Cryo-ET grid preparation.""")
+    other_setup: Optional[str] = Field(None, description="""Describes other setup not covered by sample preparation or grid preparation that may make this dataset unique in   the same publication.""")
+    organism: Optional[Organism] = Field(None, description="""The species from which the sample was derived.""")
+    tissue: Optional[Tissue] = Field(None, description="""The type of tissue from which the sample was derived.""")
+    cell_type: Optional[CellType] = Field(None, description="""The cell type from which the sample was derived.""")
+    cell_strain: Optional[CellStrain] = Field(None, description="""The strain or cell line from which the sample was derived.""")
+    cell_component: Optional[CellComponent] = Field(None, description="""The cellular component from which the sample was derived.""")
+    
+    
+
+class Camera(ConfiguredBaseModel):
+    """
+    The camera used to collect the tilt series.
+    """
+    manufacturer: Optional[str] = Field(None, description="""Name of the camera manufacturer""")
+    model: Optional[str] = Field(None, description="""Camera model name""")
+    
+    
+
+class Microscope(ConfiguredBaseModel):
+    """
+    The microscope used to collect the tilt series.
+    """
+    manufacturer: Optional[str] = Field(None)
+    model: Optional[str] = Field(None)
+    
+    
+
+class MicroscopeOpticalSetup(ConfiguredBaseModel):
+    """
+    The optical setup of the microscope used to collect the tilt series.
+    """
+    energy_filter: Optional[str] = Field(None, description="""Energy filter setup used""")
+    phase_plate: Optional[str] = Field(None, description="""Phase plate configuration""")
+    image_corrector: Optional[str] = Field(None, description="""Image corrector setup""")
+    
+    
+
+class TiltRange(ConfiguredBaseModel):
+    """
+    The range of tilt angles in the tilt series.
+    """
+    min: Optional[float] = Field(None, description="""Minimal tilt angle in degrees""")
+    max: Optional[float] = Field(None, description="""Maximal tilt angle in degrees""")
+    
+    
+
+class TiltSeries(ConfiguredBaseModel):
+    """
+    Metadata describing a tilt series.
+    """
+    acceleration_voltage: Optional[int] = Field(None, description="""Electron Microscope Accelerator voltage in volts""")
+    spherical_aberration_constant: Optional[float] = Field(None, description="""Spherical Aberration Constant of the objective lens in millimeters""")
+    microscope_additional_info: Optional[str] = Field(None, description="""Other microscope optical setup information, in addition to energy filter, phase plate and image corrector""")
+    tilt_axis: Optional[float] = Field(None, description="""Rotation angle in degrees""")
+    tilt_step: Optional[float] = Field(None, description="""Tilt step in degrees""")
+    tilting_scheme: Optional[str] = Field(None, description="""The order of stage tilting during acquisition of the data""")
+    total_flux: Optional[float] = Field(None, description="""Number of Electrons reaching the specimen in a square Angstrom area for the entire tilt series""")
+    data_acquisition_software: Optional[str] = Field(None, description="""Software used to collect data""")
+    binning_from_frames: Optional[float] = Field(None, description="""Describes the binning factor from frames to tilt series file""")
+    tilt_series_quality: Optional[int] = Field(None, description="""Author assessment of tilt series quality within the dataset (1-5, 5 is best)""")
+    pixel_spacing: Optional[float] = Field(None, description="""Pixel spacing for the tilt series""")
+    aligned_tiltseries_binning: Optional[int] = Field(None, description="""Binning factor of the aligned tilt series""")
+    frames_count: Optional[int] = Field(None, description="""Number of frames associated with this tiltseries""")
+    camera: Optional[Camera] = Field(None, description="""The camera used to collect the tilt series.""")
+    microscope: Optional[Microscope] = Field(None, description="""The microscope used to collect the tilt series.""")
+    microscope_optical_setup: Optional[MicroscopeOpticalSetup] = Field(None, description="""The optical setup of the microscope used to collect the tilt series.""")
+    tilt_range: Optional[TiltRange] = Field(None, description="""The range of tilt angles in the tilt series.""")
+    
+    
+
+class TomogramSize(ConfiguredBaseModel):
+    """
+    The size of a tomogram in voxels in each dimension.
+    """
+    x: Optional[int] = Field(None, description="""Number of pixels in the 3D data fast axis""")
+    y: Optional[int] = Field(None, description="""Number of pixels in the 3D data medium axis""")
+    z: Optional[int] = Field(None, description="""Number of pixels in the 3D data slow axis.  This is the image projection direction at zero stage tilt""")
+    
+    
+
+class TomogramOffset(ConfiguredBaseModel):
+    """
+    The offset of a tomogram in voxels in each dimension relative to the canonical tomogram.
+    """
+    x: Optional[str] = Field(None)
+    y: Optional[str] = Field(None)
+    z: Optional[str] = Field(None)
+    
+    
+
+class Tomogram(PicturedEntity, AuthoredEntity):
+    """
+    Metadata describing a tomogram.
+    """
+    voxel_spacing: Optional[float] = Field(None, description="""Voxel spacing equal in all three axes in angstroms""")
+    fiducial_alignment_status: Optional[FiducialAlignmentStatusEnum] = Field(None, description="""Whether the tomographic alignment was computed based on fiducial markers.""")
+    ctf_corrected: Optional[bool] = Field(None, description="""Whether this tomogram is CTF corrected""")
+    reconstruction_method: Optional[str] = Field(None, description="""Describe reconstruction method (Weighted back-projection, SART, SIRT)""")
+    reconstruction_software: Optional[str] = Field(None, description="""Name of software used for reconstruction""")
+    processing: Optional[str] = Field(None, description="""Describe additional processing used to derive the tomogram""")
+    processing_software: Optional[str] = Field(None, description="""Processing software used to derive the tomogram""")
+    tomogram_version: Optional[str] = Field(None, description="""Version of tomogram using the same software and post-processing. Version of tomogram using the same software and post-processing. This will be presented as the latest version""")
+    affine_transformation_matrix: Optional[str] = Field(None, description="""The flip or rotation transformation of this author submitted tomogram is indicated here""")
+    size: Optional[TomogramSize] = Field(None, description="""The size of a tomogram in voxels in each dimension.""")
+    offset: Optional[TomogramOffset] = Field(None, description="""The offset of a tomogram in voxels in each dimension relative to the canonical tomogram.""")
+    authors: List[Author] = Field(default_factory=list, description="""Author of a scientific data entity.""")
+    key_photos: PicturePath = Field(..., description="""A set of paths to representative images of a piece of data.""")
+    
+    
+
+class AnnotationFile(ConfiguredBaseModel):
+    """
+    Metadata describing a file containing an annotation.
+    """
+    format: Optional[str] = Field(None, description="""File format for this file""")
+    shape: Optional[str] = Field(None, description="""Describe whether this is a Point, OrientedPoint, or SegmentationMask file""")
+    path: Optional[str] = Field(None, description="""Path to the annotation file relative to the dataset root.""")
+    is_visualization_default: Optional[bool] = Field(None, description="""This annotation will be rendered in neuroglancer by default.""")
+    
+    
+
+class AnnotationConfidence(ConfiguredBaseModel):
+    """
+    Metadata describing the confidence of an annotation.
+    """
+    precision: Optional[float] = Field(None, description="""Describe the confidence level of the annotation. Precision is defined as the % of annotation objects being true positive""")
+    recall: Optional[float] = Field(None, description="""Describe the confidence level of the annotation. Recall is defined as the % of true positives being annotated correctly""")
+    ground_truth_used: Optional[str] = Field(None, description="""Annotation filename used as ground truth for precision and recall""")
+    
+    
+
+class AnnotationObject(ConfiguredBaseModel):
+    """
+    Metadata describing the object being annotated.
+    """
+    id: Optional[str] = Field(None)
+    name: Optional[str] = Field(None)
+    description: Optional[str] = Field(None, description="""A textual description of the annotation object, can be a longer description to include additional information not covered by the Annotation object name and state.""")
+    state: Optional[str] = Field(None, description="""Molecule state annotated (e.g. open, closed)""")
+    
+    
+
+class Annotation(AnnotatoredEntity, DatestampedEntity):
+    """
+    Metadata describing an annotation.
+    """
+    annotation_method: Optional[str] = Field(None, description="""Describe how the annotation is made (e.g. Manual, crYoLO, Positive Unlabeled Learning, template matching)""")
+    annotation_method_type: Optional[AnnotationMethodTypeEnum] = Field(None, description="""Classification of the annotation method based on supervision.""")
+    annotation_publications: Optional[str] = Field(None, description="""DOIs for publications that describe the dataset. Use a comma to separate multiple DOIs.""")
+    annotation_software: Optional[str] = Field(None, description="""Software used for generating this annotation""")
+    ground_truth_status: Optional[bool] = Field(None, description="""Whether an annotation is considered ground truth, as determined by the annotator.""")
+    object_count: Optional[int] = Field(None, description="""Number of objects identified""")
+    is_curator_recommended: Optional[bool] = Field(None, description="""This annotation is recommended by the curator to be preferred for this object type.""")
+    files: Optional[List[AnnotationFile]] = Field(default_factory=list, description="""Metadata describing a file containing an annotation.""")
+    confidence: Optional[AnnotationConfidence] = Field(None, description="""Metadata describing the confidence of an annotation.""")
+    annotation_object: Optional[AnnotationObject] = Field(None, description="""Metadata describing the object being annotated.""")
+    dates: DateStamp = Field(..., description="""A set of dates at which a data item was deposited, published and last modified.""")
+    authors: List[Annotator] = Field(default_factory=list, description="""Annotator of a scientific data entity.""")
+    
+    
+
+class CrossReferences(ConfiguredBaseModel):
+    """
+    A set of cross-references to other databases and publications.
+    """
+    dataset_publications: Optional[str] = Field(None, description="""Comma-separated list of DOIs for publications associated with the dataset.""")
+    related_database_entries: Optional[str] = Field(None, description="""Comma-separated list of related database entries for the dataset.""")
+    related_database_links: Optional[str] = Field(None, description="""Comma-separated list of related database links for the dataset.""")
+    dataset_citations: Optional[str] = Field(None, description="""Comma-separated list of DOIs for publications citing the dataset.""")
+    
+    
+
+
+# Model rebuild
+# see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
+PicturePath.model_rebuild()
+Author.model_rebuild()
+Annotator.model_rebuild()
+Funding.model_rebuild()
+DateStamp.model_rebuild()
+DatestampedEntity.model_rebuild()
+AuthoredEntity.model_rebuild()
+AnnotatoredEntity.model_rebuild()
+FundedEntity.model_rebuild()
+CrossReferencedEntity.model_rebuild()
+PicturedEntity.model_rebuild()
+Organism.model_rebuild()
+Tissue.model_rebuild()
+CellType.model_rebuild()
+CellStrain.model_rebuild()
+CellComponent.model_rebuild()
+ExperimentalMetadata.model_rebuild()
+Dataset.model_rebuild()
+Camera.model_rebuild()
+Microscope.model_rebuild()
+MicroscopeOpticalSetup.model_rebuild()
+TiltRange.model_rebuild()
+TiltSeries.model_rebuild()
+TomogramSize.model_rebuild()
+TomogramOffset.model_rebuild()
+Tomogram.model_rebuild()
+AnnotationFile.model_rebuild()
+AnnotationConfidence.model_rebuild()
+AnnotationObject.model_rebuild()
+Annotation.model_rebuild()
+CrossReferences.model_rebuild()
+

--- a/schema/v1.1.0/requirements.txt
+++ b/schema/v1.1.0/requirements.txt
@@ -1,0 +1,3 @@
+linkml
+linkml-runtime
+click

--- a/schema/v1.1.0/schema.py
+++ b/schema/v1.1.0/schema.py
@@ -1,5 +1,5 @@
 from linkml_runtime.utils.schemaview import SchemaView
-from linkml_runtime.dumpers import json_dumper, yaml_dumper
+from linkml_runtime.dumpers import yaml_dumper
 from linkml.utils.helpers import write_to_file
 
 import click

--- a/schema/v1.1.0/schema.py
+++ b/schema/v1.1.0/schema.py
@@ -1,0 +1,103 @@
+from linkml_runtime.utils.schemaview import SchemaView
+from linkml_runtime.dumpers import json_dumper, yaml_dumper
+from linkml.utils.helpers import write_to_file
+
+import click
+
+
+def _materialize_classes(schema: SchemaView) -> None:
+    all_classes = schema.all_classes()
+
+    for c_name, c_def in all_classes.items():
+        attrs = schema.class_induced_slots(c_name)
+        for attr in attrs:
+            c_def.attributes[attr.name] = attr
+
+
+def _materialize_schema(schema: SchemaView, common_schema: SchemaView) -> SchemaView:
+    """
+    Copy range, descriptions and patterns from exact_mappings to common_schema.
+    """
+    # Make all slots attributes of their classes
+    _materialize_classes(schema)
+
+    # Copy descriptions and ranges from common_schema
+    input_slots = schema.all_slots()
+    common_slots = common_schema.all_slots()
+
+    for s in input_slots:
+        slot = input_slots.get(s)
+        mappings = slot["exact_mappings"]
+        if mappings:
+            mappings = [
+                m.replace("cdp-common:", "") for m in mappings if "cdp-common:" in m
+            ]
+
+            if len(mappings) > 1:
+                raise ValueError(
+                    f"Slot {slot['name']} has multiple mappings to common schema"
+                )
+
+            common_slot = common_slots.get(mappings[0])
+
+            if not common_slot:
+                raise ValueError(
+                    f"Slot {mappings[0]} does not exist in common schema. Check the exact_mappings for {slot['name']}."
+                )
+
+            slot["range"] = common_slot["range"]
+            slot["description"] = common_slot["description"]
+            slot["pattern"] = common_slot["pattern"]
+
+    # Make sure the descriptions from mixin classes are carried over
+    for c in schema.all_classes():
+        clz = schema.get_class(c)
+        for m in clz.mixins:
+            mixin = schema.get_class(m)
+            for name, attr in mixin.attributes.items():
+                clz.attributes[name].description = attr.description
+
+    # Make sure the attributes that have classes as range have their descriptions set
+    for c in schema.all_classes():
+        clz = schema.get_class(c)
+        for name, attr in clz.attributes.items():
+            if attr.range in schema.all_classes():
+                attr.description = schema.get_class(attr.range).description
+
+    return schema
+
+
+@click.group()
+@click.pass_context
+def cli(ctx):
+    pass
+
+
+@cli.command()
+@click.argument("schema_file", required=True, type=str)
+@click.argument("common_schema_file", required=True, type=str)
+@click.argument("output_path", required=True, type=str)
+@click.pass_context
+def materialize(ctx, schema_file: str, common_schema_file: str, output_path: str):
+    # Load
+    schema = SchemaView(schema_file)
+    common_schema = SchemaView(common_schema_file)
+
+    # Copy common elements from common definitions to schema
+    _materialize_classes(common_schema)
+    for c in common_schema.all_classes():
+        schema.add_class(common_schema.get_class(c))
+
+    for e in common_schema.all_enums():
+        schema.add_enum(common_schema.get_enum(e))
+
+    # Materialize output schema from common schema
+    schema.materialize_derived_schema()
+    output_schema = _materialize_schema(schema, common_schema)
+
+    output = yaml_dumper.dumps(output_schema.schema)
+    write_to_file(output_path, output)
+
+
+if __name__ == "__main__":
+    cli()

--- a/test_infra/seed_moto.sh
+++ b/test_infra/seed_moto.sh
@@ -2,7 +2,7 @@
 
 # Script to seed moto server; runs outside the motoserver container for development
 
-aws="aws --endpoint-url=http://localhost:4001"
+aws="aws --endpoint-url=http://localhost:4000"
 export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
 export AWS_REGION=us-west-2

--- a/test_infra/seed_moto.sh
+++ b/test_infra/seed_moto.sh
@@ -2,7 +2,7 @@
 
 # Script to seed moto server; runs outside the motoserver container for development
 
-aws="aws --endpoint-url=http://localhost:4000"
+aws="aws --endpoint-url=http://localhost:4001"
 export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
 export AWS_REGION=us-west-2


### PR DESCRIPTION
Common slots (shared between the database and metadata files) are defined in `schema/v1.1.0/common.yaml`, this includes type (called "range" in LinkML), description and optionally a unit or a regex pattern (e.g. for validation of identifiers).

The nested structure of the metadata files is defined in `schema/v1.1.0/metadata.yaml`. This file contains an "underdefined" version of the metadata schema, that contains references to `common.yaml` via the "exact_mappings" slot.

`schema.py` consumes `common.yaml` and `metadata.yaml` to produce `metadata_materialized.yaml`, which contains all all classes with correctly typed attributes with descriptions. This file can be used for code- and docgen. All generation is handled in the makefile. 

The README specifies the folder structure and links to the relevant file specs. We could change the doc templates if we wanted to. Recommend to start looking at this at the schema root directory: https://github.com/chanzuckerberg/cryoet-data-portal-backend/tree/uermel/linkml/schema/v1.1.0