### PR TITLE
Fix setting extended header when importing MRC

### DIFF
--- a/ingestion_tools/scripts/common/image.py
+++ b/ingestion_tools/scripts/common/image.py
@@ -132,7 +132,7 @@ class VolumeReader(ABC):
     def get_volume_info(self) -> VolumeInfo:
         pass
 
-    def get_mrc_extended_header(self) -> np.record | None:
+    def get_mrc_extended_header(self) -> np.ndarray | None:
         return None
 
     def get_mrc_header(self) -> np.record | None:
@@ -161,7 +161,7 @@ class MRCReader(VolumeReader):
     def get_mrc_header(self) -> np.rec.array:
         return self.header
 
-    def get_mrc_extended_header(self) -> np.rec.array:
+    def get_mrc_extended_header(self) -> np.ndarray:
         return self.extended_header
 
     def get_pyramid_base_data(self) -> np.ndarray:
@@ -353,7 +353,10 @@ class TomoConverter:
             if old_header.exttyp.item().decode().strip():
                 header.nsymbt = old_header.nsymbt
                 header.exttyp = old_header.exttyp
-                if ext := self.volume_reader.get_mrc_extended_header():
+                ext = self.volume_reader.get_mrc_extended_header()
+                # Converting to list, so we can compare both for None and empty np.ndarray. Actually setting the
+                # ndarray.
+                if ext.tolist():
                     mrcfile.set_extended_header(ext)
 
         if header_mapper:

--- a/ingestion_tools/scripts/common/image.py
+++ b/ingestion_tools/scripts/common/image.py
@@ -270,7 +270,7 @@ class TomoConverter:
         # Ensure voxel spacing rounded to 3rd digit
         voxel_spacing = round(voxel_spacing, 3)
 
-        pyramid = [self.volume_reader.get_pyramid_base_data()]
+        pyramid = [self.scaled_data_transformation(self.volume_reader.get_pyramid_base_data())]
         pyramid_voxel_spacing = [(voxel_spacing, voxel_spacing, voxel_spacing)]
         z_scale = 2 if scale_z_axis else 1
         # Then make a pyramid of 100/50/25 percent scale volumes
@@ -351,8 +351,6 @@ class TomoConverter:
             header.extra1 = old_header.extra1
             header.extra2 = old_header.extra2
             if old_header.exttyp.item().decode().strip():
-                header.nsymbt = old_header.nsymbt
-                header.exttyp = old_header.exttyp
                 ext = self.volume_reader.get_mrc_extended_header()
                 # In order to cover the following cases:
                 # 1. do set on filled np.ndarray > np.array(val: np.ndarray).tolist() -> list
@@ -360,7 +358,12 @@ class TomoConverter:
                 # 3. skip setting on empty np.ndarray > np.array(np.empty(0)).tolist() == []
                 # 4. skip setting on None > np.array(None).tolist() == None
                 if np.array(ext).tolist():
+                    header.exttyp = old_header.exttyp
                     mrcfile.set_extended_header(ext)
+                else:
+                    # Empty extended header
+                    header.exttyp = b"MRCO"
+                    header.nsymbt = 0
 
         if header_mapper:
             header_mapper(header)


### PR DESCRIPTION
Relates to
#166

## Description
The property `MrcObject.extended_header` may return `None`, or values of type `np.recarray` or `np.ndarray`. In contrast to python lists, `np.ndarray` is not truthy, so comparison with any `np.ndarray` will raise exceptions. In order to circumvent, we ensure that the result of `MRCReader.get_mrc_extended_header()` is a np.array and then convert to a python list that enables truthy/falsy comparison. 

Covers the following cases: 
1. do set extended header on filled `np.ndarray` > `np.array(val: np.ndarray).tolist() -> list`
2. do set extended header on filled `np.recarray` > `np.array(val: np.recarray).tolist() -> list`
3. skip setting extended header on empty `np.ndarray` > `np.array(np.empty(0)).tolist() == []`
4. skip setting extended header on `None` > `np.array(None).tolist() == None`
