### PR TITLE
Run ingestion scripts semi-locally and update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # Community Tomography Data Portal Backend
 CryoET Portal API server and ingestion tools
 
-To launch a local dev environment:
+To launch a local dev environment (Docker required):
 ```
 make init
 ```
 
 Wait another ~10s and then visit http://localhost:9695/ in your browser.
 
+## Testing
+
+To initialize the database with test data:
+```
+make ingestor-test-db-init
+```
+
+For ingestion process testing, see the [ingestion_tools README](ingestion_tools/README.md).
 
 ## Code of Conduct
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - ./test_infra:/test_infra
     ports:
       - '5432:5432'
+      - '5433:5432' # for connecting to the db from localhost
   cryoet-api:
     platform: linux/arm64
     profiles: ["api"]

--- a/ingestion_tools/README.md
+++ b/ingestion_tools/README.md
@@ -1,3 +1,55 @@
 # Ingestion utilities
 
 This package contains ingestion scripts, libraries, and configurations for converting raw research datasets into a format compatible with the CryoET Data Portal.
+
+## Running tests
+
+Whether running tests on Docker or locally, please ensure that your Docker environment is set up and has the test data as described in the [README](../README.md) before running tests.
+Either way, `breakpoint()` statements can be added to the code to pause execution and allow for debugging.
+
+### Running tests on Docker
+
+From the root of the repository, run the following command to build the Docker image and run the tests:
+```bash
+make ingestor-test-db
+make ingestor-test-s3
+```
+
+### Running tests locally
+
+Install dependencies with (from the `ingestion_tools/scripts` directory):
+```bash
+pip install poetry
+poetry install
+```
+
+If running these tests locally with a Dockerized database, set the `DB_CONNECTION` and `ENDPOINT_URL` environment variables:
+```bash
+export DB_CONNECTION=postgresql://postgres:postgres@127.0.0.1:5433/cryoet
+export ENDPOINT_URL=http://127.0.0.1:5566/
+export AWS_REGION=us-west-2
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+```
+
+Run the tests with (from the `ingestion_tools/scripts` directory):
+```bash
+python -m pytest
+```
+
+### Forwarding nginx port 80 to 4444
+
+When running tests locally, note that any URLs in test dataset files referencing `nginx:80` in the tests will fail with the above code. To prevent this, a workaround is
+ to run the following commands instead (`socat` must be installed, `sudo` is required):
+
+In a new terminal terminal (to forward port 80 to 4444):
+```bash
+sudo socat TCP-LISTEN:80,fork,reuseaddr TCP:localhost:4444
+```
+
+In the terminal which your environmenmt variables are set (from the `ingestion_tools/scripts` directory):
+```bash
+sudo bash -c 'echo "127.0.0.1 nginx # temp entry" >> /etc/hosts'
+python -m pytest
+sudo sed -i '/127.0.0.1 nginx # temp entry/d' /etc/hosts
+```


### PR DESCRIPTION
Note that it is semi-locally since we still depend on the servers running in Docker containers.

To run ingestion scripts (for dev / debugging purposes) on your local machine, port 5433 is exposed to the local machine (arbitrary port) since trying to connect to port 5432 was giving issues, see https://stackoverflow.com/a/55259785. 

Also updated README files to provide a bit more insight to running tests in general, as well as adding sections about how to get Dockerized and local testing running (especially local testing, since there's some workarounds to get all tests passing with the postgresql / motoserver / nginx servers on Docker).