### PR TITLE
Support depositions of annotations that are associated with existing datasets

### DIFF
--- a/ingestion_tools/dataset_configs/deposition_10301.yaml
+++ b/ingestion_tools/dataset_configs/deposition_10301.yaml
@@ -1,0 +1,79 @@
+annotations:
+  - metadata:
+      annotation_object:
+        id: GO:0016020
+        name: membrane
+        description: ~
+        state: ~
+      dates: &repo-dates
+        deposition_date: 2024-02-20
+        last_modified_date: 2024-02-20
+        release_date: 2024-02-20
+      annotation_method: TARDIS
+      method_type: automated
+      annotation_publications: ~
+      ground_truth_status: False
+      authors: &annotation_authors
+        - name: Robert Kiewisz
+          primary_annotator_status: true
+        - name: Tristan Bepler
+          corresponding_author_status: true
+      annotation_software: TARDIS
+      version: '1.0'
+      confidence:
+        precision: ~
+        recall: ~
+      is_curator_recommended: False
+    sources:
+      - file_format: tardis
+        binning: 1
+        order: xyz
+        shape: InstanceSegmentation
+        glob_string: "{dataset_name}/{run_name}/{run_name}_instance.csv"
+        is_visualization_default: false
+  - metadata:
+      dates: *repo-dates
+      annotation_method: TARDIS
+      method_type: automated
+      annotation_publications: ~
+      ground_truth_status: False
+      authors: *annotation_authors
+      annotation_software: TARDIS
+      version: '1.0'
+      confidence:
+        precision: ~
+        recall: ~
+        ground_truth_used: ~
+      annotation_object:
+        id: GO:0016020
+        name: membrane
+        description: ~
+        state: ~
+      is_curator_recommended: false
+    sources:
+      - file_format: mrc
+        shape: SemanticSegmentationMask
+        glob_string: "{dataset_name}/{run_name}/{run_name}_semantic.mrc"
+        is_visualization_default: false
+standardization_config:
+  deposition_id: 10301
+  dataset:
+    source:
+      source_glob:
+        list_glob: '*'
+        match_regex: .*
+        name_regex: (.*)
+  run:
+    source:
+      source_glob:
+        list_glob: '{dataset_name}/*'
+        match_regex: .*
+        name_regex: (.*)
+  tomogram_voxel_spacing:
+    source:
+      destination_glob:
+        list_glob: '{run_output_path}/Tomograms/VoxelSpacing*'
+        match_regex: .*
+        name_regex: VoxelSpacing(.*)
+  destination_prefix: ''
+  source_prefix: 'robert_kiewisz_tardis_01_2024'

--- a/ingestion_tools/scripts/common/config.py
+++ b/ingestion_tools/scripts/common/config.py
@@ -30,6 +30,7 @@ class RunOverride:
 class DataImportConfig:
     https_prefix = os.getenv("DOMAIN_NAME", "https://files.cryoetdataportal.cziscience.com")
     source_prefix: str
+    deposition_id: str
     destination_prefix: str
     fs: FileSystemApi
     run_glob: str

