### PR TITLE
feat: Adding db_import support for new fields

### DIFF
--- a/ingestion_tools/scripts/common/db_models.py
+++ b/ingestion_tools/scripts/common/db_models.py
@@ -135,6 +135,7 @@ class Tomogram(BaseModel):
     key_photo_thumbnail_url = CharField(null=True)
     neuroglancer_config = CharField(null=True)
     type = CharField(null=True)
+    deposition_id = IntegerField(null=True)
 
 
 class TomogramAuthor(BaseModel):
@@ -178,6 +179,8 @@ class Annotation(BaseModel):
     confidence_recall = FloatField(null=True)
     ground_truth_used = CharField()
     is_curator_recommended = BooleanField(default=False)
+    method_type = CharField()
+    deposition_id = IntegerField(null=True)
 
 
 class AnnotationFiles(BaseModel):

--- a/ingestion_tools/scripts/importers/db/annotation.py
+++ b/ingestion_tools/scripts/importers/db/annotation.py
@@ -50,6 +50,8 @@ class AnnotationDBImporter(BaseDBImporter):
             "ground_truth_used": ["annotation_confidence", "ground_truth_used"],
             "annotation_software": ["annotation_software"],
             "is_curator_recommended": ["is_curator_recommended"],
+            "method_type": ["method_type"],
+            "deposition_id": ["deposition_id"],
         }
 
     def import_to_db(self) -> BaseModel:

--- a/ingestion_tools/scripts/importers/db/tomogram.py
+++ b/ingestion_tools/scripts/importers/db/tomogram.py
@@ -57,6 +57,7 @@ class TomogramDBImporter(BaseDBImporter):
             "offset_y": ["offset", "y"],
             "offset_z": ["offset", "z"],
             "affine_transformation_matrix": ["affine_transformation_matrix"],
+            "deposition_id": ["deposition_id"],
         }
 
     def get_tomogram_type(self) -> str:

--- a/ingestion_tools/scripts/tests/db_import/test_db_annotation_import.py
+++ b/ingestion_tools/scripts/tests/db_import/test_db_annotation_import.py
@@ -37,6 +37,8 @@ def expected_annotations(http_prefix: str) -> list[dict[str, Any]]:
             "annotation_software": "pyTOM + Keras",
             "is_curator_recommended": True,
             "object_count": 16,
+            "deposition_id": 111111,
+            "method_type": "hybrid",
         },
     ]
 

--- a/ingestion_tools/scripts/tests/db_import/test_db_tomo_import.py
+++ b/ingestion_tools/scripts/tests/db_import/test_db_tomo_import.py
@@ -110,6 +110,7 @@ def expected_tomograms(http_prefix: str) -> list[dict[str, Any]]:
             "offset_z": 0,
             "neuroglancer_config": "{}",
             "type": "CANONICAL",
+            "deposition_id": 111111,
         },
     ]
 

--- a/test_infra/sql/schema.sql
+++ b/test_infra/sql/schema.sql
@@ -325,7 +325,9 @@ CREATE TABLE public.annotations (
     ground_truth_used character varying,
     tomogram_voxel_spacing_id integer,
     annotation_software character varying,
-    is_curator_recommended boolean DEFAULT false
+    is_curator_recommended boolean DEFAULT false,
+    deposition_id integer,
+    method_type character varying
 );
 
 
@@ -1405,7 +1407,8 @@ CREATE TABLE public.tomograms (
     key_photo_url character varying,
     key_photo_thumbnail_url character varying,
     neuroglancer_config character varying,
-    type text
+    type text,
+    deposition_id integer
 );
 
 

--- a/test_infra/test_files/30001/RUN1/Tomograms/VoxelSpacing12.300/Annotations/100-foo-1.0.json
+++ b/test_infra/test_files/30001/RUN1/Tomograms/VoxelSpacing12.300/Annotations/100-foo-1.0.json
@@ -49,5 +49,6 @@
             "shape": "SegmentationMask",
             "is_visualization_default": false
         }
-    ]
+    ],
+    "deposition_id": 111111
 }

--- a/test_infra/test_files/30001/RUN2/Tomograms/VoxelSpacing3.456/CanonicalTomogram/tomogram_metadata.json
+++ b/test_infra/test_files/30001/RUN2/Tomograms/VoxelSpacing3.456/CanonicalTomogram/tomogram_metadata.json
@@ -38,5 +38,6 @@
     "mrc_files": [
         "RUN2.mrc"
     ],
-    "run_name": "RUN2"
+    "run_name": "RUN2",
+    "deposition_id": 111111
 }


### PR DESCRIPTION
Relates to: https://github.com/chanzuckerberg/cryoet-data-portal/issues/542, https://github.com/chanzuckerberg/cryoet-data-portal/issues/443

### Changes Introduced
Adds db import support for deposition_id and method_type, and updates the relevant tests. 