### PR TITLE
Ingestion config for 10301 and tomoman mat-file to map-tsv conversion tool

### DIFF
--- a/ingestion_tools/dataset_configs/10301.yaml
+++ b/ingestion_tools/dataset_configs/10301.yaml
@@ -1,0 +1,312 @@
+dataset:
+  authors: &dataset_authors
+    - name: Ron Kelley,
+      corresponding_author_status: false
+      primary_author_status: true
+    - name: Xianjun Zhang,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: Martin Obr,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: Sagar Khavnekar,
+      corresponding_author_status: true
+      primary_author_status: true
+      ORCID: 0000-0003-2020-3561
+    - name: Ricardo D. Righetto,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: Florent Waltz,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: Wojciech Wietrzynski,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: Michael A,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: Grigory Tagiltsev,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: Florian Beck,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: Ellen Zhong,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: William Wan,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: John Briggs,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: M. Jürgen Plitzko,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: Benjamin D. Engel,
+      corresponding_author_status: false
+      primary_author_status: false
+    - name: Abhay Kotecha
+      corresponding_author_status: true
+      primary_author_status: false
+  cross_references:
+    dataset_publications: &dataset-publications EMPIAR-11756, 10.1093/micmic/ozad067.480
+    related_database_entries: EMPIAR-11756
+  cell_type:
+    name: Chlamydomonas reinhardtii
+  dataset_identifier: 10301
+  dataset_description: Cryo-electron tomography dataset of cryo-plasmaFIB milled lamella.
+  dataset_title: In situ cryo-ET dataset of Chlamydomonas reinhardtii prepared using cryo-plasmaFIB milling
+  dates: &repo-dates
+    deposition_date: 2024-04-09
+    last_modified_date: 2024-04-09
+    release_date: 2024-04-09
+#  funding:
+#    - funding_agency_name: RECOMMENDED
+#      grant_id: RECOMMENDED
+  grid_preparation: ~
+  key_photos:
+    snapshot: https://www.ebi.ac.uk/pdbe/emdb-empiar/entryIcons//11756-l.gif
+    thumbnail: https://www.ebi.ac.uk/pdbe/emdb-empiar/entryIcons//11756.gif
+  organism:
+    name: Chlamydomonas reinhardtii
+    taxonomy_id: 3055
+  sample_preparation: ~
+  sample_type: Organism
+annotations:
+  # F1-F0-ATPase complex
+  - metadata:
+      annotation_object:
+        id: GO:0045259
+        name: F1-F0-ATPase complex
+        description: proton-transporting ATP synthase complex
+      dates: *repo-dates
+      annotation_method: &annotation_method Template matching + manual filtering + 3D classification filtering
+      annotation_publications: *dataset-publications
+      ground_truth_status: true
+      authors: &annotation_authors
+        - name: Ron Kelley,
+          corresponding_author_status: false
+          primary_annotator_status: true
+        - name: Xianjun Zhang,
+        - name: Martin Obr,
+        - name: Sagar Khavnekar,
+          corresponding_author_status: true
+          primary_annotator_status: true
+          ORCID: 0000-0003-2020-3561
+        - name: Ricardo D. Righetto,
+          corresponding_author_status: false
+        - name: Florent Waltz,
+          corresponding_author_status: false
+        - name: Wojciech Wietrzynski,
+          corresponding_author_status: false
+        - name: Michael A,
+          corresponding_author_status: false
+        - name: Grigory Tagiltsev,
+          corresponding_author_status: false
+        - name: Florian Beck,
+          corresponding_author_status: false
+        - name: Ellen Zhong,
+          corresponding_author_status: false
+        - name: William Wan,
+          corresponding_author_status: false
+        - name: John Briggs,
+          corresponding_author_status: false
+        - name: M. Jürgen Plitzko,
+          corresponding_author_status: false
+        - name: Benjamin D. Engel,
+          corresponding_author_status: false
+        - name: Abhay Kotecha
+          corresponding_author_status: true
+      annotation_software: STOPGAP
+      version: "1.0"
+      is_curator_recommended: true
+    sources:
+      - file_format: stopgap_star
+        binning: 1
+        order: zyx
+        glob_string: "{run_name}/metadata/particles/f1atpase_*.star"
+        shape: OrientedPoint
+        filter_value: ~
+        is_visualization_default: true
+
+  # mitochondrial F1-F0-ATPase complex
+  - metadata:
+      annotation_object:
+        id: GO:0005753
+        name: mitochondrial F1-F0-ATPase complex
+        description: mitochondrial proton-transporting ATP synthase complex
+      dates: *repo-dates
+      annotation_method: *annotation_method
+      annotation_publications: *dataset-publications
+      ground_truth_status: true
+      authors: *annotation_authors
+      annotation_software: STOPGAP
+      version: "1.0"
+      is_curator_recommended: true
+    sources:
+      - file_format: stopgap_star
+        binning: 1
+        order: zyx
+        glob_string: "{run_name}/metadata/particles/f1atpase_mito_*.star"
+        shape: OrientedPoint
+        filter_value: ~
+        is_visualization_default: true
+
+  # Ribosome
+  - metadata:
+      annotation_object:
+        id: GO:0009326
+        name: cytosolic ribosome
+        description: Cytosolic ribosome
+      dates: *repo-dates
+      annotation_method: *annotation_method
+      annotation_publications: *dataset-publications
+      ground_truth_status: true
+      authors: *annotation_authors
+      annotation_software: STOPGAP
+      version: "1.0"
+      is_curator_recommended: true
+    sources:
+      - file_format: stopgap_star
+        binning: 1
+        order: zyx
+        glob_string: "{run_name}/metadata/particles/ribosome_*.star"
+        shape: OrientedPoint
+        filter_value: ~
+        is_visualization_default: true
+
+  # Nucleosome
+  - metadata:
+      annotation_object:
+        id: GO:0000786
+        name: nucleosome
+      dates: *repo-dates
+      annotation_method: *annotation_method
+      annotation_publications: *dataset-publications
+      ground_truth_status: true
+      authors: *annotation_authors
+      annotation_software: STOPGAP
+      version: "1.0"
+      is_curator_recommended: true
+    sources:
+      - file_format: stopgap_star
+        binning: 1
+        order: zyx
+        glob_string: "{run_name}/metadata/particles/nucleosome_*.star"
+        shape: OrientedPoint
+        filter_value: ~
+        is_visualization_default: true
+
+  # rubisco
+  - metadata:
+      annotation_object:
+        id: GO:0048492
+        name: RubisCO complex
+        description: ribulose bisphosphate carboxylase complex
+      dates: *repo-dates
+      annotation_method: *annotation_method
+      annotation_publications: *dataset-publications
+      ground_truth_status: true
+      authors: *annotation_authors
+      annotation_software: STOPGAP
+      version: "1.0"
+      is_curator_recommended: true
+    sources:
+      - file_format: stopgap_star
+        binning: 1
+        order: zyx
+        glob_string: "{run_name}/metadata/particles/rubisco_*.star"
+        shape: OrientedPoint
+        filter_value: ~
+        is_visualization_default: true
+
+  # microtubule
+  - metadata:
+      annotation_object:
+        id: GO:0005874
+        name: microtubule
+      dates: *repo-dates
+      annotation_method: *annotation_method
+      annotation_publications: *dataset-publications
+      ground_truth_status: true
+      authors: *annotation_authors
+      annotation_software: STOPGAP
+      version: "1.0"
+      is_curator_recommended: true
+    sources:
+      - file_format: stopgap_star
+        binning: 1
+        order: zyx
+        glob_string: "{run_name}/metadata/particles/microtubule_*.star"
+        shape: OrientedPoint
+        filter_value: ~
+        is_visualization_default: true
+
+runs: {}
+tiltseries:
+  acceleration_voltage: 300000
+  binning_from_frames: 1
+  camera:
+    manufacturer: FEI
+    model: FALCON IV
+  data_acquisition_software: TEM Tomography 5
+  microscope:
+    manufacturer: FEI
+    model: TITAN KRIOS
+  microscope_optical_setup:
+    energy_filter: Selectris X
+    phase_plate: None
+    image_corrector: None
+  pixel_spacing: 1.96
+  related_empiar_entry: EMPIAR-11756
+  scales: []
+  spherical_aberration_constant: 2.7
+  tilting_scheme: dose-symmetric
+  tilt_axis: "{tilt_series_tilt_axis_angle}"
+  tilt_range:
+    min: "{tilt_series_min}"
+    max: "{tilt_series_max}"
+  tilt_step: 3.0
+  tilt_series_quality: 5
+  total_flux: "{tilt_series_total_flux}"
+  is_aligned: false
+  alignment_binning_factor: null
+tomograms:
+  ctf_corrected: true
+  fiducial_alignment_status: false
+  offset:
+    x: 0
+    y: 0
+    z: 0
+  affine_transformation_matrix: [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]] # this is the identity matrix
+  processing: denoised
+  reconstruction_method: WBP
+  reconstruction_software: IMOD
+  tomogram_version: 1
+  voxel_spacing: 7.84
+  authors: *dataset_authors
+
+standardization_config:
+  destination_prefix: "10301"
+  source_prefix: "EMPIAR/11756/data/tomoman_minimal_project/"
+  run_data_map_file: "run_to_data_map.tsv"
+  run_glob: "*_BrnoKrios_*"
+  run_regex: /.*_BrnoKrios_.*$
+  run_name_regex: (.*)
+  frames_glob: "{run_name}/frames/*.eer"
+  frames_name_regex: (.*)
+  gain_glob: "{run_name}/*.dm4"
+  rawtlt_files:
+    - "{run_name}/{run_name}.rawtlt"
+    - "{run_name}/{run_name}.mdoc"
+    - "AreTomo/{run_name}_dose-filt.tlt"
+    - "AreTomo/{run_name}_dose-filt.xf"
+    - "ctffind4/ctfphaseflip_ctffind4.txt"
+  tiltseries_glob: "{run_name}/{run_name}.st"
+  ts_name_regex: (.*)
+  tomo_format: mrc
+  tomo_glob: "cryocare_bin4_tomoname/{run_name}.mrc"
+  tomo_regex: (.*)\.mrc
+  tomo_voxel_size: "7.84"
+  tomo_key_photo_glob: .*\.jpg