--- a/ingestion_tools/scripts/common/finders.py
+++ b/ingestion_tools/scripts/common/finders.py
@@ -1,0 +1,168 @@
+import re
+from dataclasses import dataclass
+from common.fs import FileSystemApi
+from typing import TYPE_CHECKING, Any
+from abc import ABC, abstractclassmethod, abstractmethod
+import os
+
+if TYPE_CHECKING:
+    from common.config import DepositionImportConfig
+else:
+    DepositionImportConfig = "DepositionImportConfig"
+    DatasetImporter = "DatasetImporter"
+
+### 
+### Base Finders
+### 
+class SourceGlobFinder(ABC):
+    list_glob: str
+    match_regex: re.Pattern[str]
+    name_regex: re.Pattern[str]
+
+    def __init__(self, list_glob: str, match_regex: re.Pattern[str], name_regex: re.Pattern[str]):
+        self.list_glob = list_glob
+        self.match_regex = re.compile(match_regex)
+        self.name_regex = re.compile(name_regex)
+    
+    def find(self, config: DepositionImportConfig, fs: FileSystemApi, glob_vars: dict[str, Any]):
+        expanded_glob = os.path.join(config.dataset_root_dir, self.list_glob.format(**glob_vars))
+        path = os.path.join(config.input_path, expanded_glob)
+        print(f"path -- {path}")
+        responses = {}
+        for fname in config.fs.glob(path):
+            if not self.match_regex.search(fname):
+                continue
+            path = fname
+            obj_name = self.name_regex.match(os.path.basename(path))[1]
+            responses[path] = obj_name
+        return responses
+
+# TODO this thing probably shouldn't exist, since it relies on a particular existing state of our
+# output directories, but for the moment we have a deposition that doesn't encode voxel spacings in it,
+# so this is about the best we can do.
+class DestinationGlobFinder(ABC):
+    list_glob: str
+    match_regex: re.Pattern[str]
+    name_regex: re.Pattern[str]
+
+    def __init__(self, list_glob: str, match_regex: re.Pattern[str], name_regex: re.Pattern[str]):
+        self.list_glob = list_glob
+        self.match_regex = re.compile(match_regex)
+        self.name_regex = re.compile(name_regex)
+    
+    def find(self, config: DepositionImportConfig, fs: FileSystemApi, glob_vars: dict[str, Any]):
+        expanded_glob = os.path.join(config.dataset_root_dir, self.list_glob.format(**glob_vars))
+        path = os.path.join(config.input_path, expanded_glob)
+        print(f"path -- {path}")
+        responses = {}
+        for fname in config.fs.glob(path):
+            if not self.match_regex.search(fname):
+                continue
+            path = fname
+            obj_name = self.name_regex.match(os.path.basename(path))[1]
+            responses[path] = obj_name
+        return responses
+
+class BaseLiteralValueFinder(ABC):
+    literal_value: list[Any]
+
+    def __init__(self, literal_value: str):
+        self.literal_value = literal_value
+
+    def find(self, config: DepositionImportConfig, fs: FileSystemApi):
+        return self.literal_value
+
+### 
+### Dataset finders
+### 
+class DatasetDestinationGlobFinder(DestinationGlobFinder):
+    pass
+
+class DatasetSourceGlobFinder(SourceGlobFinder):
+    pass
+
+class DatasetLiteralFinder(BaseLiteralValueFinder):
+    pass
+
+class RunDestinationGlobFinder(DestinationGlobFinder):
+    pass
+
+class RunSourceGlobFinder(SourceGlobFinder):
+    pass
+
+class RunLiteralFinder(BaseLiteralValueFinder):
+    pass
+
+class VSDestinationGlobFinder(DestinationGlobFinder):
+    pass
+
+class VSSourceGlobFinder(SourceGlobFinder):
+    pass
+
+class VSLiteralFinder(BaseLiteralValueFinder):
+    pass
+
+### 
+### Factories
+### 
+class DepositionObjectImporterFactory(ABC):
+    def __init__(self, source: dict[str, Any]):
+        self.source = source
+    
+    @abstractmethod
+    def load(self, expansion_data: dict, config: DepositionImportConfig, fs: FileSystemApi):
+        pass
+
+    # TODO FIXME -- passing in the class-to-instantiate is a temporary hack to work around
+    # python circular import shenanigans. We should try to refactor this out and have each 
+    # factory create the specific object types it's supposed to create, so we can customize
+    # instantiation per object type when we need it.
+    def find(self, cls, parent_object: Any | None, config: DepositionImportConfig, fs: FileSystemApi):
+        loader = self.load(parent_object, config, fs)  
+        glob_vars = {}
+        if parent_object:
+            glob_vars = parent_object.get_glob_vars()
+        tmp_parent_object = parent_object
+        while tmp_parent_object:
+            glob_vars[f"{tmp_parent_object.type_key}_output_path"] = tmp_parent_object.get_output_path()
+            tmp_parent_object = tmp_parent_object.parent
+        found = loader.find(config, fs, glob_vars)
+        results = []
+        for path, name in found.items():
+            results.append(cls(config=config, parent=parent_object, name=name, path=path))
+        for item in results:
+            print(f":::: {item.name} -- {item.path}")
+        return results
+
+class DatasetImporterFactory(DepositionObjectImporterFactory):
+    def load(self, parent_object: Any | None, config: DepositionImportConfig, fs: FileSystemApi):
+        source = self.source
+        if source.get('source_glob'):
+            return DatasetSourceGlobFinder(**source['source_glob'])
+        if source.get('destination_glob'):
+            return DatasetDestinationGlobFinder(**source['destination_glob'])
+        if source.get('literal'):
+            return DatasetLiteralFinder(**source['tomogram_header'])
+        raise Exception("Invalid source type")
+
+class RunImporterFactory(DepositionObjectImporterFactory):
+    def load(self, parent_object: Any | None, config: DepositionImportConfig, fs: FileSystemApi):
+        source = self.source
+        if source.get('source_glob'):
+            return RunSourceGlobFinder(**source['source_glob'])
+        if source.get('destination_glob'):
+            return RunDestinationGlobFinder(**source['destination_glob'])
+        if source.get('literal'):
+            return RunLiteralFinder(**source['tomogram_header'])
+        raise Exception("Invalid source type")
+
+class VSImporterFactory(DepositionObjectImporterFactory):
+    def load(self, parent_object: Any | None, config: DepositionImportConfig, fs: FileSystemApi):
+        source = self.source
+        if source.get('source_glob'):
+            return VSSourceGlobFinder(**source['source_glob'])
+        if source.get('destination_glob'):
+            return VSDestinationGlobFinder(**source['destination_glob'])
+        if source.get('literal'):
+            return VSLiteralFinder(**source['tomogram_header'])
+        raise Exception("Invalid source type")

