### PR TITLE
Fix annotation type for segmentation masks in 10002

### DIFF
--- a/ingestion_tools/dataset_configs/10002.yaml
+++ b/ingestion_tools/dataset_configs/10002.yaml
@@ -154,7 +154,7 @@ annotations:
       is_curator_recommended: true
     sources:
       - file_format: mrc
-        shape: SegmentationMask
+        shape: SemanticSegmentationMask
         glob_string: labels/{run_name}_actin_ground_truth.mrc
         is_visualization_default: true
   - metadata:
@@ -178,7 +178,7 @@ annotations:
       is_curator_recommended: false
     sources:
       - file_format: mrc
-        shape: SegmentationMask
+        shape: SemanticSegmentationMask
         glob_string: prediction/{run_name}_*.mrc
         is_visualization_default: false
 #     - columns: zyx


### PR DESCRIPTION
Masks in 10002 were still imported using the old "SegmentationMask" type instead of the "SemanticSegmentationMask". 

Changed to the appropriate annotation type with this PR.