--- a/ingestion_tools/scripts/tomoman_to_tsv.py
+++ b/ingestion_tools/scripts/tomoman_to_tsv.py
@@ -1,0 +1,234 @@
+import csv
+from dataclasses import asdict, dataclass
+
+import click
+import numpy as np
+from scipy.io import loadmat
+
+from common.fs import FileSystemApi
+
+
+@dataclass
+class CtfParameters:
+    spherical_aberration: float  # mm
+    amplitude_contrast: float
+
+
+@dataclass
+class Defocus:
+    defocus_1: float  # micron
+    defocus_2: float  # micron
+    defocus_angle: float  # degrees
+
+
+@dataclass
+class TomomanData:
+    """Dataclass for Tomoman data"""
+
+    root_dir: str
+    stack_dir: str
+    frame_dir: str
+    mdoc_name: str
+    tomo_num: int
+    collected_tilts: list[float]  # degrees, in order of acquisition
+    frame_names: list[str]  # in order of acquisition
+    n_frames: int
+    pixelsize: float  # Angstrom
+    image_size: tuple[int, int]  # Pixels
+    voltage: float  # V
+    cumulative_exposure_time: list[float]
+    dose: list[float]  # e/A^2, cumulative, ordered by acquisition, before exclusion
+    target_defocus: float  # micron
+    gainref: str
+    defects_file: str
+    rotate_gain: float
+    flip_gain: float
+    raw_stack_name: str
+    mirror_stack: bool
+    skip: bool
+    frames_aligned: bool
+    frame_alignment_algorithm: str
+    stack_name: str
+    clean_stack: bool
+    removed_tilts: list[float]  # degrees
+    rawtlt: list[float]  # degrees, ordered low to high
+    max_tilt: float  # degrees (after removal)
+    min_tilt: float  # degrees (after removal)
+    tilt_axis_angle: float  # degrees
+    dose_filtered: bool
+    dose_filtered_stack_name: str
+    dose_filter_algorithm: str
+    imod_preprocessed: bool
+    stack_aligned: bool
+    alignment_stack: str
+    alignment_software: str
+    ctf_determined: bool
+    ctf_parameters: CtfParameters
+    ctf_determination_algorithm: str
+    determined_defocii: Defocus
+    tomo_recons: bool
+    tomo_recons_algorithm: str
+    metadata: dict[any, any]
+
+    @classmethod
+    def from_record(cls, record: np.ndarray):
+        root_dir = str(record["root_dir"][0])
+        stack_dir = str(record["stack_dir"][0])
+        frame_dir = str(record["frame_dir"][0])
+        mdoc_name = str(record["frame_dir"][0])
+        tomo_num = int(record["tomo_num"][0][0])
+        collected_tilts = [float(it[0]) for it in record["collected_tilts"].tolist()]
+        frame_names = [str(n[0][0]) for n in record["frame_names"]]
+        n_frames = int(record["n_frames"][0][0])
+        pixelsize = float(record["pixelsize"][0][0])
+        image_size = (int(record["image_size"][0][0]), int(record["image_size"][0][1]))
+        voltage = float(record["voltage"][0][0]) * 1000
+        cumulative_exposure_time = [float(it[0]) for it in record["cumulative_exposure_time"]]
+        dose = [float(it[0]) for it in record["dose"]]
+        target_defocus = float(record["target_defocus"][0][0])
+        gainref = str(record["gainref"][0])
+        defects_file = str(record["defects_file"][0])
+        rotate_gain = float(record["rotate_gain"][0][0])
+        flip_gain = float(record["flip_gain"][0][0])
+        raw_stack_name = str(record["raw_stack_name"][0])
+        mirror_stack = str(record["mirror_stack"][0]) == "y"
+        skip = record["skip"][0][0] != 0
+        frames_aligned = record["frames_aligned"][0][0] != 0
+        frame_alignment_algorithm = str(record["frame_alignment_algorithm"][0])
+        stack_name = str(record["stack_name"][0])
+        clean_stack = record["clean_stack"][0][0] != 0
+        removed_tilts = [float(it[0]) for it in record["removed_tilts"]]
+        rawtlt = [float(it[0]) for it in record["rawtlt"]]
+        max_tilt = float(record["max_tilt"][0][0])
+        min_tilt = float(record["min_tilt"][0][0])
+        tilt_axis_angle = float(record["tilt_axis_angle"][0][0])
+        dose_filtered = record["dose_filtered"][0][0] != 0
+        dose_filtered_stack_name = str(record["dose_filtered_stack_name"][0])
+        dose_filter_algorithm = str(record["dose_filter_algorithm"][0])
+        imod_preprocessed = record["imod_preprocessed"][0][0] != 0
+        stack_aligned = record["stack_aligned"][0][0] != 0
+        alignment_stack = str(record["alignment_stack"][0])
+        alignment_software = str(record["alignment_software"][0])
+        ctf_determined = record["ctf_determined"][0][0] != 0
+        ctf_parameters = CtfParameters(
+            float(record["ctf_parameters"][0][0][0][0][0]),
+            float(record["ctf_parameters"][0][0][1][0][0]),  # lol
+        )
+        ctf_determination_algorithm = str(record["ctf_determination_algorithm"][0])
+        determined_defocii = Defocus(
+            float(record["determined_defocii"][0][0]),
+            float(record["determined_defocii"][0][1]),
+            float(record["determined_defocii"][0][2]),
+        )
+        tomo_recons = record["tomo_recons"][0][0] != 0
+        tomo_recons_algorithm = str(record["tomo_recons_algorithm"])
+        metadata = {}
+
+        return cls(
+            root_dir,
+            stack_dir,
+            frame_dir,
+            mdoc_name,
+            tomo_num,
+            collected_tilts,
+            frame_names,
+            n_frames,
+            pixelsize,
+            image_size,
+            voltage,
+            cumulative_exposure_time,
+            dose,
+            target_defocus,
+            gainref,
+            defects_file,
+            rotate_gain,
+            flip_gain,
+            raw_stack_name,
+            mirror_stack,
+            skip,
+            frames_aligned,
+            frame_alignment_algorithm,
+            stack_name,
+            clean_stack,
+            removed_tilts,
+            rawtlt,
+            max_tilt,
+            min_tilt,
+            tilt_axis_angle,
+            dose_filtered,
+            dose_filtered_stack_name,
+            dose_filter_algorithm,
+            imod_preprocessed,
+            stack_aligned,
+            alignment_stack,
+            alignment_software,
+            ctf_determined,
+            ctf_parameters,
+            ctf_determination_algorithm,
+            determined_defocii,
+            tomo_recons,
+            tomo_recons_algorithm,
+            metadata,
+        )
+
+
+@dataclass
+class PortalOutput:
+    run_name: str
+    tilt_series_min_tilt: float
+    tilt_series_max_tilt: float
+    tilt_series_tilt_axis_angle: float
+    tilt_series_total_flux: float
+
+    @classmethod
+    def from_tomoman(cls, record: TomomanData):
+        # collected_tilts has all acquired tilts in acquisition order before excluding tilts
+        # rawtlt has all remaining tilts, ordered low to high after excluding bad tilts
+        # need to find the index into dose (cumulative dose) of the angle that was last acquired to find total flux
+        # step backward through collected_tilts to find the last acquired tilt remaining in rawtlt
+        last_tilt = record.collected_tilts[-1]
+        for tilt in reversed(record.collected_tilts):
+            if tilt in record.rawtlt:
+                last_tilt = tilt
+                break
+
+        idx = record.collected_tilts.index(last_tilt)
+        tilt_series_total_flux = record.dose[idx]
+
+        return cls(
+            run_name=record.stack_dir.replace(record.root_dir, "").strip("/"),
+            tilt_series_min_tilt=record.min_tilt,
+            tilt_series_max_tilt=record.max_tilt,
+            tilt_series_tilt_axis_angle=record.tilt_axis_angle,
+            tilt_series_total_flux=tilt_series_total_flux,
+        )
+
+
+@click.group()
+@click.pass_context
+def cli(ctx):
+    pass
+
+
+@cli.command()
+@click.argument("tomoman_file", required=True, type=str)
+@click.argument("output_file", required=True, type=str)
+@click.pass_context
+def convert(ctx, tomoman_file: str, output_file: str):
+    fs = FileSystemApi.get_fs_api(mode="s3", force_overwrite=True)
+    local_file = fs.localreadable(tomoman_file)
+
+    records = loadmat(local_file)["tomolist"][0]
+    data = [TomomanData.from_record(record) for record in records]
+
+    with fs.open(output_file, "w") as f:
+        head = asdict(PortalOutput.from_tomoman(data[0])).keys()
+        writer = csv.DictWriter(f, fieldnames=head, delimiter="\t")
+        writer.writeheader()
+
+        for d in data:
+            writer.writerow(asdict(PortalOutput.from_tomoman(d)))
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
1. Ingestion config for 10301 including metadata and all available annotations. 
2. A short script extracting metadata referenced in the ingestion config from the tomoman `.mat` file and writing them to a run to data map tsv

Run the script as 

`tomoman_to_tsv.py convert PATH/TO/tomolist.mat PATH/TO/run_to_data_map.tsv`

Both files live on S3.
