### PR TITLE
fix config validation bugs

### DIFF
--- a/schema/v1.1.0/api_models_materialized.yaml
+++ b/schema/v1.1.0/api_models_materialized.yaml
@@ -3486,7 +3486,8 @@ classes:
           descriptive_name: pixels
       affine_transformation_matrix:
         name: affine_transformation_matrix
-        description: A placeholder for any type of data.
+        description: The flip or rotation transformation of this author submitted
+          tomogram is indicated here
         from_schema: cdp-dataset-config
         array:
           exact_number_dimensions: 2
@@ -3597,7 +3598,6 @@ classes:
         inlined_as_list: true
   Any:
     name: Any
-    description: A placeholder for any type of data.
     from_schema: cdp-dataset-config
     class_uri: linkml:Any
   DateStampedEntityMixin:

--- a/schema/v1.1.0/common.yaml
+++ b/schema/v1.1.0/common.yaml
@@ -13,7 +13,7 @@ prefixes:
 imports:
   - linkml:types
 default_prefix: cdp-common
-default_range: string
+default_range: Any
 
 
 slots:
@@ -1006,7 +1006,6 @@ types:
 classes:
   Any:
     class_uri: linkml:Any
-    description: A placeholder for any type of data.
 
   # ============================================================================
   # Mixins

--- a/schema/v1.1.0/dataset_config_materialized.yaml
+++ b/schema/v1.1.0/dataset_config_materialized.yaml
@@ -1011,7 +1011,7 @@ classes:
     attributes:
       value:
         name: value
-        description: A placeholder for any type of data.
+        description: The value for the literal.
         from_schema: cdp-dataset-config
         alias: value
         owner: DefaultLiteral
@@ -4017,7 +4017,6 @@ classes:
         inlined_as_list: true
   Any:
     name: Any
-    description: A placeholder for any type of data.
     from_schema: cdp-dataset-config
     class_uri: linkml:Any
   DateStampedEntityMixin:

