### PR TITLE
fix: Segmentation mask output datatype to int

### DIFF
--- a/ingestion_tools/scripts/common/image.py
+++ b/ingestion_tools/scripts/common/image.py
@@ -270,7 +270,7 @@ class TomoConverter:
         # Ensure voxel spacing rounded to 3rd digit
         voxel_spacing = round(voxel_spacing, 3)
 
-        pyramid = [self.volume_reader.get_pyramid_base_data()]
+        pyramid = [self.scaled_data_transformation(self.volume_reader.get_pyramid_base_data())]
         pyramid_voxel_spacing = [(voxel_spacing, voxel_spacing, voxel_spacing)]
         z_scale = 2 if scale_z_axis else 1
         # Then make a pyramid of 100/50/25 percent scale volumes

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -265,12 +265,25 @@ class VolumeAnnotationSource(BaseAnnotationSource):
 
 class SegmentationMaskAnnotation(VolumeAnnotationSource):
     shape = "SegmentationMask"  # Don't expose SemanticSegmentationMask to the public portal.
+    mask_label: int
+
+    def __init__(
+        self,
+        mask_label: int | None = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        if not mask_label:
+            mask_label = 1
+        self.mask_label = mask_label
 
     def convert(self, output_prefix: str):
         return make_pyramids(
             self.config.fs,
             self.get_output_filename(output_prefix),
             self.path,
+            label=self.mask_label,
             write_mrc=self.config.write_mrc,
             write_zarr=self.config.write_zarr,
             voxel_spacing=self.get_voxel_spacing().as_float(),


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
Fixes the issue of segmentation mask output being a float. The [converter selection](https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/66e0ddc0cffdafe8b0d71d678b7443a585337ca2/ingestion_tools/scripts/common/image.py#L418) is determined by if the label is `None`.
<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
