### PR TITLE
chore: Make a new `annotation_authors.primary_author_status` field

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 23.9.1
+  rev: 24.4.0
   hooks:
   - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.292
+  rev: v0.4.1
   hooks:
   - id: ruff
     args:

--- a/api_server/metadata/databases/cryoetdataportal/tables/public_annotation_authors.yaml
+++ b/api_server/metadata/databases/cryoetdataportal/tables/public_annotation_authors.yaml
@@ -20,6 +20,7 @@ select_permissions:
         - name
         - orcid
         - primary_annotator_status
+        - primary_author_status
       filter: {}
       allow_aggregations: true
       query_root_fields:

--- a/api_server/migrations/cryoetdataportal/1712956764128_alter_table_public_annotation_authors_add_column_primary_author_status/down.sql
+++ b/api_server/migrations/cryoetdataportal/1712956764128_alter_table_public_annotation_authors_add_column_primary_author_status/down.sql
@@ -1,4 +1,1 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- alter table "public"."annotation_authors" add column "primary_author_status" boolean
---  null;
+alter table "public"."annotation_authors" drop column "primary_author_status";

--- a/api_server/migrations/cryoetdataportal/1712956764128_alter_table_public_annotation_authors_add_column_primary_author_status/down.sql
+++ b/api_server/migrations/cryoetdataportal/1712956764128_alter_table_public_annotation_authors_add_column_primary_author_status/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."annotation_authors" add column "primary_author_status" boolean
+--  null;

--- a/api_server/migrations/cryoetdataportal/1712956764128_alter_table_public_annotation_authors_add_column_primary_author_status/up.sql
+++ b/api_server/migrations/cryoetdataportal/1712956764128_alter_table_public_annotation_authors_add_column_primary_author_status/up.sql
@@ -1,0 +1,3 @@
+alter table "public"."annotation_authors" add column "primary_author_status" boolean
+ null;
+UPDATE "public"."annotation_authors" SET primary_author_status = primary_annotator_status;

--- a/ingestion_tools/Dockerfile
+++ b/ingestion_tools/Dockerfile
@@ -17,7 +17,7 @@ ENV IMOD_DIR /usr/local/IMOD
 
 # Get our packaging house in order
 RUN pip install --upgrade pip
-ENV POETRY_VERSION=1.7
+ENV POETRY_VERSION=1.8.2
 RUN python3 -m pip install --no-cache-dir poetry==$POETRY_VERSION
 
 # Install our dependencies

--- a/ingestion_tools/pyproject.toml
+++ b/ingestion_tools/pyproject.toml
@@ -50,6 +50,10 @@ line-length = 120
 target_version = ['py311']
 
 [tool.ruff]