--- a/schema/v1.1.0/dataset_config_models.py
+++ b/schema/v1.1.0/dataset_config_models.py
@@ -733,7 +733,7 @@ class DateStampedEntity(ConfiguredBaseModel):
     An entity with associated deposition, release and last modified dates.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"abstract": True, "from_schema": "metadata"})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
     dates: DateStamp = Field(
         ...,
@@ -749,7 +749,7 @@ class AuthoredEntity(ConfiguredBaseModel):
     An entity with associated authors.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"abstract": True, "from_schema": "metadata"})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
     authors: List[Author] = Field(
         default_factory=list,
@@ -770,7 +770,7 @@ class FundedEntity(ConfiguredBaseModel):
     An entity with associated funding sources.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"abstract": True, "from_schema": "metadata"})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
     funding: Optional[List[FundingDetails]] = Field(
         default_factory=list,
@@ -810,7 +810,7 @@ class PicturedEntity(ConfiguredBaseModel):
     An entity with associated preview images.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"abstract": True, "from_schema": "metadata"})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
     key_photos: PicturePath = Field(
         ...,
@@ -1084,7 +1084,7 @@ class ExperimentMetadata(ConfiguredBaseModel):
     Metadata describing sample and sample preparation methods used in a cryoET dataset.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"abstract": True, "from_schema": "metadata"})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
     sample_type: SampleTypeEnum = Field(
         ...,
@@ -3360,9 +3360,7 @@ class CrossReferences(CrossReferencesMixin):
     A set of cross-references to other databases and publications.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {"abstract": True, "from_schema": "metadata", "mixins": ["CrossReferencesMixin"]}
-    )
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata", "mixins": ["CrossReferencesMixin"]})
 
     publications: Optional[str] = Field(
         None,
@@ -4042,7 +4040,7 @@ class DefaultLiteral(ConfiguredBaseModel):
 
     value: List[Any] = Field(
         default_factory=list,
-        description="""A placeholder for any type of data.""",
+        description="""The value for the literal.""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "value",

--- a/schema/v1.1.0/dataset_config_models.schema.json
+++ b/schema/v1.1.0/dataset_config_models.schema.json
@@ -521,7 +521,7 @@
         },
         "Any": {
             "additionalProperties": true,
-            "description": "A placeholder for any type of data.",
+            "description": "",
             "title": "Any",
             "type": [
                 "null",
@@ -573,6 +573,25 @@
                 "name"
             ],
             "title": "Author",
+            "type": "object"
+        },
+        "AuthoredEntity": {
+            "additionalProperties": false,
+            "description": "An entity with associated authors.",
+            "properties": {
+                "authors": {
+                    "description": "Author of a scientific data entity.",
+                    "items": {
+                        "$ref": "#/$defs/Author"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "authors"
+            ],
+            "title": "AuthoredEntity",
             "type": "object"
         },
         "CameraDetails": {
@@ -789,6 +808,32 @@
                 "voxel_spacings"
             ],
             "title": "Container",
+            "type": "object"
+        },
+        "CrossReferences": {
+            "additionalProperties": false,
+            "description": "A set of cross-references to other databases and publications.",
+            "properties": {
+                "dataset_citations": {
+                    "description": "Comma-separated list of DOIs for publications citing the dataset.",
+                    "type": "string"
+                },
+                "publications": {
+                    "description": "Comma-separated list of DOIs for publications associated with the dataset.",
+                    "pattern": "(^(doi:)?10\\.[0-9]{4,9}/[-._;()/:a-zA-Z0-9]+(\\s*,\\s*(doi:)?10\\.[0-9]{4,9}/[-._;()/:a-zA-Z0-9]+)*$)|(^(doi:)?10\\.[0-9]{4,9}/[-._;()/:a-zA-Z0-9]+(\\s*,\\s*(doi:)?10\\.[0-9]{4,9}/[-._;()/:a-zA-Z0-9]+)*$)",
+                    "type": "string"
+                },
+                "related_database_entries": {
+                    "description": "Comma-separated list of related database entries for the dataset.",
+                    "pattern": "(^(EMPIAR-[0-9]{5}|EMD-[0-9]{4,5}|pdb[0-9a-zA-Z]{4,8})(\\s*,\\s*(EMPIAR-[0-9]{5}|EMD-[0-9]{4,5}|pdb[0-9a-zA-Z]{4,8}))*$)|(^(EMPIAR-[0-9]{5}|EMD-[0-9]{4,5}|pdb[0-9a-zA-Z]{4,8})(\\s*,\\s*(EMPIAR-[0-9]{5}|EMD-[0-9]{4,5}|pdb[0-9a-zA-Z]{4,8}))*$)",
+                    "type": "string"
+                },
+                "related_database_links": {
+                    "description": "Comma-separated list of related database links for the dataset.",
+                    "type": "string"
+                }
+            },
+            "title": "CrossReferences",
             "type": "object"
         },
         "Dataset": {
@@ -1055,12 +1100,27 @@
             "title": "DateStamp",
             "type": "object"
         },
+        "DateStampedEntity": {
+            "additionalProperties": false,
+            "description": "An entity with associated deposition, release and last modified dates.",
+            "properties": {
+                "dates": {
+                    "$ref": "#/$defs/DateStamp",
+                    "description": "A set of dates at which a data item was deposited, published and last modified."
+                }
+            },
+            "required": [
+                "dates"
+            ],
+            "title": "DateStampedEntity",
+            "type": "object"
+        },
         "DefaultLiteral": {
             "additionalProperties": false,
             "description": "A literal class with a value attribute.",
             "properties": {
                 "value": {
-                    "description": "A placeholder for any type of data.",
+                    "description": "The value for the literal.",
                     "items": {
                         "$ref": "#/$defs/Any"
                     },
@@ -1305,6 +1365,54 @@
             "title": "DestinationGlob",
             "type": "object"
         },
+        "ExperimentMetadata": {
+            "additionalProperties": false,
+            "description": "Metadata describing sample and sample preparation methods used in a cryoET dataset.",
+            "properties": {
+                "cell_component": {
+                    "$ref": "#/$defs/CellComponent",
+                    "description": "The cellular component from which the sample was derived."
+                },
+                "cell_strain": {
+                    "$ref": "#/$defs/CellStrain",
+                    "description": "The strain or cell line from which the sample was derived."
+                },
+                "cell_type": {
+                    "$ref": "#/$defs/CellType",
+                    "description": "The cell type from which the sample was derived."
+                },
+                "grid_preparation": {
+                    "description": "Describes Cryo-ET grid preparation.",
+                    "type": "string"
+                },
+                "organism": {
+                    "$ref": "#/$defs/OrganismDetails",
+                    "description": "The species from which the sample was derived."
+                },
+                "other_setup": {
+                    "description": "Describes other setup not covered by sample preparation or grid preparation that may make this dataset unique in the same publication.",
+                    "type": "string"
+                },
+                "sample_preparation": {
+                    "description": "Describes how the sample was prepared.",
+                    "type": "string"
+                },
+                "sample_type": {
+                    "$ref": "#/$defs/SampleTypeEnum",
+                    "description": "Type of sample imaged in a CryoET study.",
+                    "pattern": "(^cell$)|(^tissue$)|(^organism$)|(^organelle$)|(^virus$)|(^in_vitro$)|(^in_silico$)|(^other$)"
+                },
+                "tissue": {
+                    "$ref": "#/$defs/TissueDetails",
+                    "description": "The type of tissue from which the sample was derived."
+                }
+            },
+            "required": [
+                "sample_type"
+            ],
+            "title": "ExperimentMetadata",
+            "type": "object"
+        },
         "FiducialAlignmentStatusEnum": {
             "description": "Fiducial Alignment method",
             "enum": [
@@ -1404,6 +1512,21 @@
                 }
             },
             "title": "FrameSource",
+            "type": "object"
+        },
+        "FundedEntity": {
+            "additionalProperties": false,
+            "description": "An entity with associated funding sources.",
+            "properties": {
+                "funding": {
+                    "description": "A funding source for a scientific data entity (base for JSON and DB representation).",
+                    "items": {
+                        "$ref": "#/$defs/FundingDetails"
+                    },
+                    "type": "array"
+                }
+            },
+            "title": "FundedEntity",
             "type": "object"
         },
         "FundingDetails": {
@@ -1644,6 +1767,7 @@
                     "type": "string"
                 },
                 "manufacturer": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "$ref": "#/$defs/TiltseriesMicroscopeManufacturerEnum"
@@ -1654,8 +1778,7 @@
                         }
                     ],
                     "description": "Name of the microscope manufacturer",
-                    "pattern": "(^FEI$)|(^TFS$)|(^JEOL$)|(^[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$)",
-                    "type": "string"
+                    "pattern": "(^FEI$)|(^TFS$)|(^JEOL$)|(^[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$)"
                 },
                 "model": {
                     "description": "Microscope model name",
@@ -1727,6 +1850,21 @@
                 }
             },
             "title": "PicturePath",
+            "type": "object"
+        },
+        "PicturedEntity": {
+            "additionalProperties": false,
+            "description": "An entity with associated preview images.",
+            "properties": {
+                "key_photos": {
+                    "$ref": "#/$defs/PicturePath",
+                    "description": "A set of paths to representative images of a piece of data."
+                }
+            },
+            "required": [
+                "key_photos"
+            ],
+            "title": "PicturedEntity",
             "type": "object"
         },
         "RawTiltEntity": {
@@ -2004,6 +2142,7 @@
             "description": "The range of tilt angles in the tilt series.",
             "properties": {
                 "max": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "maximum": 90,
@@ -2018,10 +2157,10 @@
                     "description": "Maximal tilt angle in degrees",
                     "maximum": 90,
                     "minimum": -90,
-                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
-                    "type": "string"
+                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "min": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "maximum": 90,
@@ -2036,8 +2175,7 @@
                     "description": "Minimal tilt angle in degrees",
                     "maximum": 90,
                     "minimum": -90,
-                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
-                    "type": "string"
+                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 }
             },
             "title": "TiltRange",
@@ -2053,6 +2191,7 @@
                     "type": "number"
                 },
                 "aligned_tiltseries_binning": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "minimum": 0,
@@ -2065,10 +2204,10 @@
                     ],
                     "description": "Binning factor of the aligned tilt series",
                     "minimum": 0,
-                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
-                    "type": "string"
+                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "binning_from_frames": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "minimum": 0,
@@ -2081,8 +2220,7 @@
                     ],
                     "description": "Describes the binning factor from frames to tilt series file",
                     "minimum": 0,
-                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
-                    "type": "string"
+                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "camera": {
                     "$ref": "#/$defs/CameraDetails",
@@ -2109,6 +2247,7 @@
                     "description": "The optical setup of the microscope used to collect the tilt series."
                 },
                 "pixel_spacing": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "minimum": 0.001,
@@ -2121,8 +2260,7 @@
                     ],
                     "description": "Pixel spacing for the tilt series",
                     "minimum": 0.001,
-                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
-                    "type": "string"
+                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "related_empiar_entry": {
                     "description": "If a tilt series is deposited into EMPIAR, enter the EMPIAR dataset identifier",
@@ -2130,6 +2268,7 @@
                     "type": "string"
                 },
                 "spherical_aberration_constant": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "minimum": 0,
@@ -2142,14 +2281,14 @@
                     ],
                     "description": "Spherical Aberration Constant of the objective lens in millimeters",
                     "minimum": 0,
-                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
-                    "type": "string"
+                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "tilt_alignment_software": {
                     "description": "Software used for tilt alignment",
                     "type": "string"
                 },
                 "tilt_axis": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "maximum": 360,
@@ -2164,14 +2303,14 @@
                     "description": "Rotation angle in degrees",
                     "maximum": 360,
                     "minimum": -360,
-                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
-                    "type": "string"
+                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "tilt_range": {
                     "$ref": "#/$defs/TiltRange",
                     "description": "The range of tilt angles in the tilt series."
                 },
                 "tilt_series_quality": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "maximum": 5,
@@ -2186,10 +2325,10 @@
                     "description": "Author assessment of tilt series quality within the dataset (1-5, 5 is best)",
                     "maximum": 5,
                     "minimum": 1,
-                    "pattern": "^int[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
-                    "type": "string"
+                    "pattern": "^int[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "tilt_step": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "maximum": 90,
@@ -2204,14 +2343,14 @@
                     "description": "Tilt step in degrees",
                     "maximum": 90,
                     "minimum": 0,
-                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
-                    "type": "string"
+                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "tilting_scheme": {
                     "description": "The order of stage tilting during acquisition of the data",
                     "type": "string"
                 },
                 "total_flux": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "minimum": 0,
@@ -2224,8 +2363,7 @@
                     ],
                     "description": "Number of Electrons reaching the specimen in a square Angstrom area for the entire tilt series",
                     "minimum": 0,
-                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
-                    "type": "string"
+                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 }
             },
             "required": [
@@ -2413,6 +2551,7 @@
                     "type": "boolean"
                 },
                 "fiducial_alignment_status": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "$ref": "#/$defs/FiducialAlignmentStatusEnum"
@@ -2423,8 +2562,7 @@
                         }
                     ],
                     "description": "Whether the tomographic alignment was computed based on fiducial markers.",
-                    "pattern": "(^FIDUCIAL$)|(^NON_FIDUCIAL$)|(^[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$)",
-                    "type": "string"
+                    "pattern": "(^FIDUCIAL$)|(^NON_FIDUCIAL$)|(^[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$)"
                 },
                 "offset": {
                     "$ref": "#/$defs/TomogramOffset",
@@ -2440,6 +2578,7 @@
                     "type": "string"
                 },
                 "reconstruction_method": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "$ref": "#/$defs/TomogromReconstructionMethodEnum"
@@ -2450,8 +2589,7 @@
                         }
                     ],
                     "description": "Describe reconstruction method (WBP, SART, SIRT)",
-                    "pattern": "(^SART$)|(^Fourier Space$)|(^SIRT$)|(^WBP$)|(^Unknown$)|(^[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$)",
-                    "type": "string"
+                    "pattern": "(^SART$)|(^Fourier Space$)|(^SIRT$)|(^WBP$)|(^Unknown$)|(^[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$)"
                 },
                 "reconstruction_software": {
                     "description": "Name of software used for reconstruction",
@@ -2467,6 +2605,7 @@
                     "type": "number"
                 },
                 "voxel_spacing": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
                             "minimum": 0.001,
@@ -2479,8 +2618,7 @@
                     ],
                     "description": "Voxel spacing equal in all three axes in angstroms",
                     "minimum": 0.001,
-                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
-                    "type": "string"
+                    "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 }
             },
             "required": [

--- a/schema/v1.1.0/metadata-docs/Any.md
+++ b/schema/v1.1.0/metadata-docs/Any.md
@@ -3,11 +3,6 @@
 # Class: Any
 
 
-_A placeholder for any type of data._
-
-
-
-
 
 URI: [linkml:Any](https://w3id.org/linkml/Any)
 
@@ -36,6 +31,28 @@ URI: [linkml:Any](https://w3id.org/linkml/Any)
 
 
 
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [CellStrain](CellStrain.md) | [id](id.md) | range | [Any](Any.md) |
+| [CameraDetails](CameraDetails.md) | [acquire_mode](acquire_mode.md) | range | [Any](Any.md) |
+| [MicroscopeDetails](MicroscopeDetails.md) | [manufacturer](manufacturer.md) | range | [Any](Any.md) |
+| [TiltRange](TiltRange.md) | [min](min.md) | range | [Any](Any.md) |
+| [TiltRange](TiltRange.md) | [max](max.md) | range | [Any](Any.md) |
+| [TiltSeries](TiltSeries.md) | [aligned_tiltseries_binning](aligned_tiltseries_binning.md) | range | [Any](Any.md) |
+| [TiltSeries](TiltSeries.md) | [binning_from_frames](binning_from_frames.md) | range | [Any](Any.md) |
+| [TiltSeries](TiltSeries.md) | [spherical_aberration_constant](spherical_aberration_constant.md) | range | [Any](Any.md) |
+| [TiltSeries](TiltSeries.md) | [tilt_axis](tilt_axis.md) | range | [Any](Any.md) |
+| [TiltSeries](TiltSeries.md) | [tilt_series_quality](tilt_series_quality.md) | range | [Any](Any.md) |
+| [TiltSeries](TiltSeries.md) | [tilt_step](tilt_step.md) | range | [Any](Any.md) |
+| [TiltSeries](TiltSeries.md) | [total_flux](total_flux.md) | range | [Any](Any.md) |
+| [TiltSeries](TiltSeries.md) | [pixel_spacing](pixel_spacing.md) | range | [Any](Any.md) |
+| [Tomogram](Tomogram.md) | [voxel_spacing](voxel_spacing.md) | range | [Any](Any.md) |
+| [Tomogram](Tomogram.md) | [fiducial_alignment_status](fiducial_alignment_status.md) | range | [Any](Any.md) |
+| [Tomogram](Tomogram.md) | [reconstruction_method](reconstruction_method.md) | range | [Any](Any.md) |
 
 
 
@@ -80,7 +97,6 @@ URI: [linkml:Any](https://w3id.org/linkml/Any)
 <details>
 ```yaml
 name: Any
-description: A placeholder for any type of data.
 from_schema: metadata
 class_uri: linkml:Any
 
@@ -92,7 +108,6 @@ class_uri: linkml:Any
 <details>
 ```yaml
 name: Any
-description: A placeholder for any type of data.
 from_schema: metadata
 class_uri: linkml:Any
 

--- a/schema/v1.1.0/metadata-docs/AuthoredEntity.md
+++ b/schema/v1.1.0/metadata-docs/AuthoredEntity.md
@@ -8,8 +8,6 @@ _An entity with associated authors._
 
 
 
-* __NOTE__: this is an abstract class and should not be instantiated directly
-
 
 URI: [cdp-meta:AuthoredEntity](metadataAuthoredEntity)
 
@@ -103,7 +101,6 @@ URI: [cdp-meta:AuthoredEntity](metadataAuthoredEntity)
 name: AuthoredEntity
 description: An entity with associated authors.
 from_schema: metadata
-abstract: true
 attributes:
   authors:
     name: authors
@@ -136,7 +133,6 @@ attributes:
 name: AuthoredEntity
 description: An entity with associated authors.
 from_schema: metadata
-abstract: true
 attributes:
   authors:
     name: authors

--- a/schema/v1.1.0/metadata-docs/CameraDetails.md
+++ b/schema/v1.1.0/metadata-docs/CameraDetails.md
@@ -22,6 +22,13 @@ URI: [cdp-meta:CameraDetails](metadataCameraDetails)
     click CameraDetails href "../CameraDetails"
       CameraDetails : acquire_mode
 
+
+
+
+    CameraDetails --> "0..1" Any : acquire_mode
+    click Any href "../Any"
+
+
       CameraDetails : manufacturer
 
       CameraDetails : model
@@ -39,7 +46,7 @@ URI: [cdp-meta:CameraDetails](metadataCameraDetails)
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [acquire_mode](acquire_mode.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md)&nbsp;or&nbsp;<br />[TiltseriesCameraAcquireModeEnum](TiltseriesCameraAcquireModeEnum.md) | Camera acquisition mode | direct |
+| [acquire_mode](acquire_mode.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md)&nbsp;or&nbsp;<br />[TiltseriesCameraAcquireModeEnum](TiltseriesCameraAcquireModeEnum.md) | Camera acquisition mode | direct |
 | [manufacturer](manufacturer.md) | 1 <br/> [String](String.md) | Name of the camera manufacturer | direct |
 | [model](model.md) | 1 <br/> [String](String.md) | Camera model name | direct |
 
@@ -171,7 +178,7 @@ attributes:
     owner: CameraDetails
     domain_of:
     - CameraDetails
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     pattern: (^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)|(^counting$)|(^superresolution$)|(^linear$)|(^cds$)

--- a/schema/v1.1.0/metadata-docs/CellStrain.md
+++ b/schema/v1.1.0/metadata-docs/CellStrain.md
@@ -22,6 +22,13 @@ URI: [cdp-meta:CellStrain](metadataCellStrain)
     click CellStrain href "../CellStrain"
       CellStrain : id
 
+
+
+
+    CellStrain --> "0..1 _recommended_" Any : id
+    click Any href "../Any"
+
+
       CellStrain : name
 
 
@@ -38,7 +45,7 @@ URI: [cdp-meta:CellStrain](metadataCellStrain)
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
 | [name](name.md) | 1 <br/> [String](String.md) | Cell line or strain for the sample | direct |
-| [id](id.md) | 0..1 _recommended_ <br/> [String](String.md)&nbsp;or&nbsp;<br />[WORMBASEID](WORMBASEID.md)&nbsp;or&nbsp;<br />[ONTOLOGYID](ONTOLOGYID.md) | Link to more information about the cell strain | direct |
+| [id](id.md) | 0..1 _recommended_ <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[WORMBASEID](WORMBASEID.md)&nbsp;or&nbsp;<br />[ONTOLOGYID](ONTOLOGYID.md) | Link to more information about the cell strain | direct |
 
 
 
@@ -188,7 +195,7 @@ attributes:
     - CellStrain
     - CellComponent
     - AnnotationObject
-    range: string
+    range: Any
     recommended: true
     inlined: true
     inlined_as_list: true

--- a/schema/v1.1.0/metadata-docs/CrossReferences.md
+++ b/schema/v1.1.0/metadata-docs/CrossReferences.md
@@ -8,8 +8,6 @@ _A set of cross-references to other databases and publications._
 
 
 
-* __NOTE__: this is an abstract class and should not be instantiated directly
-
 
 URI: [cdp-meta:CrossReferences](metadataCrossReferences)
 
@@ -111,7 +109,6 @@ URI: [cdp-meta:CrossReferences](metadataCrossReferences)
 name: CrossReferences
 description: A set of cross-references to other databases and publications.
 from_schema: metadata
-abstract: true
 mixins:
 - CrossReferencesMixin
 attributes:
@@ -183,7 +180,6 @@ attributes:
 name: CrossReferences
 description: A set of cross-references to other databases and publications.
 from_schema: metadata
-abstract: true
 mixins:
 - CrossReferencesMixin
 attributes:

--- a/schema/v1.1.0/metadata-docs/DateStampedEntity.md
+++ b/schema/v1.1.0/metadata-docs/DateStampedEntity.md
@@ -8,8 +8,6 @@ _An entity with associated deposition, release and last modified dates._
 
 
 
-* __NOTE__: this is an abstract class and should not be instantiated directly
-
 
 URI: [cdp-meta:DateStampedEntity](metadataDateStampedEntity)
 
@@ -101,7 +99,6 @@ URI: [cdp-meta:DateStampedEntity](metadataDateStampedEntity)
 name: DateStampedEntity
 description: An entity with associated deposition, release and last modified dates.
 from_schema: metadata
-abstract: true
 attributes:
   dates:
     name: dates
@@ -131,7 +128,6 @@ attributes:
 name: DateStampedEntity
 description: An entity with associated deposition, release and last modified dates.
 from_schema: metadata
-abstract: true
 attributes:
   dates:
     name: dates

--- a/schema/v1.1.0/metadata-docs/ExperimentMetadata.md
+++ b/schema/v1.1.0/metadata-docs/ExperimentMetadata.md
@@ -8,8 +8,6 @@ _Metadata describing sample and sample preparation methods used in a cryoET data
 
 
 
-* __NOTE__: this is an abstract class and should not be instantiated directly
-
 
 URI: [cdp-meta:ExperimentMetadata](metadataExperimentMetadata)
 
@@ -157,7 +155,6 @@ name: ExperimentMetadata
 description: Metadata describing sample and sample preparation methods used in a cryoET
   dataset.
 from_schema: metadata
-abstract: true
 attributes:
   sample_type:
     name: sample_type
@@ -302,7 +299,6 @@ name: ExperimentMetadata
 description: Metadata describing sample and sample preparation methods used in a cryoET
   dataset.
 from_schema: metadata
-abstract: true
 attributes:
   sample_type:
     name: sample_type

--- a/schema/v1.1.0/metadata-docs/FundedEntity.md
+++ b/schema/v1.1.0/metadata-docs/FundedEntity.md
@@ -8,8 +8,6 @@ _An entity with associated funding sources._
 
 
 
-* __NOTE__: this is an abstract class and should not be instantiated directly
-
 
 URI: [cdp-meta:FundedEntity](metadataFundedEntity)
 
@@ -97,7 +95,6 @@ URI: [cdp-meta:FundedEntity](metadataFundedEntity)
 name: FundedEntity
 description: An entity with associated funding sources.
 from_schema: metadata
-abstract: true
 attributes:
   funding:
     name: funding
@@ -127,7 +124,6 @@ attributes:
 name: FundedEntity
 description: An entity with associated funding sources.
 from_schema: metadata
-abstract: true
 attributes:
   funding:
     name: funding

--- a/schema/v1.1.0/metadata-docs/MicroscopeDetails.md
+++ b/schema/v1.1.0/metadata-docs/MicroscopeDetails.md
@@ -24,6 +24,13 @@ URI: [cdp-meta:MicroscopeDetails](metadataMicroscopeDetails)
 
       MicroscopeDetails : manufacturer
 
+
+
+
+    MicroscopeDetails --> "0..1" Any : manufacturer
+    click Any href "../Any"
+
+
       MicroscopeDetails : model
 
 
@@ -40,7 +47,7 @@ URI: [cdp-meta:MicroscopeDetails](metadataMicroscopeDetails)
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
 | [additional_info](additional_info.md) | 0..1 <br/> [String](String.md) | Other microscope optical setup information, in addition to energy filter, pha... | direct |
-| [manufacturer](manufacturer.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[TiltseriesMicroscopeManufacturerEnum](TiltseriesMicroscopeManufacturerEnum.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md) | Name of the microscope manufacturer | direct |
+| [manufacturer](manufacturer.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[TiltseriesMicroscopeManufacturerEnum](TiltseriesMicroscopeManufacturerEnum.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md) | Name of the microscope manufacturer | direct |
 | [model](model.md) | 1 <br/> [String](String.md) | Microscope model name | direct |
 
 
@@ -123,7 +130,7 @@ attributes:
     domain_of:
     - CameraDetails
     - MicroscopeDetails
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     pattern: (^FEI$)|(^TFS$)|(^JEOL$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)
@@ -181,7 +188,7 @@ attributes:
     domain_of:
     - CameraDetails
     - MicroscopeDetails
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     pattern: (^FEI$)|(^TFS$)|(^JEOL$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)

--- a/schema/v1.1.0/metadata-docs/PicturedEntity.md
+++ b/schema/v1.1.0/metadata-docs/PicturedEntity.md
@@ -8,8 +8,6 @@ _An entity with associated preview images._
 
 
 
-* __NOTE__: this is an abstract class and should not be instantiated directly
-
 
 URI: [cdp-meta:PicturedEntity](metadataPicturedEntity)
 
@@ -94,7 +92,6 @@ URI: [cdp-meta:PicturedEntity](metadataPicturedEntity)
 name: PicturedEntity
 description: An entity with associated preview images.
 from_schema: metadata
-abstract: true
 attributes:
   key_photos:
     name: key_photos
@@ -120,7 +117,6 @@ attributes:
 name: PicturedEntity
 description: An entity with associated preview images.
 from_schema: metadata
-abstract: true
 attributes:
   key_photos:
     name: key_photos

--- a/schema/v1.1.0/metadata-docs/TiltRange.md
+++ b/schema/v1.1.0/metadata-docs/TiltRange.md
@@ -22,7 +22,21 @@ URI: [cdp-meta:TiltRange](metadataTiltRange)
     click TiltRange href "../TiltRange"
       TiltRange : max
 
+
+
+
+    TiltRange --> "0..1" Any : max
+    click Any href "../Any"
+
+
       TiltRange : min
+
+
+
+
+    TiltRange --> "0..1" Any : min
+    click Any href "../Any"
+
 
 
 ```
@@ -37,8 +51,8 @@ URI: [cdp-meta:TiltRange](metadataTiltRange)
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [min](min.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Minimal tilt angle in degrees | direct |
-| [max](max.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Maximal tilt angle in degrees | direct |
+| [min](min.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Minimal tilt angle in degrees | direct |
+| [max](max.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Maximal tilt angle in degrees | direct |
 
 
 
@@ -105,7 +119,7 @@ attributes:
     owner: TiltRange
     domain_of:
     - TiltRange
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: -90
@@ -128,7 +142,7 @@ attributes:
     owner: TiltRange
     domain_of:
     - TiltRange
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: -90
@@ -163,7 +177,7 @@ attributes:
     owner: TiltRange
     domain_of:
     - TiltRange
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: -90
@@ -186,7 +200,7 @@ attributes:
     owner: TiltRange
     domain_of:
     - TiltRange
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: -90

--- a/schema/v1.1.0/metadata-docs/TiltSeries.md
+++ b/schema/v1.1.0/metadata-docs/TiltSeries.md
@@ -24,7 +24,21 @@ URI: [cdp-meta:TiltSeries](metadataTiltSeries)
 
       TiltSeries : aligned_tiltseries_binning
 
+
+
+
+    TiltSeries --> "0..1" Any : aligned_tiltseries_binning
+    click Any href "../Any"
+
+
       TiltSeries : binning_from_frames
+
+
+
+
+    TiltSeries --> "0..1" Any : binning_from_frames
+    click Any href "../Any"
+
 
       TiltSeries : camera
 
@@ -61,13 +75,34 @@ URI: [cdp-meta:TiltSeries](metadataTiltSeries)
 
       TiltSeries : pixel_spacing
 
+
+
+
+    TiltSeries --> "0..1" Any : pixel_spacing
+    click Any href "../Any"
+
+
       TiltSeries : related_empiar_entry
 
       TiltSeries : spherical_aberration_constant
 
+
+
+
+    TiltSeries --> "0..1" Any : spherical_aberration_constant
+    click Any href "../Any"
+
+
       TiltSeries : tilt_alignment_software
 
       TiltSeries : tilt_axis
+
+
+
+
+    TiltSeries --> "0..1" Any : tilt_axis
+    click Any href "../Any"
+
 
       TiltSeries : tilt_range
 
@@ -80,11 +115,32 @@ URI: [cdp-meta:TiltSeries](metadataTiltSeries)
 
       TiltSeries : tilt_series_quality
 
+
+
+
+    TiltSeries --> "0..1" Any : tilt_series_quality
+    click Any href "../Any"
+
+
       TiltSeries : tilt_step
+
+
+
+
+    TiltSeries --> "0..1" Any : tilt_step
+    click Any href "../Any"
+
 
       TiltSeries : tilting_scheme
 
       TiltSeries : total_flux
+
+
+
+
+    TiltSeries --> "0..1" Any : total_flux
+    click Any href "../Any"
+
 
 
 ```
@@ -100,8 +156,8 @@ URI: [cdp-meta:TiltSeries](metadataTiltSeries)
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
 | [acceleration_voltage](acceleration_voltage.md) | 1 <br/> [Float](Float.md) | Electron Microscope Accelerator voltage in volts | direct |
-| [aligned_tiltseries_binning](aligned_tiltseries_binning.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Binning factor of the aligned tilt series | direct |
-| [binning_from_frames](binning_from_frames.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Describes the binning factor from frames to tilt series file | direct |
+| [aligned_tiltseries_binning](aligned_tiltseries_binning.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Binning factor of the aligned tilt series | direct |
+| [binning_from_frames](binning_from_frames.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Describes the binning factor from frames to tilt series file | direct |
 | [camera](camera.md) | 1 <br/> [CameraDetails](CameraDetails.md) | The camera used to collect the tilt series | direct |
 | [data_acquisition_software](data_acquisition_software.md) | 1 <br/> [String](String.md) | Software used to collect data | direct |
 | [frames_count](frames_count.md) | 0..1 <br/> [Integer](Integer.md) | Number of frames associated with this tiltseries | direct |
@@ -109,15 +165,15 @@ URI: [cdp-meta:TiltSeries](metadataTiltSeries)
 | [microscope](microscope.md) | 1 <br/> [MicroscopeDetails](MicroscopeDetails.md) | The microscope used to collect the tilt series | direct |
 | [microscope_optical_setup](microscope_optical_setup.md) | 1 <br/> [MicroscopeOpticalSetup](MicroscopeOpticalSetup.md) | The optical setup of the microscope used to collect the tilt series | direct |
 | [related_empiar_entry](related_empiar_entry.md) | 0..1 <br/> [EMPIARID](EMPIARID.md) | If a tilt series is deposited into EMPIAR, enter the EMPIAR dataset identifie... | direct |
-| [spherical_aberration_constant](spherical_aberration_constant.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Spherical Aberration Constant of the objective lens in millimeters | direct |
+| [spherical_aberration_constant](spherical_aberration_constant.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Spherical Aberration Constant of the objective lens in millimeters | direct |
 | [tilt_alignment_software](tilt_alignment_software.md) | 0..1 <br/> [String](String.md) | Software used for tilt alignment | direct |
-| [tilt_axis](tilt_axis.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Rotation angle in degrees | direct |
+| [tilt_axis](tilt_axis.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Rotation angle in degrees | direct |
 | [tilt_range](tilt_range.md) | 1 <br/> [TiltRange](TiltRange.md) | The range of tilt angles in the tilt series | direct |
-| [tilt_series_quality](tilt_series_quality.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[Integer](Integer.md)&nbsp;or&nbsp;<br />[IntegerFormattedString](IntegerFormattedString.md) | Author assessment of tilt series quality within the dataset (1-5, 5 is best) | direct |
-| [tilt_step](tilt_step.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Tilt step in degrees | direct |
+| [tilt_series_quality](tilt_series_quality.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[Integer](Integer.md)&nbsp;or&nbsp;<br />[IntegerFormattedString](IntegerFormattedString.md) | Author assessment of tilt series quality within the dataset (1-5, 5 is best) | direct |
+| [tilt_step](tilt_step.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Tilt step in degrees | direct |
 | [tilting_scheme](tilting_scheme.md) | 1 <br/> [String](String.md) | The order of stage tilting during acquisition of the data | direct |
-| [total_flux](total_flux.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Number of Electrons reaching the specimen in a square Angstrom area for the e... | direct |
-| [pixel_spacing](pixel_spacing.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Pixel spacing for the tilt series | direct |
+| [total_flux](total_flux.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Number of Electrons reaching the specimen in a square Angstrom area for the e... | direct |
+| [pixel_spacing](pixel_spacing.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Pixel spacing for the tilt series | direct |
 
 
 
@@ -197,7 +253,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0
@@ -216,7 +272,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0
@@ -333,7 +389,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0
@@ -368,7 +424,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: -360
@@ -405,7 +461,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 1
@@ -425,7 +481,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0
@@ -464,7 +520,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0
@@ -485,7 +541,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0.001
@@ -538,7 +594,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0
@@ -557,7 +613,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0
@@ -674,7 +730,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0
@@ -709,7 +765,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: -360
@@ -746,7 +802,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 1
@@ -766,7 +822,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0
@@ -805,7 +861,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0
@@ -826,7 +882,7 @@ attributes:
     owner: TiltSeries
     domain_of:
     - TiltSeries
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0.001

--- a/schema/v1.1.0/metadata-docs/Tomogram.md
+++ b/schema/v1.1.0/metadata-docs/Tomogram.md
@@ -40,6 +40,13 @@ URI: [cdp-meta:Tomogram](metadataTomogram)
 
       Tomogram : fiducial_alignment_status
 
+
+
+
+    Tomogram --> "0..1" Any : fiducial_alignment_status
+    click Any href "../Any"
+
+
       Tomogram : offset
 
 
@@ -62,6 +69,13 @@ URI: [cdp-meta:Tomogram](metadataTomogram)
 
       Tomogram : reconstruction_method
 
+
+
+
+    Tomogram --> "0..1" Any : reconstruction_method
+    click Any href "../Any"
+
+
       Tomogram : reconstruction_software
 
       Tomogram : size
@@ -76,6 +90,13 @@ URI: [cdp-meta:Tomogram](metadataTomogram)
       Tomogram : tomogram_version
 
       Tomogram : voxel_spacing
+
+
+
+
+    Tomogram --> "0..1" Any : voxel_spacing
+    click Any href "../Any"
+
 
 
 ```
@@ -93,11 +114,11 @@ URI: [cdp-meta:Tomogram](metadataTomogram)
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [voxel_spacing](voxel_spacing.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Voxel spacing equal in all three axes in angstroms | direct |
-| [fiducial_alignment_status](fiducial_alignment_status.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[FiducialAlignmentStatusEnum](FiducialAlignmentStatusEnum.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md) | Whether the tomographic alignment was computed based on fiducial markers | direct |
+| [voxel_spacing](voxel_spacing.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md) | Voxel spacing equal in all three axes in angstroms | direct |
+| [fiducial_alignment_status](fiducial_alignment_status.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[FiducialAlignmentStatusEnum](FiducialAlignmentStatusEnum.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md) | Whether the tomographic alignment was computed based on fiducial markers | direct |
 | [ctf_corrected](ctf_corrected.md) | 0..1 _recommended_ <br/> [Boolean](Boolean.md) | Whether this tomogram is CTF corrected | direct |
 | [align_software](align_software.md) | 0..1 <br/> [String](String.md) | Software used for alignment | direct |
-| [reconstruction_method](reconstruction_method.md) | 0..1 <br/> [String](String.md)&nbsp;or&nbsp;<br />[TomogromReconstructionMethodEnum](TomogromReconstructionMethodEnum.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md) | Describe reconstruction method (WBP, SART, SIRT) | direct |
+| [reconstruction_method](reconstruction_method.md) | 0..1 <br/> [Any](Any.md)&nbsp;or&nbsp;<br />[TomogromReconstructionMethodEnum](TomogromReconstructionMethodEnum.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md) | Describe reconstruction method (WBP, SART, SIRT) | direct |
 | [reconstruction_software](reconstruction_software.md) | 1 <br/> [String](String.md) | Name of software used for reconstruction | direct |
 | [processing](processing.md) | 1 <br/> [TomogramProcessingEnum](TomogramProcessingEnum.md) | Describe additional processing used to derive the tomogram | direct |
 | [processing_software](processing_software.md) | 0..1 _recommended_ <br/> [String](String.md) | Processing software used to derive the tomogram | direct |
@@ -167,7 +188,7 @@ attributes:
     owner: Tomogram
     domain_of:
     - Tomogram
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0.001
@@ -189,7 +210,7 @@ attributes:
     owner: Tomogram
     domain_of:
     - Tomogram
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     pattern: (^FIDUCIAL$)|(^NON_FIDUCIAL$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)
@@ -234,7 +255,7 @@ attributes:
     owner: Tomogram
     domain_of:
     - Tomogram
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     pattern: (^SART$)|(^Fourier Space$)|(^SIRT$)|(^WBP$)|(^Unknown$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[
@@ -389,7 +410,7 @@ attributes:
     owner: Tomogram
     domain_of:
     - Tomogram
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     minimum_value: 0.001
@@ -411,7 +432,7 @@ attributes:
     owner: Tomogram
     domain_of:
     - Tomogram
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     pattern: (^FIDUCIAL$)|(^NON_FIDUCIAL$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)
@@ -456,7 +477,7 @@ attributes:
     owner: Tomogram
     domain_of:
     - Tomogram
-    range: string
+    range: Any
     inlined: true
     inlined_as_list: true
     pattern: (^SART$)|(^Fourier Space$)|(^SIRT$)|(^WBP$)|(^Unknown$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[

--- a/schema/v1.1.0/metadata-docs/acquire_mode.md
+++ b/schema/v1.1.0/metadata-docs/acquire_mode.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:acquire_mode](metadataacquire_mode)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md)&nbsp;or&nbsp;<br />[TiltseriesCameraAcquireModeEnum](TiltseriesCameraAcquireModeEnum.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md)&nbsp;or&nbsp;<br />[TiltseriesCameraAcquireModeEnum](TiltseriesCameraAcquireModeEnum.md)
 
 * Regex pattern: `(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)|(^counting$)|(^superresolution$)|(^linear$)|(^cds$)`
 
@@ -80,7 +80,7 @@ alias: acquire_mode
 owner: CameraDetails
 domain_of:
 - CameraDetails
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 pattern: (^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)|(^counting$)|(^superresolution$)|(^linear$)|(^cds$)

--- a/schema/v1.1.0/metadata-docs/affiliation_address.md
+++ b/schema/v1.1.0/metadata-docs/affiliation_address.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:affiliation_address](metadataaffiliation_address)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: affiliation_address
 domain_of:
 - Author
 - AuthorMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/affiliation_identifier.md
+++ b/schema/v1.1.0/metadata-docs/affiliation_identifier.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:affiliation_identifier](metadataaffiliation_identifier)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: affiliation_identifier
 domain_of:
 - Author
 - AuthorMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/affiliation_name.md
+++ b/schema/v1.1.0/metadata-docs/affiliation_name.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:affiliation_name](metadataaffiliation_name)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: affiliation_name
 domain_of:
 - Author
 - AuthorMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/aligned_tiltseries_binning.md
+++ b/schema/v1.1.0/metadata-docs/aligned_tiltseries_binning.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:aligned_tiltseries_binning](metadataaligned_tiltseries_binning)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
 
 * Minimum Value: 0
 
@@ -80,7 +80,7 @@ alias: aligned_tiltseries_binning
 owner: TiltSeries
 domain_of:
 - TiltSeries
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 minimum_value: 0

--- a/schema/v1.1.0/metadata-docs/authors.md
+++ b/schema/v1.1.0/metadata-docs/authors.md
@@ -16,9 +16,9 @@ URI: [cdp-meta:authors](metadataauthors)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
 | [AuthoredEntity](AuthoredEntity.md) | An entity with associated authors |  no  |
+| [Tomogram](Tomogram.md) | Metadata describing a tomogram |  no  |
 | [Annotation](Annotation.md) | Metadata describing an annotation |  no  |
 | [Deposition](Deposition.md) | Metadata describing a deposition |  no  |
 
@@ -30,7 +30,7 @@ URI: [cdp-meta:authors](metadataauthors)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -67,7 +67,7 @@ domain_of:
 - Deposition
 - Tomogram
 - Annotation
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/binning.md
+++ b/schema/v1.1.0/metadata-docs/binning.md
@@ -16,9 +16,9 @@ URI: [cdp-meta:binning](metadatabinning)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
-| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
 | [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
+| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
+| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 
 
 
@@ -28,7 +28,7 @@ URI: [cdp-meta:binning](metadatabinning)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -63,7 +63,7 @@ domain_of:
 - AnnotationOrientedPointFile
 - AnnotationInstanceSegmentationFile
 - AnnotationPointFile
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/binning_from_frames.md
+++ b/schema/v1.1.0/metadata-docs/binning_from_frames.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:binning_from_frames](metadatabinning_from_frames)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
 
 * Minimum Value: 0
 
@@ -80,7 +80,7 @@ alias: binning_from_frames
 owner: TiltSeries
 domain_of:
 - TiltSeries
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 minimum_value: 0

--- a/schema/v1.1.0/metadata-docs/cell_component.md
+++ b/schema/v1.1.0/metadata-docs/cell_component.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:cell_component](metadatacell_component)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:cell_component](metadatacell_component)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: cell_component
 domain_of:
 - ExperimentMetadata
 - Dataset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/cell_strain.md
+++ b/schema/v1.1.0/metadata-docs/cell_strain.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:cell_strain](metadatacell_strain)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:cell_strain](metadatacell_strain)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: cell_strain
 domain_of:
 - ExperimentMetadata
 - Dataset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/cell_type.md
+++ b/schema/v1.1.0/metadata-docs/cell_type.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:cell_type](metadatacell_type)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:cell_type](metadatacell_type)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: cell_type
 domain_of:
 - ExperimentMetadata
 - Dataset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/corresponding_author_status.md
+++ b/schema/v1.1.0/metadata-docs/corresponding_author_status.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:corresponding_author_status](metadatacorresponding_author_status)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: corresponding_author_status
 domain_of:
 - Author
 - AuthorMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/cross_references.md
+++ b/schema/v1.1.0/metadata-docs/cross_references.md
@@ -16,9 +16,9 @@ URI: [cdp-meta:cross_references](metadatacross_references)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
+| [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
 | [Deposition](Deposition.md) | Metadata describing a deposition |  no  |
 | [CrossReferencedEntity](CrossReferencedEntity.md) | An entity with associated cross-references to other databases and publication... |  no  |
-| [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
 
 
 
@@ -28,7 +28,7 @@ URI: [cdp-meta:cross_references](metadatacross_references)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -63,7 +63,7 @@ domain_of:
 - CrossReferencedEntity
 - Dataset
 - Deposition
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/dataset_citations.md
+++ b/schema/v1.1.0/metadata-docs/dataset_citations.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:dataset_citations](metadatadataset_citations)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: dataset_citations
 domain_of:
 - CrossReferences
 - CrossReferencesMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/dates.md
+++ b/schema/v1.1.0/metadata-docs/dates.md
@@ -16,10 +16,10 @@ URI: [cdp-meta:dates](metadatadates)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Annotation](Annotation.md) | Metadata describing an annotation |  no  |
-| [DateStampedEntity](DateStampedEntity.md) | An entity with associated deposition, release and last modified dates |  no  |
-| [Deposition](Deposition.md) | Metadata describing a deposition |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [Deposition](Deposition.md) | Metadata describing a deposition |  no  |
+| [DateStampedEntity](DateStampedEntity.md) | An entity with associated deposition, release and last modified dates |  no  |
+| [Annotation](Annotation.md) | Metadata describing an annotation |  no  |
 
 
 
@@ -29,7 +29,7 @@ URI: [cdp-meta:dates](metadatadates)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -65,7 +65,7 @@ domain_of:
 - Dataset
 - Deposition
 - Annotation
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/deposition_date.md
+++ b/schema/v1.1.0/metadata-docs/deposition_date.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:deposition_date](metadatadeposition_date)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... |  no  |
 | [DateStampedEntityMixin](DateStampedEntityMixin.md) | A set of dates at which a data item was deposited, published and last modifie... |  no  |
+| [DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:deposition_date](metadatadeposition_date)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: deposition_date
 domain_of:
 - DateStamp
 - DateStampedEntityMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/email.md
+++ b/schema/v1.1.0/metadata-docs/email.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:email](metadataemail)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: email
 domain_of:
 - Author
 - AuthorMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/fiducial_alignment_status.md
+++ b/schema/v1.1.0/metadata-docs/fiducial_alignment_status.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:fiducial_alignment_status](metadatafiducial_alignment_status)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[FiducialAlignmentStatusEnum](FiducialAlignmentStatusEnum.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[FiducialAlignmentStatusEnum](FiducialAlignmentStatusEnum.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md)
 
 * Regex pattern: `(^FIDUCIAL$)|(^NON_FIDUCIAL$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)`
 
@@ -77,7 +77,7 @@ alias: fiducial_alignment_status
 owner: Tomogram
 domain_of:
 - Tomogram
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 pattern: (^FIDUCIAL$)|(^NON_FIDUCIAL$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)

--- a/schema/v1.1.0/metadata-docs/file_format.md
+++ b/schema/v1.1.0/metadata-docs/file_format.md
@@ -16,12 +16,12 @@ URI: [cdp-meta:file_format](metadatafile_format)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
-| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
-| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 | [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
 | [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
 | [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
+| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
+| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
+| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 
 
 
@@ -31,7 +31,7 @@ URI: [cdp-meta:file_format](metadatafile_format)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -69,7 +69,7 @@ domain_of:
 - AnnotationPointFile
 - AnnotationSegmentationMaskFile
 - AnnotationSemanticSegmentationMaskFile
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/filter_value.md
+++ b/schema/v1.1.0/metadata-docs/filter_value.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:filter_value](metadatafilter_value)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 | [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
+| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:filter_value](metadatafilter_value)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: filter_value
 domain_of:
 - AnnotationOrientedPointFile
 - AnnotationInstanceSegmentationFile
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/funding.md
+++ b/schema/v1.1.0/metadata-docs/funding.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:funding](metadatafunding)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: funding
 domain_of:
 - FundedEntity
 - Dataset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/glob_string.md
+++ b/schema/v1.1.0/metadata-docs/glob_string.md
@@ -16,12 +16,12 @@ URI: [cdp-meta:glob_string](metadataglob_string)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
-| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
-| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 | [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
 | [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
 | [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
+| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
+| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
+| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 
 
 
@@ -31,7 +31,7 @@ URI: [cdp-meta:glob_string](metadataglob_string)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -69,7 +69,7 @@ domain_of:
 - AnnotationPointFile
 - AnnotationSegmentationMaskFile
 - AnnotationSemanticSegmentationMaskFile
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/glob_strings.md
+++ b/schema/v1.1.0/metadata-docs/glob_strings.md
@@ -16,12 +16,12 @@ URI: [cdp-meta:glob_strings](metadataglob_strings)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
-| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
-| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 | [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
 | [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
 | [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
+| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
+| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
+| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 
 
 
@@ -31,7 +31,7 @@ URI: [cdp-meta:glob_strings](metadataglob_strings)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -69,7 +69,7 @@ domain_of:
 - AnnotationPointFile
 - AnnotationSegmentationMaskFile
 - AnnotationSemanticSegmentationMaskFile
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/grid_preparation.md
+++ b/schema/v1.1.0/metadata-docs/grid_preparation.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:grid_preparation](metadatagrid_preparation)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:grid_preparation](metadatagrid_preparation)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: grid_preparation
 domain_of:
 - ExperimentMetadata
 - Dataset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/id.md
+++ b/schema/v1.1.0/metadata-docs/id.md
@@ -16,11 +16,11 @@ URI: [cdp-meta:id](metadataid)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [TissueDetails](TissueDetails.md) | The type of tissue from which the sample was derived |  no  |
-| [AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated |  no  |
-| [CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived |  no  |
 | [CellType](CellType.md) | The cell type from which the sample was derived |  no  |
 | [CellComponent](CellComponent.md) | The cellular component from which the sample was derived |  no  |
+| [AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated |  no  |
+| [CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived |  no  |
+| [TissueDetails](TissueDetails.md) | The type of tissue from which the sample was derived |  no  |
 
 
 
@@ -30,7 +30,7 @@ URI: [cdp-meta:id](metadataid)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -67,7 +67,7 @@ domain_of:
 - CellStrain
 - CellComponent
 - AnnotationObject
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/index.md
+++ b/schema/v1.1.0/metadata-docs/index.md
@@ -22,7 +22,7 @@ Name: cdp-meta
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation. Annotation that identifies points in the volume. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation. Annotation that identifies an object. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation. Annotation that identifies classes of objects. |
-| [Any](Any.md) | A placeholder for any type of data. |
+| [Any](Any.md) | None |
 | [Author](Author.md) | Author of a scientific data entity. |
 | [AuthoredEntity](AuthoredEntity.md) | An entity with associated authors. |
 | [AuthorMixin](AuthorMixin.md) | An entity with author data |

--- a/schema/v1.1.0/metadata-docs/is_visualization_default.md
+++ b/schema/v1.1.0/metadata-docs/is_visualization_default.md
@@ -16,12 +16,12 @@ URI: [cdp-meta:is_visualization_default](metadatais_visualization_default)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
-| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
-| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 | [AnnotationSemanticSegmentationMaskFile](AnnotationSemanticSegmentationMaskFile.md) | File and sourcing data for a semantic segmentation mask annotation |  no  |
 | [AnnotationSegmentationMaskFile](AnnotationSegmentationMaskFile.md) | File and sourcing data for a segmentation mask annotation |  no  |
 | [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
+| [AnnotationPointFile](AnnotationPointFile.md) | File and sourcing data for a point annotation |  no  |
+| [AnnotationSourceFile](AnnotationSourceFile.md) | File and sourcing data for an annotation |  no  |
+| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 
 
 
@@ -31,7 +31,7 @@ URI: [cdp-meta:is_visualization_default](metadatais_visualization_default)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -69,7 +69,7 @@ domain_of:
 - AnnotationPointFile
 - AnnotationSegmentationMaskFile
 - AnnotationSemanticSegmentationMaskFile
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/last_modified_date.md
+++ b/schema/v1.1.0/metadata-docs/last_modified_date.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:last_modified_date](metadatalast_modified_date)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... |  no  |
 | [DateStampedEntityMixin](DateStampedEntityMixin.md) | A set of dates at which a data item was deposited, published and last modifie... |  no  |
+| [DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:last_modified_date](metadatalast_modified_date)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: last_modified_date
 domain_of:
 - DateStamp
 - DateStampedEntityMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/manufacturer.md
+++ b/schema/v1.1.0/metadata-docs/manufacturer.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:manufacturer](metadatamanufacturer)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: manufacturer
 domain_of:
 - CameraDetails
 - MicroscopeDetails
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/max.md
+++ b/schema/v1.1.0/metadata-docs/max.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:max](metadatamax)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
 
 * Minimum Value: -90
 
@@ -81,7 +81,7 @@ alias: max
 owner: TiltRange
 domain_of:
 - TiltRange
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 minimum_value: -90

--- a/schema/v1.1.0/metadata-docs/min.md
+++ b/schema/v1.1.0/metadata-docs/min.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:min](metadatamin)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
 
 * Minimum Value: -90
 
@@ -81,7 +81,7 @@ alias: min
 owner: TiltRange
 domain_of:
 - TiltRange
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 minimum_value: -90

--- a/schema/v1.1.0/metadata-docs/model.md
+++ b/schema/v1.1.0/metadata-docs/model.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:model](metadatamodel)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: model
 domain_of:
 - CameraDetails
 - MicroscopeDetails
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/name.md
+++ b/schema/v1.1.0/metadata-docs/name.md
@@ -16,15 +16,15 @@ URI: [cdp-meta:name](metadataname)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [CellComponent](CellComponent.md) | The cellular component from which the sample was derived |  no  |
-| [AnnotationMethodLinks](AnnotationMethodLinks.md) | A set of links to models, sourcecode, documentation, etc referenced by annota... |  no  |
-| [TissueDetails](TissueDetails.md) | The type of tissue from which the sample was derived |  no  |
-| [AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated |  no  |
-| [CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived |  no  |
-| [OrganismDetails](OrganismDetails.md) | The species from which the sample was derived |  no  |
-| [CellType](CellType.md) | The cell type from which the sample was derived |  no  |
 | [AuthorMixin](AuthorMixin.md) | An entity with author data |  no  |
 | [Author](Author.md) | Author of a scientific data entity |  no  |
+| [CellType](CellType.md) | The cell type from which the sample was derived |  no  |
+| [CellComponent](CellComponent.md) | The cellular component from which the sample was derived |  no  |
+| [AnnotationObject](AnnotationObject.md) | Metadata describing the object being annotated |  no  |
+| [AnnotationMethodLinks](AnnotationMethodLinks.md) | A set of links to models, sourcecode, documentation, etc referenced by annota... |  no  |
+| [CellStrain](CellStrain.md) | The strain or cell line from which the sample was derived |  no  |
+| [TissueDetails](TissueDetails.md) | The type of tissue from which the sample was derived |  no  |
+| [OrganismDetails](OrganismDetails.md) | The species from which the sample was derived |  no  |
 
 
 
@@ -34,7 +34,7 @@ URI: [cdp-meta:name](metadataname)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -75,7 +75,7 @@ domain_of:
 - AnnotationObject
 - AuthorMixin
 - AnnotationMethodLinks
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/order.md
+++ b/schema/v1.1.0/metadata-docs/order.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:order](metadataorder)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 | [AnnotationOrientedPointFile](AnnotationOrientedPointFile.md) | File and sourcing data for an oriented point annotation |  no  |
+| [AnnotationInstanceSegmentationFile](AnnotationInstanceSegmentationFile.md) | File and sourcing data for an instance segmentation annotation |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:order](metadataorder)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: order
 domain_of:
 - AnnotationOrientedPointFile
 - AnnotationInstanceSegmentationFile
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/organism.md
+++ b/schema/v1.1.0/metadata-docs/organism.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:organism](metadataorganism)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:organism](metadataorganism)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: organism
 domain_of:
 - ExperimentMetadata
 - Dataset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/other_setup.md
+++ b/schema/v1.1.0/metadata-docs/other_setup.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:other_setup](metadataother_setup)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:other_setup](metadataother_setup)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: other_setup
 domain_of:
 - ExperimentMetadata
 - Dataset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/pixel_spacing.md
+++ b/schema/v1.1.0/metadata-docs/pixel_spacing.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:pixel_spacing](metadatapixel_spacing)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
 
 * Minimum Value: 0
 
@@ -79,7 +79,7 @@ alias: pixel_spacing
 owner: TiltSeries
 domain_of:
 - TiltSeries
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 minimum_value: 0.001

--- a/schema/v1.1.0/metadata-docs/primary_author_status.md
+++ b/schema/v1.1.0/metadata-docs/primary_author_status.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:primary_author_status](metadataprimary_author_status)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: primary_author_status
 domain_of:
 - Author
 - AuthorMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/publications.md
+++ b/schema/v1.1.0/metadata-docs/publications.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:publications](metadatapublications)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: publications
 domain_of:
 - CrossReferences
 - CrossReferencesMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/reconstruction_method.md
+++ b/schema/v1.1.0/metadata-docs/reconstruction_method.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:reconstruction_method](metadatareconstruction_method)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[TomogromReconstructionMethodEnum](TomogromReconstructionMethodEnum.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[TomogromReconstructionMethodEnum](TomogromReconstructionMethodEnum.md)&nbsp;or&nbsp;<br />[StringFormattedString](StringFormattedString.md)
 
 * Regex pattern: `(^SART$)|(^Fourier Space$)|(^SIRT$)|(^WBP$)|(^Unknown$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)`
 
@@ -77,7 +77,7 @@ alias: reconstruction_method
 owner: Tomogram
 domain_of:
 - Tomogram
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 pattern: (^SART$)|(^Fourier Space$)|(^SIRT$)|(^WBP$)|(^Unknown$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[

--- a/schema/v1.1.0/metadata-docs/related_database_entries.md
+++ b/schema/v1.1.0/metadata-docs/related_database_entries.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:related_database_entries](metadatarelated_database_entries)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: related_database_entries
 domain_of:
 - CrossReferences
 - CrossReferencesMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/related_database_links.md
+++ b/schema/v1.1.0/metadata-docs/related_database_links.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:related_database_links](metadatarelated_database_links)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: related_database_links
 domain_of:
 - CrossReferences
 - CrossReferencesMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/release_date.md
+++ b/schema/v1.1.0/metadata-docs/release_date.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:release_date](metadatarelease_date)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... |  no  |
 | [DateStampedEntityMixin](DateStampedEntityMixin.md) | A set of dates at which a data item was deposited, published and last modifie... |  no  |
+| [DateStamp](DateStamp.md) | A set of dates at which a data item was deposited, published and last modifie... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:release_date](metadatarelease_date)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: release_date
 domain_of:
 - DateStamp
 - DateStampedEntityMixin
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/sample_preparation.md
+++ b/schema/v1.1.0/metadata-docs/sample_preparation.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:sample_preparation](metadatasample_preparation)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:sample_preparation](metadatasample_preparation)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: sample_preparation
 domain_of:
 - ExperimentMetadata
 - Dataset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/sample_type.md
+++ b/schema/v1.1.0/metadata-docs/sample_type.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:sample_type](metadatasample_type)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:sample_type](metadatasample_type)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: sample_type
 domain_of:
 - ExperimentMetadata
 - Dataset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/spherical_aberration_constant.md
+++ b/schema/v1.1.0/metadata-docs/spherical_aberration_constant.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:spherical_aberration_constant](metadataspherical_aberration_const
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
 
 * Minimum Value: 0
 
@@ -79,7 +79,7 @@ alias: spherical_aberration_constant
 owner: TiltSeries
 domain_of:
 - TiltSeries
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 minimum_value: 0

--- a/schema/v1.1.0/metadata-docs/tilt_axis.md
+++ b/schema/v1.1.0/metadata-docs/tilt_axis.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:tilt_axis](metadatatilt_axis)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
 
 * Minimum Value: -360
 
@@ -81,7 +81,7 @@ alias: tilt_axis
 owner: TiltSeries
 domain_of:
 - TiltSeries
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 minimum_value: -360

--- a/schema/v1.1.0/metadata-docs/tilt_series_quality.md
+++ b/schema/v1.1.0/metadata-docs/tilt_series_quality.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:tilt_series_quality](metadatatilt_series_quality)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[Integer](Integer.md)&nbsp;or&nbsp;<br />[IntegerFormattedString](IntegerFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[Integer](Integer.md)&nbsp;or&nbsp;<br />[IntegerFormattedString](IntegerFormattedString.md)
 
 * Minimum Value: 1
 
@@ -82,7 +82,7 @@ alias: tilt_series_quality
 owner: TiltSeries
 domain_of:
 - TiltSeries
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 minimum_value: 1

--- a/schema/v1.1.0/metadata-docs/tilt_step.md
+++ b/schema/v1.1.0/metadata-docs/tilt_step.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:tilt_step](metadatatilt_step)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
 
 * Minimum Value: 0
 
@@ -81,7 +81,7 @@ alias: tilt_step
 owner: TiltSeries
 domain_of:
 - TiltSeries
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 minimum_value: 0

--- a/schema/v1.1.0/metadata-docs/tissue.md
+++ b/schema/v1.1.0/metadata-docs/tissue.md
@@ -16,8 +16,8 @@ URI: [cdp-meta:tissue](metadatatissue)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 | [Dataset](Dataset.md) | High-level description of a cryoET dataset |  no  |
+| [ExperimentMetadata](ExperimentMetadata.md) | Metadata describing sample and sample preparation methods used in a cryoET da... |  no  |
 
 
 
@@ -27,7 +27,7 @@ URI: [cdp-meta:tissue](metadatatissue)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: tissue
 domain_of:
 - ExperimentMetadata
 - Dataset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/total_flux.md
+++ b/schema/v1.1.0/metadata-docs/total_flux.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:total_flux](metadatatotal_flux)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
 
 * Minimum Value: 0
 
@@ -80,7 +80,7 @@ alias: total_flux
 owner: TiltSeries
 domain_of:
 - TiltSeries
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 minimum_value: 0

--- a/schema/v1.1.0/metadata-docs/voxel_spacing.md
+++ b/schema/v1.1.0/metadata-docs/voxel_spacing.md
@@ -31,7 +31,7 @@ URI: [cdp-meta:voxel_spacing](metadatavoxel_spacing)
 
 ## Properties
 
-* Range: [String](String.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
+* Range: [Any](Any.md)&nbsp;or&nbsp;<br />[Float](Float.md)&nbsp;or&nbsp;<br />[FloatFormattedString](FloatFormattedString.md)
 
 * Minimum Value: 0
 
@@ -79,7 +79,7 @@ alias: voxel_spacing
 owner: Tomogram
 domain_of:
 - Tomogram
-range: string
+range: Any
 inlined: true
 inlined_as_list: true
 minimum_value: 0.001

--- a/schema/v1.1.0/metadata-docs/x.md
+++ b/schema/v1.1.0/metadata-docs/x.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:x](metadatax)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: x
 domain_of:
 - TomogramSize
 - TomogramOffset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/y.md
+++ b/schema/v1.1.0/metadata-docs/y.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:y](metadatay)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: y
 domain_of:
 - TomogramSize
 - TomogramOffset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata-docs/z.md
+++ b/schema/v1.1.0/metadata-docs/z.md
@@ -27,7 +27,7 @@ URI: [cdp-meta:z](metadataz)
 
 ## Properties
 
-* Range: [String](String.md)
+* Range: [Any](Any.md)
 
 
 
@@ -61,7 +61,7 @@ alias: z
 domain_of:
 - TomogramSize
 - TomogramOffset
-range: string
+range: Any
 
 ```
 </details>

--- a/schema/v1.1.0/metadata.yaml
+++ b/schema/v1.1.0/metadata.yaml
@@ -12,7 +12,7 @@ prefixes:
   #cdp-common: common
 imports:
   - linkml:types
-default_range: string
+default_range: Any
 default_prefix: cdp-meta
 
 classes:
@@ -73,7 +73,6 @@ classes:
   # Meta-Mixins
   # ============================================================================
   DateStampedEntity:
-    abstract: true
     description: An entity with associated deposition, release and last modified dates.
     attributes:
       dates:
@@ -81,7 +80,6 @@ classes:
         required: true
 
   AuthoredEntity:
-    abstract: true
     description: An entity with associated authors.
     attributes:
       authors:
@@ -93,7 +91,6 @@ classes:
         list_elements_ordered: true
 
   FundedEntity:
-    abstract: true
     description: An entity with associated funding sources.
     attributes:
       funding:
@@ -105,7 +102,6 @@ classes:
         list_elements_ordered: true
 
   CrossReferences:
-    abstract: true
     description: A set of cross-references to other databases and publications.
     mixins:
       - CrossReferencesMixin
@@ -118,7 +114,6 @@ classes:
         range: CrossReferences
 
   PicturedEntity:
-    abstract: true
     description: An entity with associated preview images.
     attributes:
       key_photos:
@@ -183,7 +178,6 @@ classes:
           - cdp-common:cell_component_id
 
   ExperimentMetadata:
-    abstract: true
     description: Metadata describing sample and sample preparation methods used in a cryoET dataset.
     attributes:
       sample_type:

--- a/schema/v1.1.0/metadata_materialized.yaml
+++ b/schema/v1.1.0/metadata_materialized.yaml
@@ -26,7 +26,7 @@ prefixes:
     prefix_prefix: GO
     prefix_reference: http://purl.obolibrary.org/obo/GO_
 default_prefix: cdp-meta
-default_range: string
+default_range: Any
 types:
   string:
     name: string
@@ -799,7 +799,6 @@ classes:
     name: DateStampedEntity
     description: An entity with associated deposition, release and last modified dates.
     from_schema: metadata
-    abstract: true
     attributes:
       dates:
         name: dates
@@ -818,7 +817,6 @@ classes:
     name: AuthoredEntity
     description: An entity with associated authors.
     from_schema: metadata
-    abstract: true
     attributes:
       authors:
         name: authors
@@ -839,7 +837,6 @@ classes:
     name: FundedEntity
     description: An entity with associated funding sources.
     from_schema: metadata
-    abstract: true
     attributes:
       funding:
         name: funding
@@ -860,7 +857,6 @@ classes:
     name: CrossReferences
     description: A set of cross-references to other databases and publications.
     from_schema: metadata
-    abstract: true
     mixins:
     - CrossReferencesMixin
     attributes:
@@ -935,7 +931,6 @@ classes:
     name: PicturedEntity
     description: An entity with associated preview images.
     from_schema: metadata
-    abstract: true
     attributes:
       key_photos:
         name: key_photos
@@ -1180,7 +1175,6 @@ classes:
     description: Metadata describing sample and sample preparation methods used in
       a cryoET dataset.
     from_schema: metadata
-    abstract: true
     attributes:
       sample_type:
         name: sample_type
@@ -1705,7 +1699,7 @@ classes:
         domain_of:
         - CameraDetails
         - MicroscopeDetails
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         pattern: (^FEI$)|(^TFS$)|(^JEOL$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)
@@ -1785,7 +1779,7 @@ classes:
         owner: TiltRange
         domain_of:
         - TiltRange
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         minimum_value: -90
@@ -1807,7 +1801,7 @@ classes:
         owner: TiltRange
         domain_of:
         - TiltRange
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         minimum_value: -90
@@ -1853,7 +1847,7 @@ classes:
         owner: TiltSeries
         domain_of:
         - TiltSeries
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         minimum_value: 0
@@ -1871,7 +1865,7 @@ classes:
         owner: TiltSeries
         domain_of:
         - TiltSeries
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         minimum_value: 0
@@ -1981,7 +1975,7 @@ classes:
         owner: TiltSeries
         domain_of:
         - TiltSeries
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         minimum_value: 0
@@ -2014,7 +2008,7 @@ classes:
         owner: TiltSeries
         domain_of:
         - TiltSeries
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         minimum_value: -360
@@ -2049,7 +2043,7 @@ classes:
         owner: TiltSeries
         domain_of:
         - TiltSeries
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         minimum_value: 1
@@ -2068,7 +2062,7 @@ classes:
         owner: TiltSeries
         domain_of:
         - TiltSeries
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         minimum_value: 0
@@ -2105,7 +2099,7 @@ classes:
         owner: TiltSeries
         domain_of:
         - TiltSeries
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         minimum_value: 0
@@ -2125,7 +2119,7 @@ classes:
         owner: TiltSeries
         domain_of:
         - TiltSeries
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         minimum_value: 0.001
@@ -2263,7 +2257,7 @@ classes:
         owner: Tomogram
         domain_of:
         - Tomogram
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         minimum_value: 0.001
@@ -2284,7 +2278,7 @@ classes:
         owner: Tomogram
         domain_of:
         - Tomogram
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         pattern: (^FIDUCIAL$)|(^NON_FIDUCIAL$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)
@@ -2326,7 +2320,7 @@ classes:
         owner: Tomogram
         domain_of:
         - Tomogram
-        range: string
+        range: Any
         inlined: true
         inlined_as_list: true
         pattern: (^SART$)|(^Fourier Space$)|(^SIRT$)|(^WBP$)|(^Unknown$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[
@@ -3325,7 +3319,6 @@ classes:
         minimum_cardinality: 1
   Any:
     name: Any
-    description: A placeholder for any type of data.
     from_schema: metadata
     class_uri: linkml:Any
   DateStampedEntityMixin:

--- a/schema/v1.1.0/metadata_models.py
+++ b/schema/v1.1.0/metadata_models.py
@@ -50,7 +50,7 @@ class LinkMLMeta(RootModel):
 linkml_meta = LinkMLMeta(
     {
         "default_prefix": "cdp-meta",
-        "default_range": "string",
+        "default_range": "Any",
         "id": "metadata",
         "imports": ["linkml:types"],
         "name": "cdp-meta",
@@ -741,7 +741,7 @@ class DateStampedEntity(ConfiguredBaseModel):
     An entity with associated deposition, release and last modified dates.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"abstract": True, "from_schema": "metadata"})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
     dates: DateStamp = Field(
         ...,
@@ -757,7 +757,7 @@ class AuthoredEntity(ConfiguredBaseModel):
     An entity with associated authors.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"abstract": True, "from_schema": "metadata"})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
     authors: List[Author] = Field(
         default_factory=list,
@@ -778,7 +778,7 @@ class FundedEntity(ConfiguredBaseModel):
     An entity with associated funding sources.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"abstract": True, "from_schema": "metadata"})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
     funding: Optional[List[FundingDetails]] = Field(
         default_factory=list,
@@ -818,7 +818,7 @@ class PicturedEntity(ConfiguredBaseModel):
     An entity with associated preview images.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"abstract": True, "from_schema": "metadata"})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
     key_photos: PicturePath = Field(
         ...,
@@ -1092,7 +1092,7 @@ class ExperimentMetadata(ConfiguredBaseModel):
     Metadata describing sample and sample preparation methods used in a cryoET dataset.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"abstract": True, "from_schema": "metadata"})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
     sample_type: SampleTypeEnum = Field(
         ...,
@@ -3368,9 +3368,7 @@ class CrossReferences(CrossReferencesMixin):
     A set of cross-references to other databases and publications.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {"abstract": True, "from_schema": "metadata", "mixins": ["CrossReferencesMixin"]}
-    )
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata", "mixins": ["CrossReferencesMixin"]})
 
     publications: Optional[str] = Field(
         None,

--- a/schema/v1.1.0/schema.py
+++ b/schema/v1.1.0/schema.py
@@ -157,6 +157,8 @@ def _materialize_schema(schema: SchemaView, common_schema: SchemaView) -> Schema
         for m in clz.mixins:
             mixin = schema.get_class(m)
             for name, attr in mixin.attributes.items():
+                if attr.description is None:
+                    continue
                 clz.attributes[name].description = attr.description
 
     # Make sure the attributes that have classes as range have their descriptions set
@@ -164,6 +166,8 @@ def _materialize_schema(schema: SchemaView, common_schema: SchemaView) -> Schema
         clz = schema.get_class(c)
         for _, attr in clz.attributes.items():
             if attr.range in schema.all_classes():
+                if schema.get_class(attr.range).description is None:
+                    continue
                 attr.description = schema.get_class(attr.range).description
 
     return schema


### PR DESCRIPTION
The generated schema.json file used for VSCode & PyCharm intellisense is bugged. When you try to provide a number for a field that can be both a number or a formatted string, it errors. This PR fixes this and does not cause any regressions. It also fixes another bug where classes are abstract and not properly included in the schema.json, so the intellisense breaks (the classes are now non-abstract, which is fine). Descriptions also get improperly removed when running schema.py, so there is a bug fix for that as well. 