### PR TITLE
Rename cell type, other dataset config files fixes

### DIFF
--- a/ingestion_tools/dataset_configs/10000.yaml
+++ b/ingestion_tools/dataset_configs/10000.yaml
@@ -372,7 +372,7 @@ datasets:
       corresponding_author_status: true
       name: Judith B. Zaugg
     cell_strain:
-      id: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=284812
+      id: NCBITaxon:284812
       name: K972 Sp h-wild type
     cross_references:
       publications: doi:10.1101/2022.04.12.488077, doi:10.1038/s41592-022-01746-2

--- a/ingestion_tools/dataset_configs/10001.yaml
+++ b/ingestion_tools/dataset_configs/10001.yaml
@@ -372,7 +372,7 @@ datasets:
       corresponding_author_status: true
       name: Judith B. Zaugg
     cell_strain:
-      id: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=284812
+      id: NCBITaxon:284812
       name: K972 Sp h-wild type
     cross_references:
       publications: doi:10.1101/2022.04.12.488077, doi:10.1038/s41592-022-01746-2

--- a/ingestion_tools/dataset_configs/10003.yaml
+++ b/ingestion_tools/dataset_configs/10003.yaml
@@ -62,8 +62,8 @@ datasets:
       corresponding_author_status: true
       name: Julia Mahamid
     cell_strain:
-      id: M129
-      name: Mycoplasmoides pneumoniae
+      id: NCBITaxon:272634
+      name: Mycoplasmoides pneumoniae M129
     cross_references:
       publications: doi:10.1038/s41586-022-05255-2, doi:10.1038/s41592-020-01054-7
       related_database_entries: EMPIAR-10731, EMPIAR-10499

--- a/ingestion_tools/dataset_configs/10008.yaml
+++ b/ingestion_tools/dataset_configs/10008.yaml
@@ -192,7 +192,7 @@ tiltseries:
       energy_filter: GIF Quantum LS
       phase_plate: null
     pixel_spacing: 3.52
-    related_empiar_entry: EMD-15053
+    related_empiar_entry: EMPIAR-11058
     spherical_aberration_constant: 2.7
     tilt_axis: 1.36
     tilt_range:

--- a/ingestion_tools/dataset_configs/gjensen/10104.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10104.yaml
@@ -28,7 +28,7 @@ datasets:
     grid_preparation: null
     organism:
       name: MLV
-      taxonomy_id: 0
+      taxonomy_id: 11786
     sample_preparation: MLV 43D
     sample_type: organism
   sources:

--- a/ingestion_tools/dataset_configs/gjensen/10172.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10172.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     dataset_description: This is 1st of 17 sets of data studying HUVECs collected
       by Cora Woodward and is a part of Caltech Jensen  lab etdb.
     dataset_identifier: 10172

--- a/ingestion_tools/dataset_configs/gjensen/10173.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10173.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 2nd of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10174.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10174.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 3rd of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10175.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10175.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     dataset_description: This is 4th of 17 sets of data studying HUVECs collected
       by Cora Woodward and is a part of Caltech Jensen  lab etdb. HUVECs- no treatment
     dataset_identifier: 10175

--- a/ingestion_tools/dataset_configs/gjensen/10176.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10176.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 5th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10177.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10177.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 6th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10178.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10178.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 7th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10179.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10179.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     dataset_description: This is 8th of 17 sets of data studying HUVECs collected
       by Cora Woodward and is a part of Caltech Jensen  lab etdb. HUVECs transfected
       with CHMP4A+VPS4DN constructs using Nucleofector Kit. Sample# C58-2

--- a/ingestion_tools/dataset_configs/gjensen/10180.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10180.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 9th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10181.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10181.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 10th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10182.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10182.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 11th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10183.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10183.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 12th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10184.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10184.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 13th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10185.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10185.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 14th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10186.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10186.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 15th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10187.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10187.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 16th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10188.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10188.yaml
@@ -19,7 +19,7 @@ datasets:
       name: ''
     cell_type:
       id: CL:0002618
-      name: umbilical vein endothelial cell
+      name: endothelial cell of umbilical vein
     cross_references:
       publications: 10.1128/JVI.02997-14
     dataset_description: This is 17th of 17 sets of data studying HUVECs collected

--- a/ingestion_tools/dataset_configs/gjensen/10240.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10240.yaml
@@ -20,7 +20,7 @@ datasets:
     dataset_description: This is 17th of 17 sets of data studying Salmonella typhimurium
       collected by Morgan Beeby and is a part of Caltech Jensen  lab etdb.
     dataset_identifier: 10240
