### PR TITLE
fix: Fix finders and add test coverage for them.

### DIFF
--- a/ingestion_tools/scripts/common/finders.py
+++ b/ingestion_tools/scripts/common/finders.py
@@ -133,14 +133,14 @@ class DepositionObjectImporterFactory(ABC):
     def _should_search(self, **parent_objects: dict[str, Any] | None) -> bool:
         for parent_key, parent_obj in parent_objects.items():
             # Apply include/exclude filters
-            if self.exclude_parents.get(parent_key):
-                for regex in self.exclude_parents[parent_key]:
-                    if regex.search(parent_obj.name):
-                        return False
-            if self.include_parents.get(parent_key):
-                for regex in self.include_parents[parent_key]:
-                    if not regex.search(parent_obj.name):
-                        return False
+            if self.exclude_parents.get(parent_key) and any(
+                regex.search(parent_obj.name) for regex in self.exclude_parents[parent_key]
+            ):
+                return False
+            if self.include_parents.get(parent_key) and not any(
+                regex.search(parent_obj.name) for regex in self.include_parents[parent_key]
+            ):
+                return False
         return True
 
     def _get_glob_vars(self, **parent_objects: dict[str, Any] | None):

--- a/ingestion_tools/scripts/tests/s3_import/test_finders.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_finders.py
@@ -1,0 +1,134 @@
+import pytest
+from importers.dataset import DatasetImporter
+from importers.run import RunImporter
+from importers.voxel_spacing import VoxelSpacingImporter
+from standardize_dirs import IMPORTERS
+
+from common.config import DepositionImportConfig
+from common.finders import DefaultImporterFactory
+from common.fs import FileSystemApi
+
+
+@pytest.fixture
+def dataset_config(s3_fs: FileSystemApi, test_output_bucket: str) -> DepositionImportConfig:
+    config_file = "tests/fixtures/annotations/anno_config.yaml"
+    output_path = f"{test_output_bucket}/output"
+    input_bucket = "test-public-bucket"
+    config = DepositionImportConfig(s3_fs, config_file, output_path, input_bucket, IMPORTERS)
+    return config
+
+
+@pytest.fixture
+def parents(dataset_config):
+    dataset = DatasetImporter(config=dataset_config, metadata={}, name="dataset1", path="dataset1")
+    run = RunImporter(config=dataset_config, metadata={}, name="run1", path="run1", parents={"dataset": dataset})
+    parents = {"run": run, "dataset": dataset}
+    return parents
+
+
+@pytest.fixture
+def source_config():
+    source_config = {
+        "literal": {"value": ["10.11"]},
+        "parent_filters": {
+            "include": {"run": []},
+            "exclude": {"run": []},
+        },
+    }
+    return source_config
+
+
+def test_include_parents_with_single_value(dataset_config, parents, source_config):
+    # Test filtering includes properly
+    source_config["parent_filters"]["include"]["run"] = ["n1$"]
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 1
+
+    # Test filtering excludes properly
+    source_config["parent_filters"]["include"]["run"] = ["xxxxx"]
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 0
+
+
+def test_include_parents_with_multiple_values(dataset_config, parents, source_config):
+    # Test filtering includes properly
+    source_config["parent_filters"]["include"]["run"] = ["^abc", "def", "n1$"]
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 1
+
+    # Test filtering excludes properly
+    source_config["parent_filters"]["include"]["run"] = ["xxxxx", "yyy"]
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 0
+
+
+def test_exclude_parents_with_single_value(dataset_config, parents, source_config):
+    # Test filtering excludes properly
+    source_config["parent_filters"]["exclude"]["run"] = [
+        "n1$",
+    ]
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 0
+
+    # Test filtering includes properly
+    source_config["parent_filters"]["exclude"]["run"] = ["xxxxx"]
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 1
+
+
+def test_exclude_parents_with_multiple_values(dataset_config, parents, source_config):
+    # Test filtering excludes properly
+    source_config["parent_filters"]["exclude"]["run"] = [
+        "^abc",
+        "def",
+        "run1",
+    ]
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 0
+
+    # Test filtering includes properly
+    source_config["parent_filters"]["exclude"]["run"] = ["xxxxx"]
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 1
+
+
+def test_multi_parent_filters(dataset_config, parents, source_config):
+    # Test filtering excludes properly
+    source_config["parent_filters"]["exclude"] = {"run": ["aaaa", "n1$"]}  # excludes
+    source_config["parent_filters"]["include"] = {"dataset": ["xxx"]}  # excludes
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 0
+
+    source_config["parent_filters"]["exclude"] = {"dataset": ["aaaa", "t1$"]}  # excludes
+    source_config["parent_filters"]["include"] = {"run": ["aaaa", "n1$"]}  # includes
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 0
+
+    source_config["parent_filters"]["exclude"] = {"dataset": ["aaa"]}  # includes
+    source_config["parent_filters"]["include"] = {"run": ["t1$"]}  # excludes
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 0
+
+    # Test filtering includes properly
+    source_config["parent_filters"]["exclude"] = {"run": ["t1$"]}  # includes
+    source_config["parent_filters"]["include"] = {"dataset": ["t1$"]}  # includes
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 1
+
+    source_config["parent_filters"]["include"] = {"dataset": ["t1$"]}  # includes
+    source_config["parent_filters"]["exclude"] = {"run": ["xxx"]}  # includes
+    finder = DefaultImporterFactory(source_config)
+    items = finder.find(VoxelSpacingImporter, dataset_config, {}, **parents)
+    assert len(items) == 1


### PR DESCRIPTION

Fixes: https://github.com/chanzuckerberg/cryoet-data-portal/issues/842

## Description
This fixes the broken logic for include/exclude filters in ingestion configs. Basically it updates the logic so that if *any* exclude filter for *any* parent object is triggered, the object import will be canceled, and *at least one* of the include filters for each of the parent filters must match for the import to proceed.
