### PR TITLE
Minor refactor of Annotation to improve code reuse

### DIFF
--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -115,8 +115,14 @@ class SegmentationMaskFile(VolumeAnnotationSource):
         write_mrc: bool = True,
         write_zarr: bool = True,
     ):
-        input_file = self.get_source_file(fs, input_prefix)
-        return scale_mrcfile(fs, self.get_output_filename(output_prefix), input_file, voxel_spacing=voxel_spacing)
+        return scale_mrcfile(
+            fs,
+            self.get_output_filename(output_prefix),
+            self.get_source_file(fs, input_prefix),
+            write_mrc=write_mrc,
+            write_zarr=write_zarr,
+            voxel_spacing=voxel_spacing,
+        )
 
 
 class SemanticSegmentationMaskFile(VolumeAnnotationSource):
@@ -147,12 +153,13 @@ class SemanticSegmentationMaskFile(VolumeAnnotationSource):
         write_mrc: bool = True,
         write_zarr: bool = True,
     ):
-        input_file = self.get_source_file(fs, input_prefix)
         return scale_mrcfile(
             fs,
             self.get_output_filename(output_prefix),
-            input_file,
+            self.get_source_file(fs, input_prefix),
             label=self.label,
+            write_mrc=write_mrc,
+            write_zarr=write_zarr,
             voxel_spacing=voxel_spacing,
         )
 

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -9,7 +9,7 @@ import numpy as np
 from common import instance_point_converter as ipc
 from common import oriented_point_converter as opc
 from common.fs import FileSystemApi
-from common.image import check_mask_for_label, scale_maskfile, scale_mrcfile
+from common.image import check_mask_for_label, scale_mrcfile
 from common.metadata import AnnotationMetadata
 from importers.base_importer import BaseImporter
 
@@ -121,12 +121,11 @@ class SemanticSegmentationMaskFile(VolumeAnnotationSource):
 
     def convert(self, fs: FileSystemApi, input_prefix: str, output_prefix: str, voxel_spacing: float = None):
         input_file = self.get_source_file(fs, input_prefix)
-        return scale_maskfile(
+        return scale_mrcfile(
             fs,
             self.get_output_filename(output_prefix),
             input_file,
-            self.label,
-            write=True,
+            label=self.label,
             voxel_spacing=voxel_spacing,
         )
 
@@ -305,11 +304,7 @@ class InstanceSegmentationFile(OrientedPointFile):
         # In case of instance segmentation, we need to count the unique IDs (i.e. number of instances)
         return len(set(ids))
 
-    def load(
-        self,
-        fs: FileSystemApi,
-        filename: str,
-    ):
+    def load(self, fs: FileSystemApi, filename: str):
         method = self.map_functions[self.file_format]
         local_file = fs.localreadable(filename)
 

--- a/ingestion_tools/scripts/standardize_dirs.py
+++ b/ingestion_tools/scripts/standardize_dirs.py
@@ -139,7 +139,7 @@ def convert(
                 if iterate_annotations:
                     for annotation in AnnotationImporter.find_annotations(config, tomo):
                         if import_annotations:
-                            annotation.import_annotations(True)
+                            annotation.import_annotations(write_mrc=write_mrc, write_zarr=write_zarr)
                         if import_annotation_metadata:
                             annotation.import_metadata()
                 if iterate_keyimages:


### PR DESCRIPTION
### Changes Introduced

- Refactors code to unify scale_mrcfile and scale_maskfile by adding `label` parameter to scale_mrcfile. 
- Simplifies `MaskConverter` by making the `TomoConverter` more extensible
- Adds write_mrc and write_zarr flag implementation to annotations 
