### PR TITLE
fix: Fixing ds10301 annotion glob

### DIFF
--- a/ingestion_tools/dataset_configs/10301.yaml
+++ b/ingestion_tools/dataset_configs/10301.yaml
@@ -53,7 +53,7 @@ annotations:
   - binning: 4
     file_format: stopgap_star
     filter_value: '{annotation_micrograph_name}'
-    glob_string: '{run_name}/metadata/particles/f1atpase_*.star'
+    glob_string: '{run_name}/metadata/particles/f1atpase_bin*.star'
     is_visualization_default: true
     order: xyz
     shape: OrientedPoint


### PR DESCRIPTION
### Changes introduced
Updates the glob for the `F1-F0-ATPase complex` as it currently also matches against files for `mitochondrial F1-F0-ATPase complex`. 