--- a/ingestion_tools/scripts/common/metadata.py
+++ b/ingestion_tools/scripts/common/metadata.py
@@ -6,27 +6,36 @@ from typing import Any
 from common.formats import tojson
 from common.fs import FileSystemApi
 from common.merge import deep_merge
+from copy import deepcopy
 
 
 class BaseMetadata:
-    def __init__(self, fs: FileSystemApi, template: dict[str, Any]):
+    def __init__(self, fs: FileSystemApi, deposition_id: str, template: dict[str, Any]):
         self.fs = fs
         self.metadata = template
+        self.deposition_id = deposition_id
 
     def write_metadata(self, filename: str, is_json=True) -> None:
+        metadata = deepcopy(self.metadata)
+        metadata["deposition_id"] = self.deposition_id
         with self.fs.open(filename, "w") as fh:
-            data = tojson(self.metadata) if is_json else self.metadata
+            data = tojson(metadata) if is_json else self.metadata
             fh.write(data)
 
 
 class MergedMetadata(BaseMetadata):
     def write_metadata(self, filename: str, merge_data: dict[str, Any]) -> None:
         metadata = deep_merge(self.metadata, merge_data)
+        metadata["deposition_id"] = self.deposition_id
         with self.fs.open(filename, "w") as fh:
             fh.write(tojson(metadata))
 
 
 class TiltSeriesMetadata(MergedMetadata):
+    pass
+
+
+class AlignmentMetadata(MergedMetadata):
     pass
 
 

--- a/ingestion_tools/scripts/enqueue_runs.py
+++ b/ingestion_tools/scripts/enqueue_runs.py
@@ -10,7 +10,7 @@ from boto3 import Session
 from importers.dataset import DatasetImporter
 from importers.run import RunImporter
 
-from common.config import DataImportConfig
+from common.config import DepositionImportConfig
 from common.fs import FileSystemApi
 
 