+line-length = 120
+target-version = "py39"
+
+[tool.ruff.lint]
 select = [
     "E", "W",  # pycodestyle
     "F",  # pyflakes
@@ -72,17 +76,15 @@ ignore = [
     "DTZ007", # Datetime objects without timezones.
     "DTZ005", # More datetimes without timezones.
 ]
-line-length = 120
-target-version = "py39"
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore `SIM115` (not using open() in a context manager) since all calls to this method *do* use a context manager.
 "scripts/common/fs.py" = ["SIM115"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party =["common"]
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 docstring-quotes = "double"
 
 [tool.mypy]

--- a/ingestion_tools/scripts/common/db_models.py
+++ b/ingestion_tools/scripts/common/db_models.py
@@ -106,10 +106,7 @@ class Tomogram(BaseModel):
         table_name = "tomograms"
 
     id = IntegerField(primary_key=True)
-    tomogram_voxel_spacing_id = ForeignKeyField(
-        TomogramVoxelSpacing,
-        backref="tomograms",
-    )
+    tomogram_voxel_spacing_id = ForeignKeyField(TomogramVoxelSpacing, backref="tomograms")
     name = CharField()
     size_x = IntegerField()
     size_y = IntegerField()
@@ -163,10 +160,7 @@ class Annotation(BaseModel):
         table_name = "annotations"
 
     id = IntegerField()
-    tomogram_voxel_spacing_id = ForeignKeyField(
-        TomogramVoxelSpacing,
-        backref="annotations",
-    )
+    tomogram_voxel_spacing_id = ForeignKeyField(TomogramVoxelSpacing, backref="annotations")
     s3_metadata_path = CharField()
     https_metadata_path = CharField()
     deposition_date = DateField()

--- a/ingestion_tools/scripts/common/db_models.py
+++ b/ingestion_tools/scripts/common/db_models.py
@@ -106,7 +106,10 @@ class Tomogram(BaseModel):
         table_name = "tomograms"
 
     id = IntegerField(primary_key=True)
-    tomogram_voxel_spacing_id = ForeignKeyField(TomogramVoxelSpacing, backref="tomograms")
+    tomogram_voxel_spacing_id = ForeignKeyField(
+        TomogramVoxelSpacing,
+        backref="tomograms",
+    )
     name = CharField()
     size_x = IntegerField()
     size_y = IntegerField()
@@ -160,7 +163,10 @@ class Annotation(BaseModel):
         table_name = "annotations"
 
     id = IntegerField()
-    tomogram_voxel_spacing_id = ForeignKeyField(TomogramVoxelSpacing, backref="annotations")
+    tomogram_voxel_spacing_id = ForeignKeyField(
+        TomogramVoxelSpacing,
+        backref="annotations",
+    )
     s3_metadata_path = CharField()
     https_metadata_path = CharField()
     deposition_date = DateField()

--- a/ingestion_tools/scripts/common/db_models.py
+++ b/ingestion_tools/scripts/common/db_models.py
@@ -206,6 +206,7 @@ class AnnotationAuthor(BaseModel):
     orcid = CharField(null=True)
     corresponding_author_status = BooleanField(default=False)
     primary_annotator_status = BooleanField(default=False)
+    primary_author_status = BooleanField(default=False)
     email = CharField(null=True)
     affiliation_name = CharField(null=True)
     affiliation_address = CharField(null=True)

--- a/ingestion_tools/scripts/importers/db/annotation.py
+++ b/ingestion_tools/scripts/importers/db/annotation.py
@@ -1,7 +1,5 @@
 from typing import Any, Iterator
 
-from common import db_models
-from common.db_models import BaseModel
 from importers.db.base_importer import (
     AuthorsStaleDeletionDBImporter,
     BaseDBImporter,
@@ -10,6 +8,9 @@ from importers.db.base_importer import (
     StaleParentDeletionDBImporter,
 )
 from importers.db.voxel_spacing import TomogramVoxelSpacingDBImporter
+
+from common import db_models
+from common.db_models import BaseModel
 
 
 class AnnotationDBImporter(BaseDBImporter):
@@ -147,6 +148,7 @@ class AnnotationAuthorDBImporter(AuthorsStaleDeletionDBImporter):
         data_map = super().update_data_map(data_map, metadata, index)
         primary_author_status = {
             "primary_annotator_status": metadata.get("primary_annotator_status", metadata.get("primary_author_status")),
+            "primary_author_status": metadata.get("primary_annotator_status", metadata.get("primary_author_status")),
         }
         return {**data_map, **primary_author_status}
 

--- a/ingestion_tools/scripts/importers/db/annotation.py
+++ b/ingestion_tools/scripts/importers/db/annotation.py
@@ -32,14 +32,8 @@ class AnnotationDBImporter(BaseDBImporter):
     def get_data_map(self) -> dict[str, Any]:
         return {
             "tomogram_voxel_spacing_id": self.voxel_spacing_id,
-            "s3_metadata_path": self.join_path(
-                self.config.s3_prefix,
-                self.metadata_path,
-            ),
-            "https_metadata_path": self.join_path(
-                self.config.https_prefix,
-                self.metadata_path,
-            ),
+            "s3_metadata_path": self.join_path(self.config.s3_prefix, self.metadata_path),
+            "https_metadata_path": self.join_path(self.config.https_prefix, self.metadata_path),
             "deposition_date": ["dates", "deposition_date"],
             "release_date": ["dates", "release_date"],
             "last_modified_date": ["dates", "last_modified_date"],
@@ -62,11 +56,7 @@ class AnnotationDBImporter(BaseDBImporter):
 
     def import_to_db(self) -> BaseModel:
         annotation_obj = super().import_to_db()
-        annotation_files = AnnotationFilesDBImporter.get_item(
-            annotation_obj.id,
-            self,
-            self.config,
-        )
+        annotation_files = AnnotationFilesDBImporter.get_item(annotation_obj.id, self, self.config)
         annotation_files.import_to_db()
         return annotation_obj
 
@@ -87,27 +77,13 @@ class AnnotationDBImporter(BaseDBImporter):
     ) -> Iterator["AnnotationDBImporter"]:
         annotation_dir_path = cls.join_path(voxel_spacing.dir_prefix, "Annotations/")
         return [
-            cls(
-                voxel_spacing_id,
-                annotation_dir_path,
-                annotation_metadata_path,
-                voxel_spacing,
-                config,
-            )
-            for annotation_metadata_path in config.glob_s3(
-                annotation_dir_path,
-                "*.json",
-            )
+            cls(voxel_spacing_id, annotation_dir_path, annotation_metadata_path, voxel_spacing, config)
+            for annotation_metadata_path in config.glob_s3(annotation_dir_path, "*.json")
         ]
 
 
 class AnnotationFilesDBImporter(StaleDeletionDBImporter):
-    def __init__(
-        self,
-        annotation_id: int,
-        parent: AnnotationDBImporter,
-        config: DBImportConfig,
-    ):
+    def __init__(self, annotation_id: int, parent: AnnotationDBImporter, config: DBImportConfig):
         self.annotation_id = annotation_id
         self.parent = parent
         self.config = config
@@ -121,17 +97,9 @@ class AnnotationFilesDBImporter(StaleDeletionDBImporter):
             "is_visualization_default": ["is_visualization_default"],
         }
 
-    def update_data_map(
-        self,
-        data_map: dict[str, Any],
-        metadata: dict[str, Any],
-        index: int,
-    ) -> dict[str, Any]:
+    def update_data_map(self, data_map: dict[str, Any], metadata: dict[str, Any], index: int) -> dict[str, Any]:
         data_map["s3_path"] = self.join_path(self.config.s3_prefix, metadata["path"])
-        data_map["https_path"] = self.join_path(
-            self.config.https_prefix,
-            metadata["path"],
-        )
+        data_map["https_path"] = self.join_path(self.config.https_prefix, metadata["path"])
         return data_map
 
     @classmethod
@@ -156,12 +124,7 @@ class AnnotationFilesDBImporter(StaleDeletionDBImporter):
 
 
 class AnnotationAuthorDBImporter(AuthorsStaleDeletionDBImporter):
-    def __init__(
-        self,
-        annotation_id: int,
-        parent: AnnotationDBImporter,
-        config: DBImportConfig,
-    ):
+    def __init__(self, annotation_id: int, parent: AnnotationDBImporter, config: DBImportConfig):
         self.annotation_id = annotation_id
         self.parent = parent
         self.config = config
@@ -180,22 +143,11 @@ class AnnotationAuthorDBImporter(AuthorsStaleDeletionDBImporter):
             "author_list_order": ["author_list_order"],
         }
 
-    def update_data_map(
-        self,
-        data_map: dict[str, Any],
-        metadata: dict[str, Any],
-        index: int,
-    ) -> dict[str, Any]:
+    def update_data_map(self, data_map: dict[str, Any], metadata: dict[str, Any], index: int) -> dict[str, Any]:
         data_map = super().update_data_map(data_map, metadata, index)
         primary_author_status = {
-            "primary_annotator_status": metadata.get(
-                "primary_annotator_status",
-                metadata.get("primary_author_status"),
-            ),
-            "primary_author_status": metadata.get(
-                "primary_annotator_status",
-                metadata.get("primary_author_status"),
-            ),
+            "primary_annotator_status": metadata.get("primary_annotator_status", metadata.get("primary_author_status")),
+            "primary_author_status": metadata.get("primary_annotator_status", metadata.get("primary_author_status")),
         }
         return {**data_map, **primary_author_status}
 

--- a/ingestion_tools/scripts/tests/db_import/test_db_annotation_import.py
+++ b/ingestion_tools/scripts/tests/db_import/test_db_annotation_import.py
@@ -19,7 +19,9 @@ import common.db_models as models
 
 @pytest.fixture
 def expected_annotations(http_prefix: str) -> list[dict[str, Any]]:
-    path = f"{DATASET_ID}/RUN1/Tomograms/VoxelSpacing12.300/Annotations/100-foo-1.0.json"
+    path = (
+        f"{DATASET_ID}/RUN1/Tomograms/VoxelSpacing12.300/Annotations/100-foo-1.0.json"
+    )
     return [
         {
             "id": ANNOTATION_ID,
@@ -84,6 +86,7 @@ def expected_annotation_authors() -> list[dict[str, Any]]:
             "name": "Jane Smith",
             "corresponding_author_status": False,
             "primary_annotator_status": True,
+            "primary_author_status": True,
             "author_list_order": 1,
         },
         {
@@ -91,6 +94,7 @@ def expected_annotation_authors() -> list[dict[str, Any]]:
             "name": "J Carpenter",
             "corresponding_author_status": False,
             "primary_annotator_status": True,
+            "primary_author_status": True,
             "author_list_order": 2,
         },
         {
@@ -98,6 +102,7 @@ def expected_annotation_authors() -> list[dict[str, Any]]:
             "name": "John Doe",
             "corresponding_author_status": False,
             "primary_annotator_status": False,
+            "primary_author_status": False,
             "orcid": "0000-0000-1234-0000",
             "email": "jdoe@test.com",
             "author_list_order": 3,
@@ -117,10 +122,15 @@ def test_import_annotations(
     expected_annotations_iter = iter(expected_annotations)
     expected_annotations_files_iter = iter(expected_annotation_files)
     actual_voxel_spacing = models.TomogramVoxelSpacing.get(id=TOMOGRAM_VOXEL_ID1)
-    for annotation in actual_voxel_spacing.annotations.order_by(models.Annotation.s3_metadata_path):
+    for annotation in actual_voxel_spacing.annotations.order_by(
+        models.Annotation.s3_metadata_path,
+    ):
         verify_model(annotation, next(expected_annotations_iter))
         assert len(annotation.files) == len(expected_annotation_files)
-        for file in annotation.files.order_by(models.AnnotationFiles.shape_type, models.AnnotationFiles.format):
+        for file in annotation.files.order_by(
+            models.AnnotationFiles.shape_type,
+            models.AnnotationFiles.format,
+        ):
             verify_model(file, next(expected_annotations_files_iter))
         assert len(annotation.authors) == 0
 
@@ -138,10 +148,15 @@ def test_import_annotations_files_removes_stale(
     expected_annotations_iter = iter(expected_annotations)
     expected_annotations_files_iter = iter(expected_annotation_files)
     actual_voxel_spacing = models.TomogramVoxelSpacing.get(id=TOMOGRAM_VOXEL_ID1)
-    for annotation in actual_voxel_spacing.annotations.order_by(models.Annotation.s3_metadata_path):
+    for annotation in actual_voxel_spacing.annotations.order_by(
+        models.Annotation.s3_metadata_path,
+    ):
         verify_model(annotation, next(expected_annotations_iter))
         assert len(annotation.files) == len(expected_annotation_files)
-        for file in annotation.files.order_by(models.AnnotationFiles.shape_type, models.AnnotationFiles.format):
+        for file in annotation.files.order_by(
+            models.AnnotationFiles.shape_type,
+            models.AnnotationFiles.format,
+        ):
             verify_model(file, next(expected_annotations_files_iter))
         assert len(annotation.authors) == 0
 
@@ -157,9 +172,13 @@ def test_import_annotation_authors(
     verify_dataset_import(["--import-annotation-authors"])
     expected_annotations_authors_iter = iter(expected_annotation_authors)
     actual_voxel_spacing = models.TomogramVoxelSpacing.get(id=TOMOGRAM_VOXEL_ID1)
-    for annotation in actual_voxel_spacing.annotations.order_by(models.Annotation.s3_metadata_path):
+    for annotation in actual_voxel_spacing.annotations.order_by(
+        models.Annotation.s3_metadata_path,
+    ):
         assert len(annotation.authors) == len(expected_annotation_authors)
-        for author in annotation.authors.order_by(models.AnnotationAuthor.author_list_order):
+        for author in annotation.authors.order_by(
+            models.AnnotationAuthor.author_list_order,
+        ):
             verify_model(author, next(expected_annotations_authors_iter))
 
 
@@ -175,7 +194,11 @@ def test_import_annotation_authors_removes_stale(
     verify_dataset_import(["--import-annotation-authors"])
     expected_annotations_authors_iter = iter(expected_annotation_authors)
     actual_voxel_spacing = models.TomogramVoxelSpacing.get(id=TOMOGRAM_VOXEL_ID1)
-    for annotation in actual_voxel_spacing.annotations.order_by(models.Annotation.s3_metadata_path):
+    for annotation in actual_voxel_spacing.annotations.order_by(
+        models.Annotation.s3_metadata_path,
+    ):
         assert len(annotation.authors) == len(expected_annotation_authors)
-        for author in annotation.authors.order_by(models.AnnotationAuthor.author_list_order):
+        for author in annotation.authors.order_by(
+            models.AnnotationAuthor.author_list_order,
+        ):
             verify_model(author, next(expected_annotations_authors_iter))

--- a/ingestion_tools/scripts/tests/db_import/test_db_annotation_import.py
+++ b/ingestion_tools/scripts/tests/db_import/test_db_annotation_import.py
@@ -19,9 +19,7 @@ import common.db_models as models
 
 @pytest.fixture
 def expected_annotations(http_prefix: str) -> list[dict[str, Any]]:
-    path = (
-        f"{DATASET_ID}/RUN1/Tomograms/VoxelSpacing12.300/Annotations/100-foo-1.0.json"
-    )
+    path = f"{DATASET_ID}/RUN1/Tomograms/VoxelSpacing12.300/Annotations/100-foo-1.0.json"
     return [
         {
             "id": ANNOTATION_ID,

--- a/ingestion_tools/scripts/tests/db_import/test_db_annotation_import.py
+++ b/ingestion_tools/scripts/tests/db_import/test_db_annotation_import.py
@@ -120,15 +120,10 @@ def test_import_annotations(
     expected_annotations_iter = iter(expected_annotations)
     expected_annotations_files_iter = iter(expected_annotation_files)
     actual_voxel_spacing = models.TomogramVoxelSpacing.get(id=TOMOGRAM_VOXEL_ID1)
-    for annotation in actual_voxel_spacing.annotations.order_by(
-        models.Annotation.s3_metadata_path,
-    ):
+    for annotation in actual_voxel_spacing.annotations.order_by(models.Annotation.s3_metadata_path):
         verify_model(annotation, next(expected_annotations_iter))
         assert len(annotation.files) == len(expected_annotation_files)
-        for file in annotation.files.order_by(
-            models.AnnotationFiles.shape_type,
-            models.AnnotationFiles.format,
-        ):
+        for file in annotation.files.order_by(models.AnnotationFiles.shape_type, models.AnnotationFiles.format):
             verify_model(file, next(expected_annotations_files_iter))
         assert len(annotation.authors) == 0
 
@@ -146,15 +141,10 @@ def test_import_annotations_files_removes_stale(
     expected_annotations_iter = iter(expected_annotations)
     expected_annotations_files_iter = iter(expected_annotation_files)
     actual_voxel_spacing = models.TomogramVoxelSpacing.get(id=TOMOGRAM_VOXEL_ID1)
-    for annotation in actual_voxel_spacing.annotations.order_by(
-        models.Annotation.s3_metadata_path,
-    ):
+    for annotation in actual_voxel_spacing.annotations.order_by(models.Annotation.s3_metadata_path):
         verify_model(annotation, next(expected_annotations_iter))
         assert len(annotation.files) == len(expected_annotation_files)
-        for file in annotation.files.order_by(
-            models.AnnotationFiles.shape_type,
-            models.AnnotationFiles.format,
-        ):
+        for file in annotation.files.order_by(models.AnnotationFiles.shape_type, models.AnnotationFiles.format):
             verify_model(file, next(expected_annotations_files_iter))
         assert len(annotation.authors) == 0
 
@@ -170,13 +160,9 @@ def test_import_annotation_authors(
     verify_dataset_import(["--import-annotation-authors"])
     expected_annotations_authors_iter = iter(expected_annotation_authors)
     actual_voxel_spacing = models.TomogramVoxelSpacing.get(id=TOMOGRAM_VOXEL_ID1)
-    for annotation in actual_voxel_spacing.annotations.order_by(
-        models.Annotation.s3_metadata_path,
-    ):
+    for annotation in actual_voxel_spacing.annotations.order_by(models.Annotation.s3_metadata_path):
         assert len(annotation.authors) == len(expected_annotation_authors)
-        for author in annotation.authors.order_by(
-            models.AnnotationAuthor.author_list_order,
-        ):
+        for author in annotation.authors.order_by(models.AnnotationAuthor.author_list_order):
             verify_model(author, next(expected_annotations_authors_iter))
 
 
@@ -192,11 +178,7 @@ def test_import_annotation_authors_removes_stale(
     verify_dataset_import(["--import-annotation-authors"])
     expected_annotations_authors_iter = iter(expected_annotation_authors)
     actual_voxel_spacing = models.TomogramVoxelSpacing.get(id=TOMOGRAM_VOXEL_ID1)
-    for annotation in actual_voxel_spacing.annotations.order_by(
-        models.Annotation.s3_metadata_path,
-    ):
+    for annotation in actual_voxel_spacing.annotations.order_by(models.Annotation.s3_metadata_path):
         assert len(annotation.authors) == len(expected_annotation_authors)
-        for author in annotation.authors.order_by(
-            models.AnnotationAuthor.author_list_order,
-        ):
+        for author in annotation.authors.order_by(models.AnnotationAuthor.author_list_order):
             verify_model(author, next(expected_annotations_authors_iter))

--- a/test_infra/sql/schema.sql
+++ b/test_infra/sql/schema.sql
@@ -117,7 +117,7 @@ CREATE TABLE public.annotation_authors (
     affiliation_address character varying,
     affiliation_identifier character varying,
     author_list_order integer,
-    primary_author_status integer
+    primary_author_status boolean
 );
 
 

--- a/test_infra/sql/schema.sql
+++ b/test_infra/sql/schema.sql
@@ -116,7 +116,8 @@ CREATE TABLE public.annotation_authors (
     affiliation_name character varying,
     affiliation_address character varying,
     affiliation_identifier character varying,
-    author_list_order integer
+    author_list_order integer,
+    primary_author_status integer
 );
 
 

--- a/test_infra/sql/seed_db_data.sql
+++ b/test_infra/sql/seed_db_data.sql
@@ -29,16 +29,16 @@ INSERT INTO public.annotations VALUES (43, 's3://test-public-bucket/20002/RUN001
 INSERT INTO public.annotations VALUES (44, 's3://test-public-bucket/20002/RUN002/TomogramVoxelSpacing13.48/Annotations/author4-ribosome-1.0.json', 'http://localhost:4444/20002/RUN002/TomogramVoxelSpacing13.48/Annotations/author4-ribosome-1.0.json', '2023-04-01', '2023-06-01', '2023-06-01', 'EMPIAR-77777', 'Manual', true, 'Ribosome', 'GO:000000A', NULL, NULL, 16, NULL, NULL, NULL, 7, NULL, true);
 INSERT INTO public.annotations VALUES (45, 's3://test-public-bucket/20002/RUN002/TomogramVoxelSpacing13.48/Annotations/author4-spike-1.0.json', 'http://localhost:4444/20002/RUN002/TomogramVoxelSpacing13.48/Annotations/author4-spike-1.0.json', '2023-04-01', '2023-06-01', '2023-06-01', 'EMPIAR-77777', 'Manual', true, 'Spike Protein', 'GO:000000A', NULL, NULL, 16, NULL, NULL, NULL, 7, NULL, true);
 
-INSERT INTO public.annotation_authors VALUES (50, 40, 'Author 1', '0000-0000-0000-0007', false, true, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO public.annotation_authors VALUES (51, 40, 'Author 2', '0000-0000-0000-0008', false, true, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO public.annotation_authors VALUES (52, 41, 'Author 1', '0000-0000-0000-0007', false, true, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO public.annotation_authors VALUES (53, 41, 'Author 2', '0000-0000-0000-0008', false, true, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO public.annotation_authors VALUES (54, 42, 'Author 3', '0000-0000-0000-0039', false, true, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO public.annotation_authors VALUES (55, 42, 'Author 4', '0000-0000-0000-0049', false, true, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO public.annotation_authors VALUES (56, 43, 'Author 5', '0000-0000-0000-0059', false, true, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO public.annotation_authors VALUES (57, 44, 'Author 6', '0000-0000-0000-0069', false, true, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO public.annotation_authors VALUES (58, 45, 'Author 7', '0000-0000-0000-0079', false, true, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO public.annotation_authors VALUES (59, 45, 'Author 8', '0000-0000-0000-0089', false, true, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO public.annotation_authors VALUES (50, 40, 'Author 1', '0000-0000-0000-0007', false, true, NULL, NULL, NULL, NULL, NULL, true);
+INSERT INTO public.annotation_authors VALUES (51, 40, 'Author 2', '0000-0000-0000-0008', false, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO public.annotation_authors VALUES (52, 41, 'Author 1', '0000-0000-0000-0007', false, true, NULL, NULL, NULL, NULL, NULL, true);
+INSERT INTO public.annotation_authors VALUES (53, 41, 'Author 2', '0000-0000-0000-0008', true,  NULL, NULL, NULL, NULL, NULL, NULL  NULL);
+INSERT INTO public.annotation_authors VALUES (54, 42, 'Author 3', '0000-0000-0000-0039', false, true, NULL, NULL, NULL, NULL, NULL, true);
+INSERT INTO public.annotation_authors VALUES (55, 42, 'Author 4', '0000-0000-0000-0049', true, false, NULL, NULL, NULL, NULL, NULL, false);
+INSERT INTO public.annotation_authors VALUES (56, 43, 'Author 5', '0000-0000-0000-0059', false, true, NULL, NULL, NULL, NULL, NULL, true);
+INSERT INTO public.annotation_authors VALUES (57, 44, 'Author 6', '0000-0000-0000-0069', false, true, NULL, NULL, NULL, NULL, NULL, true);
+INSERT INTO public.annotation_authors VALUES (58, 45, 'Author 7', '0000-0000-0000-0079', false, true, NULL, NULL, NULL, NULL, NULL, true);
+INSERT INTO public.annotation_authors VALUES (59, 45, 'Author 8', '0000-0000-0000-0089', false, true, NULL, NULL, NULL, NULL, NULL, true);
 
 
 INSERT INTO public.annotation_files VALUES (70, 40, 'OrientedPoint', 'ndjson', 'http://localhost:4444/20001/RUN1/TomogramVoxelSpacing13.48/Annotations/mitochondria.ndjson', 's3://test-public-bucket/20001/RUN1/TomogramVoxelSpacing13.48/Annotations/mitochondria.ndjson');


### PR DESCRIPTION
This field is set up to have the exact same data as `annotation_authors.primary_annotation_status` so we can add the new field, get clients updated to use it, and then deprecate the old one.