### PR TITLE
Adding relationship from deposition entity

### DIFF
--- a/api_server/metadata/databases/cryoetdataportal/tables/public_depositions.yaml
+++ b/api_server/metadata/databases/cryoetdataportal/tables/public_depositions.yaml
@@ -2,12 +2,48 @@ table:
   name: depositions
   schema: public
 array_relationships:
+  - name: annotations
+    using:
+      manual_configuration:
+        column_mapping:
+          id: deposition_id
+        insertion_order: null
+        remote_table:
+          name: annotations
+          schema: public
   - name: authors
     using:
       foreign_key_constraint_on:
         column: deposition_id
         table:
           name: deposition_authors
+          schema: public
+  - name: dataset
+    using:
+      manual_configuration:
+        column_mapping:
+          id: deposition_id
+        insertion_order: null
+        remote_table:
+          name: datasets
+          schema: public
+  - name: tiltseries
+    using:
+      manual_configuration:
+        column_mapping:
+          id: deposition_id
+        insertion_order: null
+        remote_table:
+          name: tiltseries
+          schema: public
+  - name: tomograms
+    using:
+      manual_configuration:
+        column_mapping:
+          id: deposition_id
+        insertion_order: null
+        remote_table:
+          name: tomograms
           schema: public
 select_permissions:
   - role: anonymous

--- a/api_server/metadata/databases/cryoetdataportal/tables/public_depositions.yaml
+++ b/api_server/metadata/databases/cryoetdataportal/tables/public_depositions.yaml
@@ -55,6 +55,8 @@ select_permissions:
         - description
         - https_prefix
         - id
+        - key_photo_thumbnail_url
+        - key_photo_url
         - last_modified_date
         - related_database_entries
         - release_date

--- a/api_server/migrations/cryoetdataportal/1723167977727_alter_table_public_depositions_add_column_key_photo_url/down.sql
+++ b/api_server/migrations/cryoetdataportal/1723167977727_alter_table_public_depositions_add_column_key_photo_url/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."depositions" drop column "key_photo_url";
+alter table "public"."depositions" drop column "key_photo_thumbnail_url";

--- a/api_server/migrations/cryoetdataportal/1723167977727_alter_table_public_depositions_add_column_key_photo_url/up.sql
+++ b/api_server/migrations/cryoetdataportal/1723167977727_alter_table_public_depositions_add_column_key_photo_url/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."depositions" add column "key_photo_url" varchar null;
+comment on column "public"."depositions"."key_photo_url" is E'URL for the deposition preview image.';
+
+alter table "public"."depositions" add column "key_photo_thumbnail_url" varchar null;
+comment on column "public"."depositions"."key_photo_thumbnail_url" is E'URL for the deposition thumbnail image.';

--- a/ingestion_tools/scripts/common/db_models.py
+++ b/ingestion_tools/scripts/common/db_models.py
@@ -35,6 +35,8 @@ class Deposition(BaseModel):
     deposition_types = CharField()
     s3_prefix = CharField()
     https_prefix = CharField()
+    key_photo_url = CharField(null=True)
+    key_photo_thumbnail_url = CharField(null=True)
 
 
 class DepositionAuthor(BaseModel):

--- a/ingestion_tools/scripts/common/db_models.py
+++ b/ingestion_tools/scripts/common/db_models.py
@@ -10,6 +10,8 @@ from peewee import (
 )
 from playhouse.postgres_ext import ArrayField, JSONField
 
+from common.formats import json_dumps
+
 db = PostgresqlDatabase(None)
 
 
@@ -215,7 +217,7 @@ class Annotation(BaseModel):
     ground_truth_used = CharField()
     is_curator_recommended = BooleanField(default=False)
     method_type = CharField()
-    method_links = JSONField(null=True)
+    method_links = JSONField(null=True, dumps=json_dumps)
     deposition_id = IntegerField(null=True)
 
 

--- a/ingestion_tools/scripts/common/formats.py
+++ b/ingestion_tools/scripts/common/formats.py
@@ -12,3 +12,8 @@ def json_serial(obj: Any) -> str:
 
 def tojson(data: Any) -> str:
     return json.dumps(data, indent=4, default=json_serial)
+
+
+def json_dumps(value: str | dict) -> str:
+    """If value is a string, return it as is, otherwise convert to JSON string."""
+    return value if isinstance(value, str) else json.dumps(value)

