### PR TITLE
fix: Updating key image generation when no annotation exists

### DIFF
--- a/ingestion_tools/scripts/common/make_key_image.py
+++ b/ingestion_tools/scripts/common/make_key_image.py
@@ -73,17 +73,7 @@ def generate_preview(
 
     i = 0
 
-    # Don't explode if we can't find an annotations file.
-    def wrapiterator(iterator):
-        while True:
-            try:
-                yield next(iterator)
-            except StopIteration:
-                break
-            except Exception as e:
-                print(f"Ignoring missing annotation for keyframe generation: {e}")
-
-    for i, annotation in wrapiterator(enumerate(annotations)):
+    for i, annotation in enumerate(annotations):
         color = cmap(i)
         for item in annotation:
             if (t := item.get("type")) is None:


### PR DESCRIPTION
Updates to handle when an annotation file doesn't exist for specific annotation spec. 