-    dataset_title: ' WT Salmonella minicells'
+    dataset_title: 'WT Salmonella minicells'
     dates: &id002
       deposition_date: '2023-10-01'
       last_modified_date: '2023-12-01'

--- a/ingestion_tools/dataset_configs/template.yaml
+++ b/ingestion_tools/dataset_configs/template.yaml
@@ -192,7 +192,7 @@ tiltseries: OPTIONAL
       image_corrector: OPTIONAL, STRING
       phase_plate: OPTIONAL, STRING
     pixel_spacing: REQUIRED, FLOAT (POSITIVE)
-    related_empiar_entry: OPTIONAL, STRING
+    related_empiar_entry: OPTIONAL, STRING (EMPIAR_ID)
     spherical_aberration_constant: REQUIRED, FLOAT (POSITIVE) (mm)
     tilt_alignment_software: OPTIONAL, STRING
     tilt_axis: REQUIRED, FLOAT ([-360, 360]) (DEGREES)

--- a/schema/v1.1.0/common.yaml
+++ b/schema/v1.1.0/common.yaml
@@ -910,7 +910,7 @@ types:
   ONTOLOGY_ID:
     description: An ontology identifier
     base: str
-    pattern: '^[A-Z]+:[0-9]+$'
+    pattern: '^[a-zA-Z]+:[0-9]+$'
 
   DOI:
     description: A Digital Object Identifier

--- a/schema/v1.1.0/dataset_config_materialized.yaml
+++ b/schema/v1.1.0/dataset_config_materialized.yaml
@@ -301,7 +301,7 @@ types:
     description: An ontology identifier
     from_schema: cdp-dataset-config
     base: str
-    pattern: ^[A-Z]+:[0-9]+$
+    pattern: ^[a-zA-Z]+:[0-9]+$
   DOI:
     name: DOI
     description: A Digital Object Identifier

