### PR TITLE
update dataset config validation docs with poetry install requirements

### DIFF
--- a/schema/v1.1.0/docs/dataset_config_validate.md
+++ b/schema/v1.1.0/docs/dataset_config_validate.md
@@ -12,6 +12,8 @@ python3 -m venv .venv  # create a virtualenv
 source .venv/bin/activate  # activate the virtualenv
 python3 -m pip install poetry  # Install the poetry package manager
 poetry install  # Use poetry to install this package's dependencies
+cd ../ingestion_tools/  # Move to the ingestion_tools directory
+poetry install  # Use poetry to install the ingestion_tools package's dependencies
 ```
 
 ## Running the script


### PR DESCRIPTION
Running dataset config validation requires scripts from the ingestion_tools and those scripts require their corresponding dependencies. A temporary workaround for properly setting up dataset config validation. A future goal could be to unify all potential pyproject.toml / poetry.lock files across the repo into one.