--- a/ingestion_tools/scripts/tests/db_import/conftest.py
+++ b/ingestion_tools/scripts/tests/db_import/conftest.py
@@ -64,12 +64,16 @@ def mock_db(db_connection: str) -> [list[BaseModel], Generator[SqliteDatabase, A
 
 @pytest.fixture
 def verify_model():
-    def _verify_model(actual: BaseModel, expected_values: dict[str, Any]):
-        for key, value in actual.__data__.items():
-            if key == "id" and key not in expected_values:
+    def _verify_model(actual_model: BaseModel, expected_values: dict[str, Any]):
+        actual_data = actual_model.__data__
+        for key, expected in expected_values.items():
+            actual = actual_data.get(key)
+            assert actual == expected, f"Unexpected value for {key} actual={actual} expected={expected}"
+        for key in actual_data.keys() - expected_values.keys():
+            if "id" in key:
                 continue
-            expected = expected_values.get(key)
-            assert value == expected, f"Unexpected value for {key} actual={value} expected={expected}"
+            actual = actual_data.get(key)
+            assert actual is None, f"Unexpected value for {key} actual={actual} expected=None"
 
     return _verify_model
 
@@ -112,7 +116,6 @@ def expected_dataset(http_prefix: str) -> dict[str, Any]:
         "related_database_entries": "TEST-1243435",
         "sample_preparation": "method1: value1, method2: value3",
         "grid_preparation": "method3: value8, method6: value4",
-        "dataset_identifier": DATASET_ID,
         "sample_type": "organism",
         "cell_component_id": "GO:123435",
         "cell_component_name": "tail",

--- a/ingestion_tools/scripts/tests/db_import/test_db_annotation_import.py
+++ b/ingestion_tools/scripts/tests/db_import/test_db_annotation_import.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 from typing import Any, Callable
 
 import pytest as pytest
@@ -40,20 +39,18 @@ def expected_annotations(http_prefix: str) -> list[dict[str, Any]]:
             "object_count": 16,
             "deposition_id": 301,
             "method_type": "hybrid",
-            "method_links": json.dumps(
-                [
-                    {
-                        "link": "https://fake-link.com/resources/100-foo-1.0_method.pdf",
-                        "link_type": "documentation",
-                        "name": "Method Documentation",
-                    },
-                    {
-                        "link": "https://another-link.com/100-foo-1.0_code.zip",
-                        "link_type": "source_code",
-                        "name": "Source Code",
-                    },
-                ],
-            ),
+            "method_links": [
+                {
+                    "link": "https://fake-link.com/resources/100-foo-1.0_method.pdf",
+                    "link_type": "documentation",
+                    "name": "Method Documentation",
+                },
+                {
+                    "link": "https://another-link.com/100-foo-1.0_code.zip",
+                    "link_type": "source_code",
+                    "name": "Source Code",
+                },
+            ],
         },
     ]
 

--- a/ingestion_tools/scripts/tests/db_import/test_db_deposition_import.py
+++ b/ingestion_tools/scripts/tests/db_import/test_db_deposition_import.py
@@ -33,8 +33,8 @@ def expected_deposition1(http_prefix: str) -> dict[str, Any]:
         "s3_prefix": f"s3://test-public-bucket/depositions_metadata/{DEPOSITION_ID1}/",
         "https_prefix": f"{http_prefix}/depositions_metadata/{DEPOSITION_ID1}/",
         "deposition_types": "annotation,dataset",
-        "key_photo_url": f"{http_prefix}/depositions_metadata/{DEPOSITION_ID1}/Images/snapshot.png",
-        "key_photo_thumbnail_url": f"{http_prefix}/depositions_metadata/{DEPOSITION_ID1}/Images/thumbnail.png",
+        "key_photo_url": f"{http_prefix}/deposition_metadata/{DEPOSITION_ID1}/Images/snapshot.png",
+        "key_photo_thumbnail_url": f"{http_prefix}/deposition_metadata/{DEPOSITION_ID1}/Images/thumbnail.png",
     }
 
 

--- a/test_infra/sql/schema.sql
+++ b/test_infra/sql/schema.sql
@@ -396,7 +396,9 @@ CREATE TABLE public.depositions (
     deposition_publications character varying,
     deposition_types character varying NOT NULL,
     s3_prefix character varying,
-    https_prefix character varying
+    https_prefix character varying,
+    key_photo_url character varying,
+    key_photo_thumbnail_url character varying
 );
 
 


### PR DESCRIPTION
## Description
- Adds relationship between deposition and datasets, annotation, tiltseries and tomograms
- Adds fix to prevent the method links from getting string encoded twice
- Adds key photo urls to depositions