--- a/schema/v1.1.0/dataset_config_models.py
+++ b/schema/v1.1.0/dataset_config_models.py
@@ -139,7 +139,7 @@ linkml_meta = LinkMLMeta(
                 "description": "An ontology identifier",
                 "from_schema": "cdp-dataset-config",
                 "name": "ONTOLOGY_ID",
-                "pattern": "^[A-Z]+:[0-9]+$",
+                "pattern": "^[a-zA-Z]+:[0-9]+$",
             },
             "ORCID": {
                 "base": "str",
@@ -1146,7 +1146,7 @@ class CellStrain(ConfiguredBaseModel):
 
     @field_validator("id")
     def pattern_id(cls, v):
-        pattern = re.compile(r"^[A-Z]+:[0-9]+$")
+        pattern = re.compile(r"^[a-zA-Z]+:[0-9]+$")
         if isinstance(v, list):
             for element in v:
                 if not pattern.match(element):

--- a/schema/v1.1.0/metadata-docs/CellStrain.md
+++ b/schema/v1.1.0/metadata-docs/CellStrain.md
@@ -136,7 +136,7 @@ attributes:
     recommended: true
     inlined: true
     inlined_as_list: true
-    pattern: ^[A-Z]+:[0-9]+$
+    pattern: ^[a-zA-Z]+:[0-9]+$
 
 ```
 </details>
@@ -188,7 +188,7 @@ attributes:
     recommended: true
     inlined: true
     inlined_as_list: true
-    pattern: ^[A-Z]+:[0-9]+$
+    pattern: ^[a-zA-Z]+:[0-9]+$
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/ONTOLOGYID.md
+++ b/schema/v1.1.0/metadata-docs/ONTOLOGYID.md
@@ -14,7 +14,7 @@ URI: [cdp-meta:ONTOLOGY_ID](metadataONTOLOGY_ID)
 
 
 
-* [pattern](https://w3id.org/linkml/pattern): `^[A-Z]+:[0-9]+$`
+* [pattern](https://w3id.org/linkml/pattern): `^[a-zA-Z]+:[0-9]+$`
 
 
 

--- a/schema/v1.1.0/metadata-docs/authors.md
+++ b/schema/v1.1.0/metadata-docs/authors.md
@@ -16,11 +16,11 @@ URI: [cdp-meta:authors](metadataauthors)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Deposition](Deposition.md) | Metadata describing a deposition |  no  |
-| [Annotation](Annotation.md) | Metadata describing an annotation |  no  |
-| [AuthoredEntity](AuthoredEntity.md) | An entity with associated authors |  no  |
 | [Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [Annotation](Annotation.md) | Metadata describing an annotation |  no  |
+| [AuthoredEntity](AuthoredEntity.md) | An entity with associated authors |  no  |
+| [Deposition](Deposition.md) | Metadata describing a deposition |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/binning.md
+++ b/schema/v1.1.0/metadata-docs/binning.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:binning](metadatabinning)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
 | [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
+| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
 | [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
 
 

--- a/schema/v1.1.0/metadata-docs/cell_component.md
+++ b/schema/v1.1.0/metadata-docs/cell_component.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:cell_component](metadatacell_component)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/cell_strain.md
+++ b/schema/v1.1.0/metadata-docs/cell_strain.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:cell_strain](metadatacell_strain)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/cell_type.md
+++ b/schema/v1.1.0/metadata-docs/cell_type.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:cell_type](metadatacell_type)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/cross_references.md
+++ b/schema/v1.1.0/metadata-docs/cross_references.md
@@ -16,9 +16,9 @@ URI: [cdp-meta:cross_references](metadatacross_references)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
+| [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
 | [CrossReferencedEntity](CrossReferencedEntity.md) | An entity with associated cross-references to other databases and publication... |  no  |
 | [Deposition](Deposition.md) | Metadata describing a deposition |  no  |
-| [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/dates.md
+++ b/schema/v1.1.0/metadata-docs/dates.md
@@ -16,9 +16,9 @@ URI: [cdp-meta:dates](metadatadates)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Deposition](Deposition.md) | Metadata describing a deposition |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
 | [DatestampedEntity](DatestampedEntity.md) | An entity with associated deposition, release and last modified dates |  no  |
+| [Deposition](Deposition.md) | Metadata describing a deposition |  no  |
 | [Annotation](Annotation.md) | Metadata describing an annotation |  no  |
 
 

--- a/schema/v1.1.0/metadata-docs/file_format.md
+++ b/schema/v1.1.0/metadata-docs/file_format.md
@@ -16,12 +16,12 @@ URI: [cdp-meta:file_format](metadatafile_format)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
-| [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
+| [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
+| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
 | [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
 | [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
-| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
-| [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
+| [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
+| [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/funding.md
+++ b/schema/v1.1.0/metadata-docs/funding.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:funding](metadatafunding)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
 | [FundedEntity](FundedEntity.md) | An entity with associated funding sources |  no  |
+| [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/glob_string.md
+++ b/schema/v1.1.0/metadata-docs/glob_string.md
@@ -16,12 +16,12 @@ URI: [cdp-meta:glob_string](metadataglob_string)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
-| [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
+| [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
+| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
 | [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
 | [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
-| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
-| [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
+| [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
+| [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/glob_strings.md
+++ b/schema/v1.1.0/metadata-docs/glob_strings.md
@@ -16,12 +16,12 @@ URI: [cdp-meta:glob_strings](metadataglob_strings)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
-| [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
+| [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
+| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
 | [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
 | [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
-| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
-| [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
+| [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
+| [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/grid_preparation.md
+++ b/schema/v1.1.0/metadata-docs/grid_preparation.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:grid_preparation](metadatagrid_preparation)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/id.md
+++ b/schema/v1.1.0/metadata-docs/id.md
@@ -17,10 +17,10 @@ URI: [cdp-meta:id](metadataid)
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
 | [TissueDetails](TissueDetails.md) | The type of tissue from which the sample was derived |  no  |
-| [CellComponent](CellComponent.md) | The cellular component from which the sample was derived |  no  |
-| [CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived |  no  |
 | [AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated |  no  |
+| [CellComponent](CellComponent.md) | The cellular component from which the sample was derived |  no  |
 | [CellType](CellType.md) | The cell type from which the sample was derived |  no  |
+| [CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/is_visualization_default.md
+++ b/schema/v1.1.0/metadata-docs/is_visualization_default.md
@@ -16,12 +16,12 @@ URI: [cdp-meta:is_visualization_default](metadatais_visualization_default)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
-| [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
+| [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
+| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
 | [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
 | [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
-| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
-| [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
+| [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
+| [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/name.md
+++ b/schema/v1.1.0/metadata-docs/name.md
@@ -17,13 +17,13 @@ URI: [cdp-meta:name](metadataname)
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
 | [TissueDetails](TissueDetails.md) | The type of tissue from which the sample was derived |  no  |
-| [AnnotationMethodLinks](AnnotationMethodLinks.md) | A set of links to models, sourcecode, documentation, etc referenced by annota... |  no  |
-| [OrganismDetails](OrganismDetails.md) | The species from which the sample was derived |  no  |
-| [Author](Author.md) | Author of a scientific data entity |  no  |
-| [CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived |  no  |
-| [CellComponent](CellComponent.md) | The cellular component from which the sample was derived |  no  |
 | [AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated |  no  |
+| [Author](Author.md) | Author of a scientific data entity |  no  |
+| [OrganismDetails](OrganismDetails.md) | The species from which the sample was derived |  no  |
+| [AnnotationMethodLinks](AnnotationMethodLinks.md) | A set of links to models, sourcecode, documentation, etc referenced by annota... |  no  |
+| [CellComponent](CellComponent.md) | The cellular component from which the sample was derived |  no  |
 | [CellType](CellType.md) | The cell type from which the sample was derived |  no  |
+| [CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/organism.md
+++ b/schema/v1.1.0/metadata-docs/organism.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:organism](metadataorganism)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/other_setup.md
+++ b/schema/v1.1.0/metadata-docs/other_setup.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:other_setup](metadataother_setup)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/sample_preparation.md
+++ b/schema/v1.1.0/metadata-docs/sample_preparation.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:sample_preparation](metadatasample_preparation)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/sample_type.md
+++ b/schema/v1.1.0/metadata-docs/sample_type.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:sample_type](metadatasample_type)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/tissue.md
+++ b/schema/v1.1.0/metadata-docs/tissue.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:tissue](metadatatissue)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentalMetadata](ExperimentalMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/x.md
+++ b/schema/v1.1.0/metadata-docs/x.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:x](metadatax)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [TomogramSize](TomogramSize.md) | The size of a tomogram in voxels in each dimension |  no  |
 | [TomogramOffset](TomogramOffset.md) | The offset of a tomogram in voxels in each dimension relative to the canonica... |  no  |
+| [TomogramSize](TomogramSize.md) | The size of a tomogram in voxels in each dimension |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/y.md
+++ b/schema/v1.1.0/metadata-docs/y.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:y](metadatay)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [TomogramSize](TomogramSize.md) | The size of a tomogram in voxels in each dimension |  no  |
 | [TomogramOffset](TomogramOffset.md) | The offset of a tomogram in voxels in each dimension relative to the canonica... |  no  |
+| [TomogramSize](TomogramSize.md) | The size of a tomogram in voxels in each dimension |  no  |
 
 
 

--- a/schema/v1.1.0/metadata-docs/z.md
+++ b/schema/v1.1.0/metadata-docs/z.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:z](metadataz)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [TomogramSize](TomogramSize.md) | The size of a tomogram in voxels in each dimension |  no  |
 | [TomogramOffset](TomogramOffset.md) | The offset of a tomogram in voxels in each dimension relative to the canonica... |  no  |
+| [TomogramSize](TomogramSize.md) | The size of a tomogram in voxels in each dimension |  no  |
 
 
 

--- a/schema/v1.1.0/metadata_materialized.yaml
+++ b/schema/v1.1.0/metadata_materialized.yaml
@@ -317,7 +317,7 @@ types:
     description: An ontology identifier
     from_schema: metadata
     base: str
-    pattern: ^[A-Z]+:[0-9]+$
+    pattern: ^[a-zA-Z]+:[0-9]+$
   DOI:
     name: DOI
     description: A Digital Object Identifier
@@ -1042,7 +1042,7 @@ classes:
         recommended: true
         inlined: true
         inlined_as_list: true
-        pattern: ^[A-Z]+:[0-9]+$
+        pattern: ^[a-zA-Z]+:[0-9]+$
   CellComponent:
     name: CellComponent
     description: The cellular component from which the sample was derived.

--- a/schema/v1.1.0/metadata_models.py
+++ b/schema/v1.1.0/metadata_models.py
@@ -147,7 +147,7 @@ linkml_meta = LinkMLMeta(
                 "description": "An ontology identifier",
                 "from_schema": "metadata",
                 "name": "ONTOLOGY_ID",
-                "pattern": "^[A-Z]+:[0-9]+$",
+                "pattern": "^[a-zA-Z]+:[0-9]+$",
             },
             "ORCID": {
                 "base": "str",
@@ -1154,7 +1154,7 @@ class CellStrain(ConfiguredBaseModel):
 
     @field_validator("id")
     def pattern_id(cls, v):
-        pattern = re.compile(r"^[A-Z]+:[0-9]+$")
+        pattern = re.compile(r"^[a-zA-Z]+:[0-9]+$")
         if isinstance(v, list):
             for element in v:
                 if not pattern.match(element):


### PR DESCRIPTION
cell_type.name umbilical vein endothelial cell -> endothelial cell of umbilical vein to match what's stored online (and pass validation, since there's no fuzzy searching planned) see https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_0002618

Other various changes that make config files pass validation. 

Also updated validation to allow for lowercase letters in the ontology prefix. 