@@ -188,7 +188,7 @@ def queue(
     fs_mode = "s3"
     fs = FileSystemApi.get_fs_api(mode=fs_mode, force_overwrite=force_overwrite)
 
-    config = DataImportConfig(fs, config_file, output_path, input_bucket)
+    config = DepositionImportConfig(fs, config_file, output_path, input_bucket)
     os.makedirs(os.path.join(output_path, config.destination_prefix), exist_ok=True)
     config.load_map_files()
 

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -14,7 +14,7 @@ from common.metadata import AnnotationMetadata
 from importers.base_importer import BaseImporter
 
 if TYPE_CHECKING:
-    from importers.tomogram import TomogramImporter
+    from importers.voxel_spacing import VoxelSpacingImporter
 
 
 class AnnotationObject(TypedDict):
@@ -387,7 +387,7 @@ class AnnotationImporter(BaseImporter):
         return self.annotation_metadata.get_filename_prefix(output_dir, self.identifier)
 
     def import_annotations(self, write: bool):
-        run_name = self.parent.get_run().run_name
+        run_name = self.parent.get_run().name
         dest_prefix = self.get_output_path()
         for source in self.sources:
             # Don't panic if we don't have a source file for this annotation source
@@ -399,7 +399,7 @@ class AnnotationImporter(BaseImporter):
             source.convert(self.config.fs, self.config.input_path, dest_prefix, self.parent.get_voxel_spacing())
 
     def import_metadata(self):
-        run_name = self.parent.get_run().run_name
+        run_name = self.parent.get_run().name
         print(f"importing annotations for {run_name}")
         real_sources = 0
         for source in self.sources:
@@ -421,7 +421,7 @@ class AnnotationImporter(BaseImporter):
         self.annotation_metadata.write_metadata(filename, self.local_metadata)
 
     @classmethod
-    def find_annotations(cls, config, tomo: "TomogramImporter"):
+    def find_annotations(cls, config, vs: "VoxelSpacingImporter"):
         annotations = []
         identifier = 100
         for annotation_config in config.annotation_template:
@@ -430,7 +430,7 @@ class AnnotationImporter(BaseImporter):
                 AnnotationImporter(
                     identifier=identifier,
                     config=config,
-                    parent=tomo,
+                    parent=vs,
                     annotation_metadata=metadata,
                     annotation_config=annotation_config,
                 ),

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -425,7 +425,7 @@ class AnnotationImporter(BaseImporter):
         annotations = []
         identifier = 100
         for annotation_config in config.annotation_template:
-            metadata = AnnotationMetadata(config.fs, annotation_config["metadata"])
+            metadata = AnnotationMetadata(config.fs, config.deposition_id, annotation_config["metadata"])
             annotations.append(
                 AnnotationImporter(
                     identifier=identifier,

--- a/ingestion_tools/scripts/importers/dataset.py
+++ b/ingestion_tools/scripts/importers/dataset.py
@@ -7,7 +7,7 @@ class DatasetImporter(BaseImporter):
     type_key = "dataset"
 
     def import_metadata(self, output_prefix: str) -> None:
-        meta = DatasetMetadata(self.config.fs, self.config.dataset_template)
+        meta = DatasetMetadata(self.config.fs, self.config.deposition_id, self.config.dataset_template)
         extra_data = self.load_extra_metadata()
         meta.write_metadata(self.get_metadata_path(), extra_data)
 

--- a/ingestion_tools/scripts/importers/dataset.py
+++ b/ingestion_tools/scripts/importers/dataset.py
@@ -1,10 +1,18 @@
 from common.metadata import DatasetMetadata
 from importers.base_importer import BaseImporter
 from importers.dataset_key_photo import DatasetKeyPhotoImporter
+from typing import Any
 
 
 class DatasetImporter(BaseImporter):
     type_key = "dataset"
+
+    def __init__(
+        self,
+        *args: list[Any],
+        **kwargs: dict[str, Any],
+    ):
+        super().__init__(*args, **kwargs)
 
     def import_metadata(self, output_prefix: str) -> None:
         meta = DatasetMetadata(self.config.fs, self.config.deposition_id, self.config.dataset_template)

--- a/ingestion_tools/scripts/importers/dataset_key_photo.py
+++ b/ingestion_tools/scripts/importers/dataset_key_photo.py
@@ -1,7 +1,7 @@
 import os
 from typing import TYPE_CHECKING, Optional
 
-from common.config import DataImportConfig
+from common.config import DepositionImportConfig
 from common.copy import copy_by_src
 from importers.base_importer import BaseImporter
 from importers.key_image import KeyImageImporter
@@ -54,5 +54,5 @@ class DatasetKeyPhotoImporter(BaseImporter):
         return None
 
     @classmethod
-    def find_dataset_key_photos(cls, config: DataImportConfig, dataset: "DatasetImporter") -> "DatasetKeyPhotoImporter":
+    def find_dataset_key_photos(cls, config: DepositionImportConfig, dataset: "DatasetImporter") -> "DatasetKeyPhotoImporter":
         return cls(config=config, parent=dataset)

--- a/ingestion_tools/scripts/importers/frames.py
+++ b/ingestion_tools/scripts/importers/frames.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from typing import TYPE_CHECKING
 
-from common.config import DataImportConfig
+from common.config import DepositionImportConfig
 from importers.base_importer import BaseImporter
 
 if TYPE_CHECKING:
@@ -27,15 +27,15 @@ class FramesImporter(BaseImporter):
         for item in self.find_all_gains(config, run):
             if item.endswith(".dm4"):
                 local_input = fs.localreadable(item)
-                local_output = fs.localwritable(os.path.join(output_dir, f"{run.run_name}_gain.mrc"))
+                local_output = fs.localwritable(os.path.join(output_dir, f"{run.name}_gain.mrc"))
                 subprocess.check_output(["/usr/local/IMOD/bin/dm2mrc", local_input, local_output])
                 fs.push(local_output)
             else:
-                dest_filename = os.path.join(output_dir, f"{run.run_name}_gain.mrc")
+                dest_filename = os.path.join(output_dir, f"{run.name}_gain.mrc")
                 fs.copy(item, dest_filename)
 
     @classmethod
-    def find_frames(cls, config: DataImportConfig, run: RunImporter) -> list["FramesImporter"]:
+    def find_frames(cls, config: DepositionImportConfig, run: RunImporter) -> list["FramesImporter"]:
         if not config.frames_glob:
             print(f"No frames for {config.dataset_template.get('dataset_identifier')}")
             return []
@@ -43,15 +43,15 @@ class FramesImporter(BaseImporter):
         return [importer]
 
     @classmethod
-    def find_all_frames(cls, config: DataImportConfig, run: RunImporter):
+    def find_all_frames(cls, config: DepositionImportConfig, run: RunImporter):
         return cls.find_files(config.frames_glob, config, run)
 
     @classmethod
-    def find_all_gains(cls, config: DataImportConfig, run: RunImporter):
+    def find_all_gains(cls, config: DepositionImportConfig, run: RunImporter):
         return cls.find_files(config.gain_glob, config, run)
 
     @classmethod
-    def find_files(cls, glob: str, config: DataImportConfig, run: RunImporter):
+    def find_files(cls, glob: str, config: DepositionImportConfig, run: RunImporter):
         if not glob:
             return []
         if config.run_to_frame_map:

--- a/ingestion_tools/scripts/importers/key_image.py
+++ b/ingestion_tools/scripts/importers/key_image.py
@@ -5,7 +5,7 @@ import imageio
 import numpy as np
 from PIL import Image
 
-from common.config import DataImportConfig
+from common.config import DepositionImportConfig
 from common.image import ZarrReader
 from common.make_key_image import generate_preview, process_key_image
 from importers.annotation import AnnotationImporter
@@ -27,7 +27,7 @@ class KeyImageImporter(BaseImporter):
     }
 
     @classmethod
-    def find_key_images(cls, config: DataImportConfig, tomogram: TomogramImporter) -> "KeyImageImporter":
+    def find_key_images(cls, config: DepositionImportConfig, tomogram: TomogramImporter) -> "KeyImageImporter":
         return [cls(config, parent=tomogram)]
 
     def get_metadata(self) -> dict[str, str]:
@@ -40,7 +40,7 @@ class KeyImageImporter(BaseImporter):
         image_path = os.path.join(self.get_output_path(), self.get_file_name(image_type))
         return os.path.relpath(image_path, self.config.output_prefix)
 
-    def make_key_image(self, config: DataImportConfig, upload: bool = True) -> None:
+    def make_key_image(self, config: DepositionImportConfig, upload: bool = True) -> None:
         dir = self.get_output_path()
         preview, tomo_width = None, None
         if config.tomo_key_photo_glob:

--- a/ingestion_tools/scripts/importers/neuroglancer.py
+++ b/ingestion_tools/scripts/importers/neuroglancer.py
@@ -17,7 +17,7 @@ class NeuroglancerImporter(BaseImporter):
     def import_neuroglancer(self) -> str:
         dest_file = self.get_output_path()
         ng_contents = self.get_config_json(self.parent.get_output_path() + ".zarr")
-        meta = NeuroglancerMetadata(self.config.fs, ng_contents)
+        meta = NeuroglancerMetadata(self.config.fs, self.config.deposition_id, ng_contents)
         meta.write_metadata(dest_file)
         return dest_file
 

--- a/ingestion_tools/scripts/importers/neuroglancer.py
+++ b/ingestion_tools/scripts/importers/neuroglancer.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
-from common.config import DataImportConfig
+from common.config import DepositionImportConfig
 from common.metadata import NeuroglancerMetadata
 from importers.base_importer import BaseImporter
 
@@ -70,5 +70,5 @@ class NeuroglancerImporter(BaseImporter):
         }
 
     @classmethod
-    def find_ng(cls, config: DataImportConfig, tomo: TomogramImporter) -> list["NeuroglancerImporter"]:
+    def find_ng(cls, config: DepositionImportConfig, tomo: TomogramImporter) -> list["NeuroglancerImporter"]:
         return [cls(config=config, parent=tomo)]

--- a/ingestion_tools/scripts/importers/run.py
+++ b/ingestion_tools/scripts/importers/run.py
@@ -36,7 +36,7 @@ class RunImporter(BaseImporter):
 
     def import_run_metadata(self) -> None:
         dest_run_metadata = self.get_metadata_path()
-        metadata = RunMetadata(self.config.fs, self.config.run_template)
+        metadata = RunMetadata(self.config.fs, self.config.deposition_id, self.config.run_template)
         merge_data = {"run_name": self.run_name}
         metadata.write_metadata(dest_run_metadata, merge_data)
 

--- a/ingestion_tools/scripts/importers/run.py
+++ b/ingestion_tools/scripts/importers/run.py
@@ -1,7 +1,7 @@
 import os
 from typing import TYPE_CHECKING, Any
 
-from common.config import DataImportConfig
+from common.config import DepositionImportConfig
 from common.metadata import RunMetadata
 from importers.base_importer import BaseImporter
 
@@ -16,32 +16,22 @@ class RunImporter(BaseImporter):
 
     def __init__(
         self,
-        path: str,
         *args: list[Any],
         **kwargs: dict[str, Any],
     ):
         super().__init__(*args, **kwargs)
-        self.run_path = path
-        self.run_name = self.config.run_name_regex.match(os.path.basename(path))[1]
-        if voxel_spacing := self.config.expand_string(
-            self.run_name,
-            self.config.tomogram_template.get("voxel_spacing"),
-        ):
-            self.set_voxel_spacing(float(voxel_spacing))
-        else:
-            self.voxel_spacing = None
-
-    def set_voxel_spacing(self, voxel_spacing: float) -> None:
-        self.voxel_spacing = "{:.3f}".format(round(voxel_spacing, 3))
+        # Backwards compatibility
+        if not self.name:
+            self.name = self.config.run_name_regex.match(os.path.basename(self.path))[1]
 
     def import_run_metadata(self) -> None:
         dest_run_metadata = self.get_metadata_path()
         metadata = RunMetadata(self.config.fs, self.config.deposition_id, self.config.run_template)
-        merge_data = {"run_name": self.run_name}
+        merge_data = {"run_name": self.name}
         metadata.write_metadata(dest_run_metadata, merge_data)
 
     @classmethod
-    def find_runs(cls, config: DataImportConfig, dataset: DatasetImporter) -> list[Any]:
+    def find_runs(cls, config: DepositionImportConfig, dataset: DatasetImporter) -> list[Any]:
         run_path = os.path.join(config.input_path, config.run_glob)
         responses = []
         for fname in config.fs.glob(run_path):

--- a/ingestion_tools/scripts/importers/tiltseries.py
+++ b/ingestion_tools/scripts/importers/tiltseries.py
@@ -54,7 +54,7 @@ class TiltSeriesImporter(VolumeImporter):
         merge_data["frames_count"] = self.get_frames_count()
         base_metadata = self.get_base_metadata()
         merge_data["pixel_spacing"] = self.get_pixel_spacing()
-        metadata = TiltSeriesMetadata(self.config.fs, base_metadata)
+        metadata = TiltSeriesMetadata(self.config.fs, self.config.deposition_id, base_metadata)
         if write:
             metadata.write_metadata(dest_ts_metadata, merge_data)
 

--- a/ingestion_tools/scripts/importers/tiltseries.py
+++ b/ingestion_tools/scripts/importers/tiltseries.py
@@ -1,7 +1,7 @@
 import os
 from typing import TYPE_CHECKING
 
-from common.config import DataImportConfig
+from common.config import DepositionImportConfig
 from common.metadata import TiltSeriesMetadata
 from importers.base_importer import BaseImporter, VolumeImporter
 from importers.frames import FramesImporter
@@ -27,7 +27,7 @@ class RawTiltImporter(BaseImporter):
                 self.config.fs.copy(item, output_file)
 
     @classmethod
-    def find_rawtilts(cls, config: DataImportConfig, run: RunImporter) -> list["RawTiltImporter"]:
+    def find_rawtilts(cls, config: DepositionImportConfig, run: RunImporter) -> list["RawTiltImporter"]:
         if not config.rawtlt_files:
             print(f"No tiltseries raw files for {config.dataset_template.get('dataset_identifier')}")
             return []
@@ -59,7 +59,7 @@ class TiltSeriesImporter(VolumeImporter):
             metadata.write_metadata(dest_ts_metadata, merge_data)
 
     @classmethod
-    def find_tiltseries(cls, config: DataImportConfig, run: RunImporter) -> "TiltSeriesImporter":
+    def find_tiltseries(cls, config: DepositionImportConfig, run: RunImporter) -> "TiltSeriesImporter":
         if not config.tiltseries_glob:
             print(f"No tiltseries for {config.dataset_template.get('dataset_identifier')}")
             return []

--- a/ingestion_tools/scripts/importers/tomogram.py
+++ b/ingestion_tools/scripts/importers/tomogram.py
@@ -1,10 +1,11 @@
 from typing import TYPE_CHECKING, Any
 
-from common.config import DataImportConfig
+from common.config import DepositionImportConfig
 from common.metadata import TomoMetadata
 from common.normalize_fields import normalize_fiducial_alignment
 from importers.base_importer import VolumeImporter
 from importers.key_image import KeyImageImporter
+from importers.voxel_spacing import VoxelSpacingImporter
 
 if TYPE_CHECKING:
     from importers.run import RunImporter
@@ -53,11 +54,12 @@ class TomogramImporter(VolumeImporter):
     @classmethod
     def find_tomograms(
         cls,
-        config: DataImportConfig,
-        run: RunImporter,
+        config: DepositionImportConfig,
+        vs: VoxelSpacingImporter,
         skip_cache: bool = False,
     ) -> list["TomogramImporter"]:
-        cache_key = run.run_name
+        run = vs.parent
+        cache_key = run.name
         if not skip_cache and cache_key in cls.cached_find_results:
             return cls.cached_find_results[cache_key]
         tomo_glob = config.tomo_glob
@@ -73,5 +75,5 @@ class TomogramImporter(VolumeImporter):
                     tomos.append(fname)
         if not tomos:
             return []
-        cls.cached_find_results[cache_key] = [cls(config=config, parent=run, path=tomos[0])]
+        cls.cached_find_results[cache_key] = [cls(config=config, parent=vs, path=tomos[0])]
         return cls.cached_find_results[cache_key]

--- a/ingestion_tools/scripts/importers/tomogram.py
+++ b/ingestion_tools/scripts/importers/tomogram.py
@@ -46,7 +46,7 @@ class TomogramImporter(VolumeImporter):
             base_metadata.get("fiducial_alignment_status"),
         )
 
