### PR TITLE
s3 data validation: photos & *_metadata.json sanity checks

### DIFF
--- a/ingestion_tools/scripts/data_validation/conftest.py
+++ b/ingestion_tools/scripts/data_validation/conftest.py
@@ -94,6 +94,7 @@ def pytest_configure(config: pytest.Config) -> None:
     # Register markers
     config.addinivalue_line("markers", "annotation: Tests concerning the annotation data.")
     config.addinivalue_line("markers", "dataset: Tests concerning the dataset.")
+    config.addinivalue_line("markers", "deposition: Tests concerning the deposition data.")
     config.addinivalue_line("markers", "run: Tests concerning the runs.")
     config.addinivalue_line("markers", "tiltseries: Tests concerning the tiltseries.")
     config.addinivalue_line("markers", "tomogram: Tests concerning the tomogram.")

--- a/ingestion_tools/scripts/data_validation/fixtures/data.py
+++ b/ingestion_tools/scripts/data_validation/fixtures/data.py
@@ -49,6 +49,18 @@ def get_zarrays(zarrfile: str, fs: FileSystemApi) -> Dict:
 
 
 # ==================================================================================================
+# Dataset fixtures
+# ==================================================================================================
+
+
+@pytest.fixture(scope="session")
+def dataset_metadata(dataset_metadata_file: str, filesystem: FileSystemApi) -> Dict:
+    """Load the dataset metadata."""
+    with filesystem.open(dataset_metadata_file, "r") as f:
+        return json.load(f)
+
+
+# ==================================================================================================
 # Tiltseries fixtures
 # ==================================================================================================
 
