### PR TITLE
fix: Updating neuroglancer config with dimensions

### DIFF
--- a/ingestion_tools/scripts/importers/neuroglancer.py
+++ b/ingestion_tools/scripts/importers/neuroglancer.py
@@ -1,6 +1,8 @@
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
+import numpy as np
+
 from common.config import DataImportConfig
 from common.metadata import NeuroglancerMetadata
 from importers.base_importer import BaseImporter
@@ -21,37 +23,43 @@ class NeuroglancerImporter(BaseImporter):
         meta.write_metadata(dest_file)
         return dest_file
 
-    def get_config_json(self, tomo_zarr_dir: str) -> dict[str, Any]:
-        tomo_zarr_dir_url_path = tomo_zarr_dir.removeprefix(self.config.output_prefix)
-        zarr_url = urljoin(self.config.https_prefix, tomo_zarr_dir_url_path)
+    def get_config_json(self, zarr_dir: str) -> dict[str, Any]:
+        zarr_dir_url_path = zarr_dir.removeprefix(self.config.output_prefix)
+        zarr_url = urljoin(self.config.https_prefix, zarr_dir_url_path)
         voxel_size = self.parent.get_voxel_spacing()
-        dimensions = {k: [voxel_size * 10e-10, "m"] for k in "xyz"}
+        volume_header = self.parent.get_output_header()
+        dimensions = {k: [voxel_size * 1e-10, "m"] for k in "xyz"}
         return {
-            "dimensions": {
-                "z": [1, ""],
-                "y": [1, ""],
-                "x": [1, ""],
-            },
+            "dimensions": dimensions,
+            "position": self.get_position(volume_header),
+            "crossSectionScale": self.get_cross_section_scale(volume_header),
+            "crossSectionBackgroundColor": "#000000",
             "layers": [
                 {
                     "type": "image",
                     "source": f"zarr://{zarr_url}",
                     "opacity": 0.51,
                     "shader": "#uicontrol invlerp normalized\n\nvoid main() {\n  emitGrayscale(normalized());\n}\n",
-                    "shaderControls": self.get_shader_controller(),
+                    "shaderControls": self.get_shader_controller(volume_header),
                     "name": "tomogram",
-                    "transform": {
-                        "outputDimensions": dimensions,
-                        "inputDimensions": dimensions,
-                    },
                 },
             ],
             "selectedLayer": {"visible": True, "layer": "tomogram"},
             "layout": "4panel",
         }
 
-    def get_shader_controller(self) -> dict[str, Any]:
-        tomo_header = self.parent.get_output_header()
+    @classmethod
+    def get_cross_section_scale(cls, header: np.recarray) -> float:
+        avg_cross_section_render_height = 400
+        largest_dimension = max([header[f"n{d}"].item() - header[f"n{d}start"].item() for d in "xyz"])
+        return max(largest_dimension / avg_cross_section_render_height, 1)
+
+    @classmethod
+    def get_position(cls, header: np.recarray) -> list[float]:
+        return [np.round(np.mean([header[f"n{d}"].item(), header[f"n{d}start"].item()])) for d in "xyz"]
+
+    @classmethod
+    def get_shader_controller(cls, tomo_header: np.recarray) -> dict[str, Any]:
         width = 3 * tomo_header.rms.item()
 
         mean = tomo_header.dmean.item()


### PR DESCRIPTION
Relates to: https://github.com/chanzuckerberg/cryoet-data-portal/issues/622

### Changes Introduced

- Updates the dimensions for the neuroglancer scale with voxel spacing
- Adds center of the volume as the focus point of the neuroglancer on load
- Updates zoom for the cross sections to fit the longest dimension of the volume
- Sets the cross-section background to black for a better user experience 


#### Example: 

[Link 1](https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B2.164e-9%2C%22m%22%5D%2C%22y%22:%5B2.164e-9%2C%22m%22%5D%2C%22z%22:%5B2.164e-9%2C%22m%22%5D%7D%2C%22position%22:%5B480%2C464%2C64%5D%2C%22crossSectionScale%22:2.4%2C%22projectionScale%22:1009.4543247609109%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%22zarr://https://files.cryoetdataportal.cziscience.com/10027/wnj2019-02-21-5/Tomograms/VoxelSpacing21.640/CanonicalTomogram/wnj2019-02-21-5.zarr%22%2C%22tab%22:%22source%22%2C%22opacity%22:0.51%2C%22shader%22:%22#uicontrol%20invlerp%20normalized%5Cn%5Cnvoid%20main%28%29%20%7B%5Cn%20%20emitGrayscale%28normalized%28%29%29%3B%5Cn%7D%5Cn%22%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B-23.769954681396484%2C39.82769584655762%5D%2C%22window%22:%5B-26.94983720779419%2C43.00757837295532%5D%7D%7D%2C%22name%22:%22tomogram%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22tomogram%22%7D%2C%22crossSectionBackgroundColor%22:%22#000000%22%2C%22layout%22:%224panel%22%7D)

[Link 2](https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B6.44e-10%2C%22m%22%5D%2C%22y%22:%5B6.44e-10%2C%22m%22%5D%2C%22z%22:%5B6.44e-10%2C%22m%22%5D%7D%2C%22position%22:%5B726%2C764%2C240%5D%2C%22crossSectionScale%22:3.8225%2C%22projectionScale%22:2048%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%22zarr://https://files.cryoetdataportal.cziscience.com/10240/mba2011-08-01-1/Tomograms/VoxelSpacing6.440/CanonicalTomogram/mba2011-08-01-1.zarr%22%2C%22tab%22:%22source%22%2C%22opacity%22:0.51%2C%22shader%22:%22#uicontrol%20invlerp%20normalized%5Cn%5Cnvoid%20main%28%29%20%7B%5Cn%20%20emitGrayscale%28normalized%28%29%29%3B%5Cn%7D%5Cn%22%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B-104.5414171218872%2C-72.55971813201904%5D%2C%22window%22:%5B-106.14050207138061%2C-70.96063318252564%5D%7D%7D%2C%22name%22:%22tomogram%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22tomogram%22%7D%2C%22crossSectionBackgroundColor%22:%22#000000%22%2C%22layout%22:%224panel%22%7D)