-        metadata = TomoMetadata(self.config.fs, base_metadata)
+        metadata = TomoMetadata(self.config.fs, self.config.deposition_id, base_metadata)
         if write:
             metadata.write_metadata(dest_tomo_metadata, merge_data)
 

--- a/ingestion_tools/scripts/importers/voxel_spacing.py
+++ b/ingestion_tools/scripts/importers/voxel_spacing.py
@@ -1,0 +1,33 @@
+from typing import TYPE_CHECKING
+
+from importers.base_importer import BaseImporter
+
+from common.config import DataImportConfig
+from common.metadata import VoxelSpacingMetadata
+
+if TYPE_CHECKING:
+    from importers.run import RunImporter
+else:
+    RunImporter = "RunImporter"
+
+
+class VoxelSpacingImporter(BaseImporter):
+    type_key = "alignment"
+
+    def write_index_file(self):
+        # TODO FIXME we should write an index file that lists all the voxel spacings we have for a given run so that nobody has to list dirs!!
+        pass
+
+    @classmethod
+    def find(
+        cls,
+        config: DataImportConfig,
+        run: RunImporter,
+        skip_cache: bool = False,
+    ) -> list["AlignmentImporter"]:
+        return [cls(config=config, parent=run, path="TODO")]
+
+    def import_metadata(self, output_prefix: str) -> None:
+        meta = VoxelSpacingMetadata(self.config.fs, self.config.deposition_id, self.config.alignment_template)
+        extra_data = {"deposition_identifier": 12445}  # TODO FIXME
+        meta.write_metadata(self.get_metadata_path(), extra_data)