@@ -116,7 +128,7 @@ def annotation_metadata(annotation_metadata_files: List[str], filesystem: FileSy
 
 
 def get_ndjson_annotations(
-    annotation_files_to_metadata_files: Dict[str, str],
+    annotation_files: List[str],
     filesystem: FileSystemApi,
 ) -> Dict[str, List[Dict]]:
     """
@@ -126,7 +138,7 @@ def get_ndjson_annotations(
     """
     annotations = {}
     # Only need the annotation file to find the annotations.
-    for annotation_file, _ in annotation_files_to_metadata_files.items():
+    for annotation_file in annotation_files:
         with filesystem.open(annotation_file, "r") as f:
             annotations[annotation_file] = ndjson.load(f)
 
@@ -135,39 +147,39 @@ def get_ndjson_annotations(
 
 @pytest.fixture(scope="session")
 def point_annotations(
-    point_annotation_files_to_metadata_files: Dict[str, str],
+    point_annotation_files: List[str],
     filesystem: FileSystemApi,
 ) -> Dict[str, List[Dict]]:
     """Load point annotations."""
-    return get_ndjson_annotations(point_annotation_files_to_metadata_files, filesystem)
+    return get_ndjson_annotations(point_annotation_files, filesystem)
 
 
 @pytest.fixture(scope="session")
 def oriented_point_annotations(
-    oriented_point_annotation_files_to_metadata_files: Dict[str, str],
+    oriented_point_annotation_files: List[str],
     filesystem: FileSystemApi,
 ) -> Dict[str, List[Dict]]:
     """Load oriented point annotations."""
-    return get_ndjson_annotations(oriented_point_annotation_files_to_metadata_files, filesystem)
+    return get_ndjson_annotations(oriented_point_annotation_files, filesystem)
 
 
 @pytest.fixture(scope="session")
 def instance_seg_annotations(
-    instance_seg_annotation_files_to_metadata_files: Dict[str, str],
+    instance_seg_annotation_files: List[str],
     filesystem: FileSystemApi,
 ) -> Dict[str, List[Dict]]:
     """Load instance segmentation annotations."""
-    return get_ndjson_annotations(instance_seg_annotation_files_to_metadata_files, filesystem)
+    return get_ndjson_annotations(instance_seg_annotation_files, filesystem)
 
 
 @pytest.fixture(scope="session")
 def seg_mask_annotation_mrc_headers(
-    seg_mask_annotation_mrc_files_to_metadata_files: Dict[str, str],
+    seg_mask_annotation_mrc_files: List[str],
     filesystem: FileSystemApi,
 ) -> Dict[str, MrcInterpreter]:
     """Get the mrc file headers for an mrc annotation file."""
     headers = {}
-    for mrc_filename, _ in seg_mask_annotation_mrc_files_to_metadata_files.items():
+    for mrc_filename in seg_mask_annotation_mrc_files:
         headers[mrc_filename] = get_header(mrc_filename, filesystem)
 
     return headers
@@ -175,7 +187,7 @@ def seg_mask_annotation_mrc_headers(
 
 @pytest.fixture(scope="session")
 def seg_mask_annotation_zarr_headers(
-    seg_mask_annotation_zarr_files_to_metadata_files: Dict[str, str],
+    seg_mask_annotation_zarr_files: List[str],
     filesystem: FileSystemApi,
 ) -> Dict[str, Dict[str, Dict]]:
     """
@@ -183,7 +195,7 @@ def seg_mask_annotation_zarr_headers(
     Dictionary structure: headers = {annotation_a_filename: {"zattrs": Dict, "zarrays": Dict}}, annotation_b_filename: ...}.
     """
     headers = {}
-    for zarr_filename, _ in seg_mask_annotation_zarr_files_to_metadata_files.items():
+    for zarr_filename in seg_mask_annotation_zarr_files:
         headers[zarr_filename] = {
             "zattrs": get_zattrs(zarr_filename, filesystem),
             "zarrays": get_zarrays(zarr_filename, filesystem),

--- a/ingestion_tools/scripts/data_validation/tests/annotation/test_metadata_annotation.py
+++ b/ingestion_tools/scripts/data_validation/tests/annotation/test_metadata_annotation.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from typing import Dict
+
+import pytest
+
+from common.fs import FileSystemApi
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from test_deposition import TestDeposition
+
+
+@pytest.mark.annotation
+@pytest.mark.metadata
+@pytest.mark.parametrize("run_name, voxel_spacing", pytest.run_spacing_combinations, scope="session")
+class TestAnnotationMetadata:
+    def test_annotation_metadata(
+        self,
+        annotation_metadata: Dict[str, Dict],
+        bucket: str,
+        filesystem: FileSystemApi,
+    ):
+        """Sanity check for annotation metadata and corresponding deposition metadata."""
+        for metadata in annotation_metadata.values():
+            assert metadata["deposition_id"]
+            assert isinstance(metadata["annotation_object"], dict)
+            assert isinstance(metadata["authors"], list)
+            assert isinstance(metadata["authors"][0], dict)
+            assert metadata["object_count"] >= 0
+            assert len(metadata["files"]) >= 0
+            TestDeposition.check_deposition_metadata(metadata["deposition_id"], bucket, filesystem)

--- a/ingestion_tools/scripts/data_validation/tests/helpers_images.py
+++ b/ingestion_tools/scripts/data_validation/tests/helpers_images.py
@@ -1,0 +1,36 @@
+import io
+
+import pytest
+import requests
+from PIL import Image
+
+from common.fs import FileSystemApi
+
+
+def check_photo_valid(photo: str, bucket: str, filesystem: FileSystemApi):
+    print(f"Checking photo: {photo}")
+    photo_data = None
+    if photo.startswith("http"):
+        response = requests.get(photo)
+        assert response.status_code < 400
+        photo_data = response.content
+    else:
+        if photo.startswith("s3://"):
+            pass
+        elif photo.startswith(bucket):
+            photo = filesystem.destformat(photo)
+        else:
+            photo = filesystem.destformat(f"{bucket}/{photo}")
+
+        assert filesystem.exists(photo)
+        photo_data = filesystem.open(photo, "rb").read()
+
+    image = Image.open(io.BytesIO(photo_data))
+    try:
+        image.verify()
+    except Exception:
+        pytest.fail(f"Image verification failed: {photo}")
+    assert image.format in ["JPEG", "PNG", "GIF"]
+    # 100px min height, 4:3 aspect ratio
+    assert image.size[0] >= 134
+    assert image.size[1] >= 100

--- a/ingestion_tools/scripts/data_validation/tests/test_dataset.py
+++ b/ingestion_tools/scripts/data_validation/tests/test_dataset.py
@@ -1,0 +1,31 @@
+from typing import Dict
+
+import pytest
+from helpers_images import check_photo_valid
+from test_deposition import TestDeposition
+
+from common.fs import FileSystemApi
+
+
+@pytest.mark.dataset
+@pytest.mark.metadata
+class TestDataset:
+    def test_dataset_metadata(self, dataset_metadata: Dict):
+        """A dataset metadata sanity check."""
+        assert dataset_metadata["dataset_description"]
+        assert dataset_metadata["dataset_title"]
+        assert dataset_metadata["dataset_identifier"]
+        assert dataset_metadata["deposition_id"]
+        assert isinstance(dataset_metadata["authors"], list)
+        assert isinstance(dataset_metadata["authors"][0], dict)
+
+    def test_dataset_key_photos(self, dataset_metadata: Dict, bucket: str, filesystem: FileSystemApi):
+        """Check that the key_photos in the metadata are valid."""
+        if (thumbnail := dataset_metadata["key_photos"]["thumbnail"]) is not None:
+            check_photo_valid(thumbnail, bucket, filesystem)
+
+        if (snapshot := dataset_metadata["key_photos"]["snapshot"]) is not None:
+            check_photo_valid(snapshot, bucket, filesystem)
+
+    def test_dataset_deposition(self, dataset_metadata: Dict, bucket: str, filesystem: FileSystemApi):
+        TestDeposition.check_deposition_metadata(dataset_metadata["deposition_id"], bucket, filesystem)

--- a/ingestion_tools/scripts/data_validation/tests/test_deposition.py
+++ b/ingestion_tools/scripts/data_validation/tests/test_deposition.py
@@ -1,0 +1,54 @@
+"""
+Validate deposition metadata. This is not an actual pytest class that is run, but instead a static class that is called
+by other test classes to validate their corresponding deposition's metadata.
+"""
+
+import json
+from typing import Dict, Union
+
+from helpers_images import check_photo_valid
+
+from common.fs import FileSystemApi
+
+
+class TestDeposition:
+    cached_deposition_valid: Dict[str, bool] = {}
+
+    @staticmethod
+    def _get_deposition_metadata_file(deposition_id: str, bucket: str, filesystem: FileSystemApi) -> str:
+        dst = f"s3://{bucket}/depositions_metadata/{deposition_id}/deposition_metadata.json"
+        assert filesystem.s3fs.exists(dst)
+        return dst
+
+    @staticmethod
+    def _get_deposition_metadata(deposition_metadata_file: str, filesystem: FileSystemApi) -> Dict:
+        """Load the deposition metadata."""
+        print(f"Loading deposition metadata: {deposition_metadata_file}")
+        with filesystem.open(deposition_metadata_file, "r") as f:
+            return json.load(f)
+
+    @staticmethod
+    def check_deposition_metadata(deposition_id: Union[str, int], bucket: str, filesystem: FileSystemApi) -> Dict:
+        """A deposition metadata sanity check and ensuring that photos are valid."""
+        # No need to check the same deposition twice.
+        deposition_id = str(deposition_id)
+        if deposition_id in TestDeposition.cached_deposition_valid:
+            return
+        print(f"Checking deposition: {deposition_id}")
+        TestDeposition.cached_deposition_valid[deposition_id] = False
+        deposition_file = TestDeposition._get_deposition_metadata_file(deposition_id, bucket, filesystem)
+        deposition_metadata = TestDeposition._get_deposition_metadata(deposition_file, filesystem)
+        assert deposition_metadata["deposition_description"]
+        assert deposition_metadata["deposition_title"]
+        assert deposition_metadata["deposition_identifier"]
+        assert deposition_metadata["deposition_id"]
+        assert isinstance(deposition_metadata["authors"], list)
+        assert isinstance(deposition_metadata["authors"][0], dict)
+
+        if (thumbnail := deposition_metadata["key_photos"]["thumbnail"]) is not None:
+            check_photo_valid(thumbnail, bucket, filesystem)
+
+        if (snapshot := deposition_metadata["key_photos"]["snapshot"]) is not None:
+            check_photo_valid(snapshot, bucket, filesystem)
+
+        TestDeposition.cached_deposition_valid[deposition_id] = True

--- a/ingestion_tools/scripts/data_validation/tests/test_tomogram.py
+++ b/ingestion_tools/scripts/data_validation/tests/test_tomogram.py
@@ -1,0 +1,34 @@
+"""
+key_images testing is also done here (since key_images are part of the tomogram metadata)
+"""
+
+from typing import Dict
+
+import pytest
+from helpers_images import check_photo_valid
+from test_deposition import TestDeposition
+
+from common.fs import FileSystemApi
+
+
+@pytest.mark.tomogram
+@pytest.mark.metadata
+@pytest.mark.parametrize("run_name, voxel_spacing", pytest.run_spacing_combinations, scope="session")
+class TestTomogram:
+    def test_tomogram_metadata(self, canonical_tomogram_metadata: Dict):
+        """A tomogram metadata sanity check."""
+        assert canonical_tomogram_metadata["deposition_id"]
+        assert isinstance(canonical_tomogram_metadata["authors"], list)
+        assert isinstance(canonical_tomogram_metadata["authors"][0], dict)
+
+    # The key_photo attribute is where the key_images data is stored and can be validated
+    def test_tomogram_key_photos(self, canonical_tomogram_metadata: Dict, bucket: str, filesystem: FileSystemApi):
+        """Check that the key_photos in the metadata are valid."""
+        if (thumbnail := canonical_tomogram_metadata["key_photo"]["thumbnail"]) is not None:
+            check_photo_valid(thumbnail, bucket, filesystem)
+
+        if (snapshot := canonical_tomogram_metadata["key_photo"]["snapshot"]) is not None:
+            check_photo_valid(snapshot, bucket, filesystem)
+
+    def test_tomogram_deposition(self, canonical_tomogram_metadata: Dict, bucket: str, filesystem: FileSystemApi):
+        TestDeposition.check_deposition_metadata(canonical_tomogram_metadata["deposition_id"], bucket, filesystem)


### PR DESCRIPTION
To be reviewed and merged after #200 (currently just comparing changes between #200 and this one)

With this PR, deposition validation is just on the deposition_metadata.json file and relevant photos, not any other actual related deposition content. Any deposition that is referenced anywhere in the dataset (annotations, tomograms, metadata, etc.) that is currently being validated will be validated alongside. As other validations are implemented (tiltseries, frames, whatnot), the validation for those fields' corresponding deposition will be added alongside (so those will be done in their respective PRs, not done in here).

Validate dataset_metadata.json file (sanity check + photo check + corresponding deposition validation)

Validate key_images, which is in the tomogram_metadata.json (and so just added to test_tomogram.py), as well as some tomogram_metadata simply sanity checks.

Also forgot to add annotation metadata sanity checks, so added that along with the annotation deposition validations. 