### PR TITLE
Fix ingestion / importer annotation version bug

### DIFF
--- a/ingestion_tools/scripts/common/metadata.py
+++ b/ingestion_tools/scripts/common/metadata.py
@@ -73,7 +73,7 @@ class AnnotationMetadata(MergedMetadata):
                 [
                     str(identifier),
                     re.sub("[^0-9a-z]", "_", obj.lower()),
-                    re.sub("[^0-9a-z.]", "_", f"{version.lower()}"),
+                    re.sub("[^0-9a-z.]", "_", f"{str(version).lower()}"),
                 ],
             ),
         )


### PR DESCRIPTION
Because the version could be a number / float (it currently is, as defined by the template.yaml), we should typecast the variable to a string before calling `lower`. Makes the code more robust and support version numbers that are both strings and numbers. 