### PR TITLE
feat: Adding index on deposition_id columns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ ingestor-init:
 .PHONY: api-init
 api-init:
 	docker compose --profile api up -d
-	cd ./test_infra/; ./seed_moto.sh
 	docker compose cp test_infra/sql db:/tmp/sql
 	docker compose exec db sh -c 'cat /tmp/sql/seed_db_data.sql | psql postgres://postgres:postgres@127.0.0.1:5432/cryoet'
 

--- a/api_server/migrations/cryoetdataportal/1717093534072_create_index_annotations_deposition_id/down.sql
+++ b/api_server/migrations/cryoetdataportal/1717093534072_create_index_annotations_deposition_id/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "public"."annotations_deposition_id";

--- a/api_server/migrations/cryoetdataportal/1717093534072_create_index_annotations_deposition_id/up.sql
+++ b/api_server/migrations/cryoetdataportal/1717093534072_create_index_annotations_deposition_id/up.sql
@@ -1,0 +1,1 @@
+CREATE  INDEX "annotations_deposition_id" on "public"."annotations" using btree ("deposition_id");

--- a/api_server/migrations/cryoetdataportal/1717093573267_create_index_tomograms_deposition_id/down.sql
+++ b/api_server/migrations/cryoetdataportal/1717093573267_create_index_tomograms_deposition_id/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "public"."tomograms_deposition_id";

--- a/api_server/migrations/cryoetdataportal/1717093573267_create_index_tomograms_deposition_id/up.sql
+++ b/api_server/migrations/cryoetdataportal/1717093573267_create_index_tomograms_deposition_id/up.sql
@@ -1,0 +1,1 @@
+CREATE  INDEX "tomograms_deposition_id" on  "public"."tomograms" using btree ("deposition_id");


### PR DESCRIPTION

### Changes introduced

Adds a btree index on the `deposition_id` column of `annotations` and `tomograms` table. This helps optimize for querying on the deposition_id on those tables. 