--- a/ingestion_tools/scripts/test_neuroglancer_config.py
+++ b/ingestion_tools/scripts/test_neuroglancer_config.py
@@ -9,7 +9,7 @@ from importers.neuroglancer import NeuroglancerImporter
 from importers.run import RunImporter
 from importers.tomogram import TomogramImporter
 
-from common.config import DataImportConfig
+from common.config import DepositionImportConfig
 from common.fs import FileSystemApi
 
 
@@ -43,18 +43,18 @@ def getlink(
     if int(dataset) >= 10013:
         dataset_path = f"gjensen/{dataset}"
     config_file = os.path.abspath(os.path.join(script_location, f"../dataset_configs/{dataset_path}.yaml"))
-    config = DataImportConfig(fs, config_file, "cryoet-data-portal-staging", "cryoetportal-rawdatasets-dev")
+    config = DepositionImportConfig(fs, config_file, "cryoet-data-portal-staging", "cryoetportal-rawdatasets-dev")
     config.load_map_files()
 
     # Always iterate over datasets and runs.
     ds = DatasetImporter(config, None)
     for iter_run in RunImporter.find_runs(config, ds):
-        if iter_run.run_name != run:
+        if iter_run.name != run:
             if debug:
-                print(f"Skipping {iter_run.run_name}..")
+                print(f"Skipping {iter_run.name}..")
             continue
         if debug:
-            print(f"Processing {iter_run.run_name}...")
+            print(f"Processing {iter_run.name}...")
         for tomo in TomogramImporter.find_tomograms(config, iter_run):
             iter_run.set_voxel_spacing(tomo.get_voxel_spacing())
             for item in NeuroglancerImporter.find_ng(config, tomo):

--- a/ingestion_tools/scripts/tests/s3_import/test_dataset_import.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_dataset_import.py
@@ -4,7 +4,7 @@ from importers.dataset import DatasetImporter
 from importers.dataset_key_photo import DatasetKeyPhotoImporter
 from mypy_boto3_s3 import S3Client
 
-from common.config import DataImportConfig
+from common.config import DepositionImportConfig
 from common.fs import FileSystemApi
 
 
@@ -12,7 +12,7 @@ def test_import_dataset_metadata(s3_fs: FileSystemApi, test_output_bucket: str) 
     config_file = "tests/fixtures/dataset1.yaml"
     output_path = f"{test_output_bucket}/output"
     input_bucket = "input_bucket"
-    config = DataImportConfig(s3_fs, config_file, output_path, input_bucket)
+    config = DepositionImportConfig(s3_fs, config_file, output_path, input_bucket)
     dataset = DatasetImporter(config, None)
     dataset.import_metadata(output_path)
 
@@ -27,7 +27,7 @@ def test_key_photo_import_http(s3_fs: FileSystemApi, test_output_bucket: str, s3
     output_prefix = "output"
     output_path = f"{test_output_bucket}/{output_prefix}"
     input_bucket = "test-public-bucket"
-    config = DataImportConfig(s3_fs, config_file, output_path, input_bucket)
+    config = DepositionImportConfig(s3_fs, config_file, output_path, input_bucket)
 
     dataset = DatasetImporter(config, None)
     dataset_key_photos_importer = DatasetKeyPhotoImporter.find_dataset_key_photos(config, dataset)

--- a/ingestion_tools/scripts/tests/s3_import/test_voxel_spacing.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_voxel_spacing.py
@@ -3,7 +3,7 @@ from importers.dataset import DatasetImporter
 from importers.run import RunImporter
 from importers.tomogram import TomogramImporter
 
-from common.config import DataImportConfig
+from common.config import DepositionImportConfig
 from common.fs import FileSystemApi
 
 
@@ -29,7 +29,7 @@ def test_voxel_spacing_by_tomogram_metadata(
     output_path = f"{test_output_bucket}/output"
     input_bucket = "test-public-bucket"
 
-    config = DataImportConfig(s3_fs, import_config, output_path, input_bucket)
+    config = DepositionImportConfig(s3_fs, import_config, output_path, input_bucket)
     config.load_map_files()
     dataset = DatasetImporter(config, None)
     run = RunImporter.find_runs(config, dataset)[0]


### PR DESCRIPTION
This is the very beginning of a refactor to change the way we "find" annotations, tomograms, etc in our standardization script. It has just-enough functionality to support the current set of annotations that we need to import, but we'll be continuing this code refactor (and ingestion config refactor!) right after the current import is complete.