### PR TITLE
Increasing prod service count

### DIFF
--- a/.happy/terraform/envs/prod/main.tf
+++ b/.happy/terraform/envs/prod/main.tf
@@ -24,7 +24,8 @@ module "stack" {
   services = {
     cryoet-api = {
       name              = "cryoet-api",
-      desired_count     = 1,
+      desired_count     = 2,
+      max_count         = 5,
       port              = 8080,
       memory            = "1500Mi"
       cpu               = "1500m"


### PR DESCRIPTION
### Changes introduced

Increases the desired number of servers for the graphql api in prod from 1 -> 2. This would help create redundancies for the production of the API service. 

Increases the max count for the graphql api in prod from 2 -> 5. Allows the application to scale to up to 5 instances.