### PR TITLE
Adding github workflow to build and push ingestor image

### DIFF
--- a/.github/workflows/push-ingestor-build.yaml
+++ b/.github/workflows/push-ingestor-build.yaml
@@ -15,8 +15,8 @@ permissions:
 
 jobs:
   deploy-to-staging:
-    name: deploy staging branch
-    runs-on: [ARM64, self-hosted, Linux]
+    name: build and push ingestor to remote
+    runs-on: ubuntu-latest
     environment: staging
     if: github.repository == 'chanzuckerberg/cryoet-data-portal-backend'
     steps:

--- a/.github/workflows/push-ingestor-build.yaml
+++ b/.github/workflows/push-ingestor-build.yaml
@@ -1,0 +1,35 @@
+name: Build and push ingestor to remote
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "ingestion_tools/**"
+      - ".github/workflows/push-ingestor-build.yaml"
+
+# https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy-to-staging:
+    name: deploy staging branch
+    runs-on: [ARM64, self-hosted, Linux]
+    environment: staging
+    if: github.repository == 'chanzuckerberg/cryoet-data-portal-backend'
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          mask-aws-account-id: true
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1200
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Build and push Docker image
+        env:
+          ECR_REPO: ${{ secrets.ECR_REPO }}
+        run: make push-ingestor-build ecr_repo=$ECR_REPO tag=latest

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ push-local-ingestor-build:
 	aws_region=$$(aws configure get region); \
 	account_id=$$(aws sts get-caller-identity | jq -r ".Account"); \
 	ecr_repo=$$account_id.dkr.ecr.$$aws_region.amazonaws.com; \
-	aws ecr get-login-password --region $$aws_region | docker login --username AWS --password-stdin $$ecr_repo;	\
+	aws ecr get-login-password --region $$aws_region | docker login --username AWS --password-stdin $$ecr_repo; \
 	make push-ingestor-build ecr_repo=$$ecr_repo/cryoet-staging tag=$(tag);
 
 .PHONY: push-ingestor-build


### PR DESCRIPTION
Relates to: https://github.com/chanzuckerberg/cryoet-data-portal/issues/363

### Changes introduced

- Adds make target to build and push to remote repo
- Introduces github workflow to build and push ingestor image to remote when changes are merged to main.