### PR TITLE
Install new TLS roots for RDS db's.

### DIFF
--- a/api_server/Dockerfile
+++ b/api_server/Dockerfile
@@ -1,4 +1,8 @@
 FROM hasura/graphql-engine:v2.25.1.cli-migrations-v3
+# Install DB certs.
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/global-bundle.crt
+RUN update-ca-certificates
+
 ADD ./migrations /hasura-migrations
 ADD ./metadata /hasura-metadata
 ADD . /app

--- a/ingestion_tools/Dockerfile
+++ b/ingestion_tools/Dockerfile
@@ -6,6 +6,10 @@ RUN mkdir ingestion_tools
 # Base utilities
 RUN apt update && apt install -y wget unzip jq
 
+# Install DB TLS certs
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/global-bundle.crt
+RUN update-ca-certificates
+
 # IMOD helps with MRC ingestion
 # bio3d.colorado.edu isn't sending an intermediate cert, which breaks openssl (no AIA support). So we're installing it here.
 RUN wget http://crt.sectigo.com/SectigoRSAOrganizationValidationSecureServerCA.crt && \


### PR DESCRIPTION
For https://github.com/chanzuckerberg/cryoet-data-portal/issues/777, updates the TLS certificates in docker containers that need DB access.