### PR TITLE
Schema.py refactor & bug fixes

### DIFF
--- a/schema/core/v1.1.0/codegen/metadata_materialized.yaml
+++ b/schema/core/v1.1.0/codegen/metadata_materialized.yaml
@@ -2279,13 +2279,17 @@ classes:
         domain_of:
         - TomogramSize
         - TomogramOffset
-        range: integer
+        range: Any
         required: true
         inlined: true
         inlined_as_list: true
+        pattern: ^int[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$
         unit:
           symbol: px
           descriptive_name: pixels
+        any_of:
+        - range: integer
+        - range: IntegerFormattedString
       y:
         name: y
         description: y offset data relative to the canonical tomogram in pixels
@@ -2295,13 +2299,17 @@ classes:
         domain_of:
         - TomogramSize
         - TomogramOffset
-        range: integer
+        range: Any
         required: true
         inlined: true
         inlined_as_list: true
+        pattern: ^int[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$
         unit:
           symbol: px
           descriptive_name: pixels
+        any_of:
+        - range: integer
+        - range: IntegerFormattedString
       z:
         name: z
         description: z offset data relative to the canonical tomogram in pixels
@@ -2311,13 +2319,17 @@ classes:
         domain_of:
         - TomogramSize
         - TomogramOffset
-        range: integer
+        range: Any
         required: true
         inlined: true
         inlined_as_list: true
+        pattern: ^int[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$
         unit:
           symbol: px
           descriptive_name: pixels
+        any_of:
+        - range: integer
+        - range: IntegerFormattedString
   Tomogram:
     name: Tomogram
     description: Metadata describing a tomogram.

--- a/schema/core/v1.1.0/codegen/metadata_materialized.yaml
+++ b/schema/core/v1.1.0/codegen/metadata_materialized.yaml
@@ -1118,6 +1118,7 @@ classes:
         - CellStrain
         - CellComponent
         - AnnotationObject
+        range: Any
         recommended: true
         inlined: true
         inlined_as_list: true
@@ -1635,9 +1636,10 @@ classes:
         owner: CameraDetails
         domain_of:
         - CameraDetails
+        range: Any
         inlined: true
         inlined_as_list: true
-        pattern: (^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)|(^counting$)|(^superresolution$)|(^linear$)|(^cds$)
+        pattern: (^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)|((^counting$)|(^superresolution$)|(^linear$)|(^cds$))
         any_of:
         - range: StringFormattedString
         - range: tiltseries_camera_acquire_mode_enum
@@ -1700,11 +1702,16 @@ classes:
         - CameraDetails
         - MicroscopeDetails
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         pattern: (^FEI$)|(^TFS$)|(^JEOL$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)
         any_of:
-        - range: tiltseries_microscope_manufacturer_enum
+        - description: Name of the microscope manufacturer
+          exact_mappings:
+          - cdp-common:tiltseries_microscope_manufacturer
+          range: tiltseries_microscope_manufacturer_enum
+          required: true
         - range: StringFormattedString
       model:
         name: model
@@ -1780,6 +1787,7 @@ classes:
         domain_of:
         - TiltRange
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         minimum_value: -90
@@ -1789,9 +1797,16 @@ classes:
           symbol: °
           descriptive_name: degrees
         any_of:
-        - range: float
+        - description: Minimal tilt angle in degrees
+          exact_mappings:
+          - cdp-common:tiltseries_tilt_min
+          range: float
+          required: true
           minimum_value: -90
           maximum_value: 90
+          unit:
+            symbol: °
+            descriptive_name: degrees
         - range: FloatFormattedString
       max:
         name: max
@@ -1802,6 +1817,7 @@ classes:
         domain_of:
         - TiltRange
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         minimum_value: -90
@@ -1811,9 +1827,16 @@ classes:
           symbol: °
           descriptive_name: degrees
         any_of:
-        - range: float
+        - description: Maximal tilt angle in degrees
+          exact_mappings:
+          - cdp-common:tiltseries_tilt_max
+          range: float
+          required: true
           minimum_value: -90
           maximum_value: 90
+          unit:
+            symbol: °
+            descriptive_name: degrees
         - range: FloatFormattedString
   TiltSeries:
     name: TiltSeries
@@ -1853,7 +1876,10 @@ classes:
         minimum_value: 0
         pattern: ^float[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$
         any_of:
-        - range: float
+        - description: Binning factor of the aligned tilt series
+          exact_mappings:
+          - cdp-common:tiltseries_aligned_tiltseries_binning
+          range: float
           minimum_value: 0
         - range: FloatFormattedString
       binning_from_frames:
@@ -1871,7 +1897,10 @@ classes:
         minimum_value: 0
         pattern: ^float[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$
         any_of:
-        - range: float
+        - description: Describes the binning factor from frames to tilt series file
+          exact_mappings:
+          - cdp-common:tiltseries_binning_from_frames
+          range: float
           minimum_value: 0
         - range: FloatFormattedString
       camera:
@@ -1976,6 +2005,7 @@ classes:
         domain_of:
         - TiltSeries
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         minimum_value: 0
@@ -1984,8 +2014,15 @@ classes:
           symbol: mm
           descriptive_name: millimeters
         any_of:
-        - range: float
+        - description: Spherical Aberration Constant of the objective lens in millimeters
+          exact_mappings:
+          - cdp-common:tiltseries_spherical_aberration_constant
+          range: float
+          required: true
           minimum_value: 0
+          unit:
+            symbol: mm
+            descriptive_name: millimeters
         - range: FloatFormattedString
       tilt_alignment_software:
         name: tilt_alignment_software
@@ -2009,6 +2046,7 @@ classes:
         domain_of:
         - TiltSeries
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         minimum_value: -360
@@ -2018,9 +2056,16 @@ classes:
           symbol: °
           descriptive_name: degrees
         any_of:
-        - range: float
+        - description: Rotation angle in degrees
+          exact_mappings:
+          - cdp-common:tiltseries_tilt_axis
+          range: float
+          required: true
           minimum_value: -360
           maximum_value: 360
+          unit:
+            symbol: °
+            descriptive_name: degrees
         - range: FloatFormattedString
       tilt_range:
         name: tilt_range
@@ -2044,13 +2089,19 @@ classes:
         domain_of:
         - TiltSeries
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         minimum_value: 1
         maximum_value: 5
         pattern: ^int[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$
         any_of:
-        - range: integer
+        - description: Author assessment of tilt series quality within the dataset
+            (1-5, 5 is best)
+          exact_mappings:
+          - cdp-common:tiltseries_tilt_series_quality
+          range: integer
+          required: true
           minimum_value: 1
           maximum_value: 5
         - range: IntegerFormattedString
@@ -2063,6 +2114,7 @@ classes:
         domain_of:
         - TiltSeries
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         minimum_value: 0
@@ -2072,9 +2124,16 @@ classes:
           symbol: °
           descriptive_name: degrees
         any_of:
-        - range: float
+        - description: Tilt step in degrees
+          exact_mappings:
+          - cdp-common:tiltseries_tilt_step
+          range: float
+          required: true
           minimum_value: 0
           maximum_value: 90
+          unit:
+            symbol: °
+            descriptive_name: degrees
         - range: FloatFormattedString
       tilting_scheme:
         name: tilting_scheme
@@ -2100,6 +2159,7 @@ classes:
         domain_of:
         - TiltSeries
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         minimum_value: 0
@@ -2108,8 +2168,16 @@ classes:
           symbol: e^-/Å^2
           descriptive_name: electrons per square Angstrom
         any_of:
-        - range: float
+        - description: Number of Electrons reaching the specimen in a square Angstrom
+            area for the entire tilt series
+          exact_mappings:
+          - cdp-common:tiltseries_total_flux
+          range: float
+          required: true
           minimum_value: 0
+          unit:
+            symbol: e^-/Å^2
+            descriptive_name: electrons per square Angstrom
         - range: FloatFormattedString
       pixel_spacing:
         name: pixel_spacing
@@ -2120,6 +2188,7 @@ classes:
         domain_of:
         - TiltSeries
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         minimum_value: 0.001
@@ -2128,8 +2197,15 @@ classes:
           symbol: Å/px
           descriptive_name: Angstroms per pixel
         any_of:
-        - range: float
+        - description: Pixel spacing for the tilt series
+          exact_mappings:
+          - cdp-common:tiltseries_pixel_spacing
+          range: float
+          required: true
           minimum_value: 0.001
+          unit:
+            symbol: Å/px
+            descriptive_name: Angstroms per pixel
         - range: FloatFormattedString
   TomogramSize:
     name: TomogramSize
@@ -2258,6 +2334,7 @@ classes:
         domain_of:
         - Tomogram
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         minimum_value: 0.001
@@ -2266,8 +2343,15 @@ classes:
           symbol: Å/voxel
           descriptive_name: Angstroms per voxel
         any_of:
-        - range: float
+        - description: Voxel spacing equal in all three axes in angstroms
+          exact_mappings:
+          - cdp-common:tomogram_voxel_spacing
+          range: float
+          required: true
           minimum_value: 0.001
+          unit:
+            symbol: Å/voxel
+            descriptive_name: Angstroms per voxel
         - range: FloatFormattedString
       fiducial_alignment_status:
         name: fiducial_alignment_status
@@ -2279,11 +2363,17 @@ classes:
         domain_of:
         - Tomogram
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         pattern: (^FIDUCIAL$)|(^NON_FIDUCIAL$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)
         any_of:
-        - range: fiducial_alignment_status_enum
+        - description: Whether the tomographic alignment was computed based on fiducial
+            markers.
+          exact_mappings:
+          - cdp-common:tomogram_fiducial_alignment_status
+          range: fiducial_alignment_status_enum
+          required: true
         - range: StringFormattedString
       ctf_corrected:
         name: ctf_corrected
@@ -2321,12 +2411,17 @@ classes:
         domain_of:
         - Tomogram
         range: Any
+        required: true
         inlined: true
         inlined_as_list: true
         pattern: (^SART$)|(^Fourier Space$)|(^SIRT$)|(^WBP$)|(^Unknown$)|(^[ ]*\{[a-zA-Z0-9_-]+\}[
           ]*$)
         any_of:
-        - range: tomogrom_reconstruction_method_enum
+        - description: Describe reconstruction method (WBP, SART, SIRT)
+          exact_mappings:
+          - cdp-common:tomogram_reconstruction_method
+          range: tomogrom_reconstruction_method_enum
+          required: true
         - range: StringFormattedString
       reconstruction_software:
         name: reconstruction_software

--- a/schema/core/v1.1.0/codegen/metadata_models.py
+++ b/schema/core/v1.1.0/codegen/metadata_models.py
@@ -1496,7 +1496,7 @@ class CameraDetails(ConfiguredBaseModel):
 
     @field_validator("acquire_mode")
     def pattern_acquire_mode(cls, v):
-        pattern = re.compile(r"(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)|(^counting$)|(^superresolution$)|(^linear$)|(^cds$)")
+        pattern = re.compile(r"(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)|((^counting$)|(^superresolution$)|(^linear$)|(^cds$))")
         if isinstance(v, list):
             for element in v:
                 if not pattern.match(element):
@@ -1525,13 +1525,21 @@ class MicroscopeDetails(ConfiguredBaseModel):
             }
         },
     )
-    manufacturer: Optional[Union[TiltseriesMicroscopeManufacturerEnum, str]] = Field(
-        None,
+    manufacturer: Union[TiltseriesMicroscopeManufacturerEnum, str] = Field(
+        ...,
         description="""Name of the microscope manufacturer""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "manufacturer",
-                "any_of": [{"range": "tiltseries_microscope_manufacturer_enum"}, {"range": "StringFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Name of the microscope manufacturer",
+                        "exact_mappings": ["cdp-common:tiltseries_microscope_manufacturer"],
+                        "range": "tiltseries_microscope_manufacturer_enum",
+                        "required": True,
+                    },
+                    {"range": "StringFormattedString"},
+                ],
                 "domain_of": ["CameraDetails", "MicroscopeDetails"],
             }
         },
@@ -1610,8 +1618,8 @@ class TiltRange(ConfiguredBaseModel):
 
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
-    min: Optional[Union[float, str]] = Field(
-        None,
+    min: Union[float, str] = Field(
+        ...,
         description="""Minimal tilt angle in degrees""",
         ge=-90,
         le=90,
@@ -1619,7 +1627,15 @@ class TiltRange(ConfiguredBaseModel):
             "linkml_meta": {
                 "alias": "min",
                 "any_of": [
-                    {"maximum_value": 90, "minimum_value": -90, "range": "float"},
+                    {
+                        "description": "Minimal tilt angle in degrees",
+                        "exact_mappings": ["cdp-common:tiltseries_tilt_min"],
+                        "maximum_value": 90,
+                        "minimum_value": -90,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "degrees", "symbol": "°"},
+                    },
                     {"range": "FloatFormattedString"},
                 ],
                 "domain_of": ["TiltRange"],
@@ -1627,8 +1643,8 @@ class TiltRange(ConfiguredBaseModel):
             }
         },
     )
-    max: Optional[Union[float, str]] = Field(
-        None,
+    max: Union[float, str] = Field(
+        ...,
         description="""Maximal tilt angle in degrees""",
         ge=-90,
         le=90,
@@ -1636,7 +1652,15 @@ class TiltRange(ConfiguredBaseModel):
             "linkml_meta": {
                 "alias": "max",
                 "any_of": [
-                    {"maximum_value": 90, "minimum_value": -90, "range": "float"},
+                    {
+                        "description": "Maximal tilt angle in degrees",
+                        "exact_mappings": ["cdp-common:tiltseries_tilt_max"],
+                        "maximum_value": 90,
+                        "minimum_value": -90,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "degrees", "symbol": "°"},
+                    },
                     {"range": "FloatFormattedString"},
                 ],
                 "domain_of": ["TiltRange"],
@@ -1697,7 +1721,15 @@ class TiltSeries(ConfiguredBaseModel):
         json_schema_extra={
             "linkml_meta": {
                 "alias": "aligned_tiltseries_binning",
-                "any_of": [{"minimum_value": 0, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Binning factor of the aligned tilt series",
+                        "exact_mappings": ["cdp-common:tiltseries_aligned_tiltseries_binning"],
+                        "minimum_value": 0,
+                        "range": "float",
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["TiltSeries"],
                 "ifabsent": "float(1)",
             }
@@ -1710,7 +1742,15 @@ class TiltSeries(ConfiguredBaseModel):
         json_schema_extra={
             "linkml_meta": {
                 "alias": "binning_from_frames",
-                "any_of": [{"minimum_value": 0, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Describes the binning factor from frames to tilt " "series file",
+                        "exact_mappings": ["cdp-common:tiltseries_binning_from_frames"],
+                        "minimum_value": 0,
+                        "range": "float",
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["TiltSeries"],
                 "ifabsent": "float(1)",
             }
@@ -1775,14 +1815,24 @@ class TiltSeries(ConfiguredBaseModel):
             }
         },
     )
-    spherical_aberration_constant: Optional[Union[float, str]] = Field(
-        None,
+    spherical_aberration_constant: Union[float, str] = Field(
+        ...,
         description="""Spherical Aberration Constant of the objective lens in millimeters""",
         ge=0,
         json_schema_extra={
             "linkml_meta": {
                 "alias": "spherical_aberration_constant",
-                "any_of": [{"minimum_value": 0, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Spherical Aberration Constant of the objective " "lens in millimeters",
+                        "exact_mappings": ["cdp-common:tiltseries_spherical_aberration_constant"],
+                        "minimum_value": 0,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "millimeters", "symbol": "mm"},
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["TiltSeries"],
                 "unit": {"descriptive_name": "millimeters", "symbol": "mm"},
             }
@@ -1799,8 +1849,8 @@ class TiltSeries(ConfiguredBaseModel):
             }
         },
     )
-    tilt_axis: Optional[Union[float, str]] = Field(
-        None,
+    tilt_axis: Union[float, str] = Field(
+        ...,
         description="""Rotation angle in degrees""",
         ge=-360,
         le=360,
@@ -1808,7 +1858,15 @@ class TiltSeries(ConfiguredBaseModel):
             "linkml_meta": {
                 "alias": "tilt_axis",
                 "any_of": [
-                    {"maximum_value": 360, "minimum_value": -360, "range": "float"},
+                    {
+                        "description": "Rotation angle in degrees",
+                        "exact_mappings": ["cdp-common:tiltseries_tilt_axis"],
+                        "maximum_value": 360,
+                        "minimum_value": -360,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "degrees", "symbol": "°"},
+                    },
                     {"range": "FloatFormattedString"},
                 ],
                 "domain_of": ["TiltSeries"],
@@ -1821,8 +1879,8 @@ class TiltSeries(ConfiguredBaseModel):
         description="""The range of tilt angles in the tilt series.""",
         json_schema_extra={"linkml_meta": {"alias": "tilt_range", "domain_of": ["TiltSeries"]}},
     )
-    tilt_series_quality: Optional[Union[int, str]] = Field(
-        None,
+    tilt_series_quality: Union[int, str] = Field(
+        ...,
         description="""Author assessment of tilt series quality within the dataset (1-5, 5 is best)""",
         ge=1,
         le=5,
@@ -1830,15 +1888,23 @@ class TiltSeries(ConfiguredBaseModel):
             "linkml_meta": {
                 "alias": "tilt_series_quality",
                 "any_of": [
-                    {"maximum_value": 5, "minimum_value": 1, "range": "integer"},
+                    {
+                        "description": "Author assessment of tilt series quality within "
+                        "the dataset (1-5, 5 is best)",
+                        "exact_mappings": ["cdp-common:tiltseries_tilt_series_quality"],
+                        "maximum_value": 5,
+                        "minimum_value": 1,
+                        "range": "integer",
+                        "required": True,
+                    },
                     {"range": "IntegerFormattedString"},
                 ],
                 "domain_of": ["TiltSeries"],
             }
         },
     )
-    tilt_step: Optional[Union[float, str]] = Field(
-        None,
+    tilt_step: Union[float, str] = Field(
+        ...,
         description="""Tilt step in degrees""",
         ge=0,
         le=90,
@@ -1846,7 +1912,15 @@ class TiltSeries(ConfiguredBaseModel):
             "linkml_meta": {
                 "alias": "tilt_step",
                 "any_of": [
-                    {"maximum_value": 90, "minimum_value": 0, "range": "float"},
+                    {
+                        "description": "Tilt step in degrees",
+                        "exact_mappings": ["cdp-common:tiltseries_tilt_step"],
+                        "maximum_value": 90,
+                        "minimum_value": 0,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "degrees", "symbol": "°"},
+                    },
                     {"range": "FloatFormattedString"},
                 ],
                 "domain_of": ["TiltSeries"],
@@ -1865,27 +1939,48 @@ class TiltSeries(ConfiguredBaseModel):
             }
         },
     )
-    total_flux: Optional[Union[float, str]] = Field(
-        None,
+    total_flux: Union[float, str] = Field(
+        ...,
         description="""Number of Electrons reaching the specimen in a square Angstrom area for the entire tilt series""",
         ge=0,
         json_schema_extra={
             "linkml_meta": {
                 "alias": "total_flux",
-                "any_of": [{"minimum_value": 0, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Number of Electrons reaching the specimen in a "
+                        "square Angstrom area for the entire tilt series",
+                        "exact_mappings": ["cdp-common:tiltseries_total_flux"],
+                        "minimum_value": 0,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "electrons per square Angstrom", "symbol": "e^-/Å^2"},
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["TiltSeries"],
                 "unit": {"descriptive_name": "electrons per square Angstrom", "symbol": "e^-/Å^2"},
             }
         },
     )
-    pixel_spacing: Optional[Union[float, str]] = Field(
-        None,
+    pixel_spacing: Union[float, str] = Field(
+        ...,
         description="""Pixel spacing for the tilt series""",
         ge=0.001,
         json_schema_extra={
             "linkml_meta": {
                 "alias": "pixel_spacing",
-                "any_of": [{"minimum_value": 0.001, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Pixel spacing for the tilt series",
+                        "exact_mappings": ["cdp-common:tiltseries_pixel_spacing"],
+                        "minimum_value": 0.001,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "Angstroms per pixel", "symbol": "Å/px"},
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["TiltSeries"],
                 "unit": {"descriptive_name": "Angstroms per pixel", "symbol": "Å/px"},
             }
@@ -2095,26 +2190,44 @@ class Tomogram(AuthoredEntity):
 
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata", "mixins": ["AuthoredEntity"]})
 
-    voxel_spacing: Optional[Union[float, str]] = Field(
-        None,
+    voxel_spacing: Union[float, str] = Field(
+        ...,
         description="""Voxel spacing equal in all three axes in angstroms""",
         ge=0.001,
         json_schema_extra={
             "linkml_meta": {
                 "alias": "voxel_spacing",
-                "any_of": [{"minimum_value": 0.001, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Voxel spacing equal in all three axes in " "angstroms",
+                        "exact_mappings": ["cdp-common:tomogram_voxel_spacing"],
+                        "minimum_value": 0.001,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "Angstroms per voxel", "symbol": "Å/voxel"},
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["Tomogram"],
                 "unit": {"descriptive_name": "Angstroms per voxel", "symbol": "Å/voxel"},
             }
         },
     )
-    fiducial_alignment_status: Optional[Union[FiducialAlignmentStatusEnum, str]] = Field(
-        None,
+    fiducial_alignment_status: Union[FiducialAlignmentStatusEnum, str] = Field(
+        ...,
         description="""Whether the tomographic alignment was computed based on fiducial markers.""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "fiducial_alignment_status",
-                "any_of": [{"range": "fiducial_alignment_status_enum"}, {"range": "StringFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Whether the tomographic alignment was computed " "based on fiducial markers.",
+                        "exact_mappings": ["cdp-common:tomogram_fiducial_alignment_status"],
+                        "range": "fiducial_alignment_status_enum",
+                        "required": True,
+                    },
+                    {"range": "StringFormattedString"},
+                ],
                 "domain_of": ["Tomogram"],
             }
         },
@@ -2142,13 +2255,21 @@ class Tomogram(AuthoredEntity):
             }
         },
     )
-    reconstruction_method: Optional[Union[TomogromReconstructionMethodEnum, str]] = Field(
-        None,
+    reconstruction_method: Union[TomogromReconstructionMethodEnum, str] = Field(
+        ...,
         description="""Describe reconstruction method (WBP, SART, SIRT)""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "reconstruction_method",
-                "any_of": [{"range": "tomogrom_reconstruction_method_enum"}, {"range": "StringFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Describe reconstruction method (WBP, SART, SIRT)",
+                        "exact_mappings": ["cdp-common:tomogram_reconstruction_method"],
+                        "range": "tomogrom_reconstruction_method_enum",
+                        "required": True,
+                    },
+                    {"range": "StringFormattedString"},
+                ],
                 "domain_of": ["Tomogram"],
             }
         },

--- a/schema/core/v1.1.0/codegen/metadata_models.py
+++ b/schema/core/v1.1.0/codegen/metadata_models.py
@@ -2148,39 +2148,78 @@ class TomogramOffset(ConfiguredBaseModel):
 
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
-    x: int = Field(
+    x: Union[int, str] = Field(
         ...,
         description="""x offset data relative to the canonical tomogram in pixels""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "x",
+                "any_of": [{"range": "integer"}, {"range": "IntegerFormattedString"}],
                 "domain_of": ["TomogramSize", "TomogramOffset"],
                 "unit": {"descriptive_name": "pixels", "symbol": "px"},
             }
         },
     )
-    y: int = Field(
+    y: Union[int, str] = Field(
         ...,
         description="""y offset data relative to the canonical tomogram in pixels""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "y",
+                "any_of": [{"range": "integer"}, {"range": "IntegerFormattedString"}],
                 "domain_of": ["TomogramSize", "TomogramOffset"],
                 "unit": {"descriptive_name": "pixels", "symbol": "px"},
             }
         },
     )
-    z: int = Field(
+    z: Union[int, str] = Field(
         ...,
         description="""z offset data relative to the canonical tomogram in pixels""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "z",
+                "any_of": [{"range": "integer"}, {"range": "IntegerFormattedString"}],
                 "domain_of": ["TomogramSize", "TomogramOffset"],
                 "unit": {"descriptive_name": "pixels", "symbol": "px"},
             }
         },
     )
+
+    @field_validator("x")
+    def pattern_x(cls, v):
+        pattern = re.compile(r"^int[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$")
+        if isinstance(v, list):
+            for element in v:
+                if not pattern.match(element):
+                    raise ValueError(f"Invalid x format: {element}")
+        elif isinstance(v, str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid x format: {v}")
+        return v
+
+    @field_validator("y")
+    def pattern_y(cls, v):
+        pattern = re.compile(r"^int[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$")
+        if isinstance(v, list):
+            for element in v:
+                if not pattern.match(element):
+                    raise ValueError(f"Invalid y format: {element}")
+        elif isinstance(v, str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid y format: {v}")
+        return v
+
+    @field_validator("z")
+    def pattern_z(cls, v):
+        pattern = re.compile(r"^int[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$")
+        if isinstance(v, list):
+            for element in v:
+                if not pattern.match(element):
+                    raise ValueError(f"Invalid z format: {element}")
+        elif isinstance(v, str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid z format: {v}")
+        return v
 
 
 class Tomogram(AuthoredEntity):

--- a/schema/core/v1.1.0/metadata.yaml
+++ b/schema/core/v1.1.0/metadata.yaml
@@ -284,7 +284,7 @@ classes:
           - cdp-common:tiltseries_microscope_additional_info
       manufacturer:
         any_of:
-          - range: cdp-common:tiltseries_microscope_manufacturer
+          - exact_mappings: cdp-common:tiltseries_microscope_manufacturer
           - range: cdp-common:StringFormattedString
       model:
         exact_mappings:
@@ -308,11 +308,11 @@ classes:
     attributes:
       min:
         any_of:
-          - range: cdp-common:tiltseries_tilt_min
+          - exact_mappings: cdp-common:tiltseries_tilt_min
           - range: cdp-common:FloatFormattedString
       max:
         any_of:
-          - range: cdp-common:tiltseries_tilt_max
+          - exact_mappings: cdp-common:tiltseries_tilt_max
           - range: cdp-common:FloatFormattedString
   # ============================================================================
 
@@ -328,12 +328,12 @@ classes:
           - cdp-common:tiltseries_acceleration_voltage
       aligned_tiltseries_binning:
         any_of:
-          - range: cdp-common:tiltseries_aligned_tiltseries_binning
+          - exact_mappings: cdp-common:tiltseries_aligned_tiltseries_binning
           - range: cdp-common:FloatFormattedString
         ifabsent: 'float(1)'
       binning_from_frames:
         any_of:
-          - range: cdp-common:tiltseries_binning_from_frames
+          - exact_mappings: cdp-common:tiltseries_binning_from_frames
           - range: cdp-common:FloatFormattedString
         ifabsent: 'float(1)'
       camera:
@@ -362,14 +362,14 @@ classes:
           - cdp-common:tiltseries_related_empiar_entry
       spherical_aberration_constant:
         any_of:
-          - range: cdp-common:tiltseries_spherical_aberration_constant
+          - exact_mappings: cdp-common:tiltseries_spherical_aberration_constant
           - range: cdp-common:FloatFormattedString
       tilt_alignment_software:
         exact_mappings:
           - cdp-common:tiltseries_tilt_alignment_software
       tilt_axis:
         any_of:
-          - range: cdp-common:tiltseries_tilt_axis
+          - exact_mappings: cdp-common:tiltseries_tilt_axis
           - range: cdp-common:FloatFormattedString
       tilt_range:
         description: *desc_tilt_range
@@ -377,22 +377,22 @@ classes:
         required: true
       tilt_series_quality:
         any_of:
-          - range: cdp-common:tiltseries_tilt_series_quality
+          - exact_mappings: cdp-common:tiltseries_tilt_series_quality
           - range: cdp-common:IntegerFormattedString
       tilt_step:
         any_of:
-          - range: cdp-common:tiltseries_tilt_step
+          - exact_mappings: cdp-common:tiltseries_tilt_step
           - range: cdp-common:FloatFormattedString
       tilting_scheme:
         exact_mappings:
           - cdp-common:tiltseries_tilting_scheme
       total_flux:
         any_of:
-          - range: cdp-common:tiltseries_total_flux
+          - exact_mappings: cdp-common:tiltseries_total_flux
           - range: cdp-common:FloatFormattedString
       pixel_spacing:
         any_of:
-          - range: cdp-common:tiltseries_pixel_spacing
+          - exact_mappings: cdp-common:tiltseries_pixel_spacing
           - range: cdp-common:FloatFormattedString
   # ============================================================================
 
@@ -489,11 +489,11 @@ classes:
     attributes:
       voxel_spacing:
         any_of:
-          - range: cdp-common:tomogram_voxel_spacing
+          - exact_mappings: cdp-common:tomogram_voxel_spacing
           - range: cdp-common:FloatFormattedString
       fiducial_alignment_status:
         any_of:
-          - range: cdp-common:tomogram_fiducial_alignment_status
+          - exact_mappings: cdp-common:tomogram_fiducial_alignment_status
           - range: cdp-common:StringFormattedString
       ctf_corrected:
         exact_mappings:
@@ -503,7 +503,7 @@ classes:
           - cdp-common:tomogram_align_software
       reconstruction_method:
         any_of:
-          - range: cdp-common:tomogram_reconstruction_method
+          - exact_mappings: cdp-common:tomogram_reconstruction_method
           - range: cdp-common:StringFormattedString
       reconstruction_software:
         exact_mappings:

--- a/schema/core/v1.1.0/metadata.yaml
+++ b/schema/core/v1.1.0/metadata.yaml
@@ -443,33 +443,27 @@ classes:
     description: &desc_tomogram_offset The offset of a tomogram in voxels in each dimension relative to the canonical tomogram.
     attributes:
       x:
-        range: integer
-        # TODO: uncomment after any_of is fixed https://github.com/linkml/linkml/issues/1521
-        # any_of:
-        #   - range: integer
-        #   - range: IntegerFormattedString
+        any_of:
+          - range: integer
+          - range: cdp-common:IntegerFormattedString
         required: true
         description: x offset data relative to the canonical tomogram in pixels
         unit:
           descriptive_name: pixels
           symbol: px
       y:
-        range: integer
-        # TODO: uncomment after any_of is fixed https://github.com/linkml/linkml/issues/1521
-        # any_of:
-        #   - range: integer
-        #   - range: IntegerFormattedString
+        any_of:
+          - range: integer
+          - range: cdp-common:IntegerFormattedString
         required: true
         description: y offset data relative to the canonical tomogram in pixels
         unit:
           descriptive_name: pixels
           symbol: px
       z:
-        range: integer
-        # TODO: uncomment after any_of is fixed https://github.com/linkml/linkml/issues/1521
-        # any_of:
-        #   - range: integer
-        #   - range: IntegerFormattedString
+        any_of:
+          - range: integer
+          - range: cdp-common:IntegerFormattedString
         required: true
         description: z offset data relative to the canonical tomogram in pixels
         unit:

--- a/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.py
+++ b/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.py
@@ -1492,7 +1492,7 @@ class CameraDetails(ConfiguredBaseModel):
 
     @field_validator("acquire_mode")
     def pattern_acquire_mode(cls, v):
-        pattern = re.compile(r"(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)|(^counting$)|(^superresolution$)|(^linear$)|(^cds$)")
+        pattern = re.compile(r"(^[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$)|((^counting$)|(^superresolution$)|(^linear$)|(^cds$))")
         if isinstance(v, list):
             for element in v:
                 if not pattern.match(element):
@@ -1521,13 +1521,21 @@ class MicroscopeDetails(ConfiguredBaseModel):
             }
         },
     )
-    manufacturer: Optional[Union[TiltseriesMicroscopeManufacturerEnum, str]] = Field(
-        None,
+    manufacturer: Union[TiltseriesMicroscopeManufacturerEnum, str] = Field(
+        ...,
         description="""Name of the microscope manufacturer""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "manufacturer",
-                "any_of": [{"range": "tiltseries_microscope_manufacturer_enum"}, {"range": "StringFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Name of the microscope manufacturer",
+                        "exact_mappings": ["cdp-common:tiltseries_microscope_manufacturer"],
+                        "range": "tiltseries_microscope_manufacturer_enum",
+                        "required": True,
+                    },
+                    {"range": "StringFormattedString"},
+                ],
                 "domain_of": ["CameraDetails", "MicroscopeDetails"],
             }
         },
@@ -1606,8 +1614,8 @@ class TiltRange(ConfiguredBaseModel):
 
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
-    min: Optional[Union[float, str]] = Field(
-        None,
+    min: Union[float, str] = Field(
+        ...,
         description="""Minimal tilt angle in degrees""",
         ge=-90,
         le=90,
@@ -1615,7 +1623,15 @@ class TiltRange(ConfiguredBaseModel):
             "linkml_meta": {
                 "alias": "min",
                 "any_of": [
-                    {"maximum_value": 90, "minimum_value": -90, "range": "float"},
+                    {
+                        "description": "Minimal tilt angle in degrees",
+                        "exact_mappings": ["cdp-common:tiltseries_tilt_min"],
+                        "maximum_value": 90,
+                        "minimum_value": -90,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "degrees", "symbol": "°"},
+                    },
                     {"range": "FloatFormattedString"},
                 ],
                 "domain_of": ["TiltRange"],
@@ -1623,8 +1639,8 @@ class TiltRange(ConfiguredBaseModel):
             }
         },
     )
-    max: Optional[Union[float, str]] = Field(
-        None,
+    max: Union[float, str] = Field(
+        ...,
         description="""Maximal tilt angle in degrees""",
         ge=-90,
         le=90,
@@ -1632,7 +1648,15 @@ class TiltRange(ConfiguredBaseModel):
             "linkml_meta": {
                 "alias": "max",
                 "any_of": [
-                    {"maximum_value": 90, "minimum_value": -90, "range": "float"},
+                    {
+                        "description": "Maximal tilt angle in degrees",
+                        "exact_mappings": ["cdp-common:tiltseries_tilt_max"],
+                        "maximum_value": 90,
+                        "minimum_value": -90,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "degrees", "symbol": "°"},
+                    },
                     {"range": "FloatFormattedString"},
                 ],
                 "domain_of": ["TiltRange"],
@@ -1693,7 +1717,15 @@ class TiltSeries(ConfiguredBaseModel):
         json_schema_extra={
             "linkml_meta": {
                 "alias": "aligned_tiltseries_binning",
-                "any_of": [{"minimum_value": 0, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Binning factor of the aligned tilt series",
+                        "exact_mappings": ["cdp-common:tiltseries_aligned_tiltseries_binning"],
+                        "minimum_value": 0,
+                        "range": "float",
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["TiltSeries"],
                 "ifabsent": "float(1)",
             }
@@ -1706,7 +1738,15 @@ class TiltSeries(ConfiguredBaseModel):
         json_schema_extra={
             "linkml_meta": {
                 "alias": "binning_from_frames",
-                "any_of": [{"minimum_value": 0, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Describes the binning factor from frames to tilt " "series file",
+                        "exact_mappings": ["cdp-common:tiltseries_binning_from_frames"],
+                        "minimum_value": 0,
+                        "range": "float",
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["TiltSeries"],
                 "ifabsent": "float(1)",
             }
@@ -1771,14 +1811,24 @@ class TiltSeries(ConfiguredBaseModel):
             }
         },
     )
-    spherical_aberration_constant: Optional[Union[float, str]] = Field(
-        None,
+    spherical_aberration_constant: Union[float, str] = Field(
+        ...,
         description="""Spherical Aberration Constant of the objective lens in millimeters""",
         ge=0,
         json_schema_extra={
             "linkml_meta": {
                 "alias": "spherical_aberration_constant",
-                "any_of": [{"minimum_value": 0, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Spherical Aberration Constant of the objective " "lens in millimeters",
+                        "exact_mappings": ["cdp-common:tiltseries_spherical_aberration_constant"],
+                        "minimum_value": 0,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "millimeters", "symbol": "mm"},
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["TiltSeries"],
                 "unit": {"descriptive_name": "millimeters", "symbol": "mm"},
             }
@@ -1795,8 +1845,8 @@ class TiltSeries(ConfiguredBaseModel):
             }
         },
     )
-    tilt_axis: Optional[Union[float, str]] = Field(
-        None,
+    tilt_axis: Union[float, str] = Field(
+        ...,
         description="""Rotation angle in degrees""",
         ge=-360,
         le=360,
@@ -1804,7 +1854,15 @@ class TiltSeries(ConfiguredBaseModel):
             "linkml_meta": {
                 "alias": "tilt_axis",
                 "any_of": [
-                    {"maximum_value": 360, "minimum_value": -360, "range": "float"},
+                    {
+                        "description": "Rotation angle in degrees",
+                        "exact_mappings": ["cdp-common:tiltseries_tilt_axis"],
+                        "maximum_value": 360,
+                        "minimum_value": -360,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "degrees", "symbol": "°"},
+                    },
                     {"range": "FloatFormattedString"},
                 ],
                 "domain_of": ["TiltSeries"],
@@ -1817,8 +1875,8 @@ class TiltSeries(ConfiguredBaseModel):
         description="""The range of tilt angles in the tilt series.""",
         json_schema_extra={"linkml_meta": {"alias": "tilt_range", "domain_of": ["TiltSeries"]}},
     )
-    tilt_series_quality: Optional[Union[int, str]] = Field(
-        None,
+    tilt_series_quality: Union[int, str] = Field(
+        ...,
         description="""Author assessment of tilt series quality within the dataset (1-5, 5 is best)""",
         ge=1,
         le=5,
@@ -1826,15 +1884,23 @@ class TiltSeries(ConfiguredBaseModel):
             "linkml_meta": {
                 "alias": "tilt_series_quality",
                 "any_of": [
-                    {"maximum_value": 5, "minimum_value": 1, "range": "integer"},
+                    {
+                        "description": "Author assessment of tilt series quality within "
+                        "the dataset (1-5, 5 is best)",
+                        "exact_mappings": ["cdp-common:tiltseries_tilt_series_quality"],
+                        "maximum_value": 5,
+                        "minimum_value": 1,
+                        "range": "integer",
+                        "required": True,
+                    },
                     {"range": "IntegerFormattedString"},
                 ],
                 "domain_of": ["TiltSeries"],
             }
         },
     )
-    tilt_step: Optional[Union[float, str]] = Field(
-        None,
+    tilt_step: Union[float, str] = Field(
+        ...,
         description="""Tilt step in degrees""",
         ge=0,
         le=90,
@@ -1842,7 +1908,15 @@ class TiltSeries(ConfiguredBaseModel):
             "linkml_meta": {
                 "alias": "tilt_step",
                 "any_of": [
-                    {"maximum_value": 90, "minimum_value": 0, "range": "float"},
+                    {
+                        "description": "Tilt step in degrees",
+                        "exact_mappings": ["cdp-common:tiltseries_tilt_step"],
+                        "maximum_value": 90,
+                        "minimum_value": 0,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "degrees", "symbol": "°"},
+                    },
                     {"range": "FloatFormattedString"},
                 ],
                 "domain_of": ["TiltSeries"],
@@ -1861,27 +1935,48 @@ class TiltSeries(ConfiguredBaseModel):
             }
         },
     )
-    total_flux: Optional[Union[float, str]] = Field(
-        None,
+    total_flux: Union[float, str] = Field(
+        ...,
         description="""Number of Electrons reaching the specimen in a square Angstrom area for the entire tilt series""",
         ge=0,
         json_schema_extra={
             "linkml_meta": {
                 "alias": "total_flux",
-                "any_of": [{"minimum_value": 0, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Number of Electrons reaching the specimen in a "
+                        "square Angstrom area for the entire tilt series",
+                        "exact_mappings": ["cdp-common:tiltseries_total_flux"],
+                        "minimum_value": 0,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "electrons per square Angstrom", "symbol": "e^-/Å^2"},
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["TiltSeries"],
                 "unit": {"descriptive_name": "electrons per square Angstrom", "symbol": "e^-/Å^2"},
             }
         },
     )
-    pixel_spacing: Optional[Union[float, str]] = Field(
-        None,
+    pixel_spacing: Union[float, str] = Field(
+        ...,
         description="""Pixel spacing for the tilt series""",
         ge=0.001,
         json_schema_extra={
             "linkml_meta": {
                 "alias": "pixel_spacing",
-                "any_of": [{"minimum_value": 0.001, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Pixel spacing for the tilt series",
+                        "exact_mappings": ["cdp-common:tiltseries_pixel_spacing"],
+                        "minimum_value": 0.001,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "Angstroms per pixel", "symbol": "Å/px"},
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["TiltSeries"],
                 "unit": {"descriptive_name": "Angstroms per pixel", "symbol": "Å/px"},
             }
@@ -2091,26 +2186,44 @@ class Tomogram(AuthoredEntity):
 
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata", "mixins": ["AuthoredEntity"]})
 
-    voxel_spacing: Optional[Union[float, str]] = Field(
-        None,
+    voxel_spacing: Union[float, str] = Field(
+        ...,
         description="""Voxel spacing equal in all three axes in angstroms""",
         ge=0.001,
         json_schema_extra={
             "linkml_meta": {
                 "alias": "voxel_spacing",
-                "any_of": [{"minimum_value": 0.001, "range": "float"}, {"range": "FloatFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Voxel spacing equal in all three axes in " "angstroms",
+                        "exact_mappings": ["cdp-common:tomogram_voxel_spacing"],
+                        "minimum_value": 0.001,
+                        "range": "float",
+                        "required": True,
+                        "unit": {"descriptive_name": "Angstroms per voxel", "symbol": "Å/voxel"},
+                    },
+                    {"range": "FloatFormattedString"},
+                ],
                 "domain_of": ["Tomogram", "AnnotationParent", "KeyImageParent", "TomogramParent"],
                 "unit": {"descriptive_name": "Angstroms per voxel", "symbol": "Å/voxel"},
             }
         },
     )
-    fiducial_alignment_status: Optional[Union[FiducialAlignmentStatusEnum, str]] = Field(
-        None,
+    fiducial_alignment_status: Union[FiducialAlignmentStatusEnum, str] = Field(
+        ...,
         description="""Whether the tomographic alignment was computed based on fiducial markers.""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "fiducial_alignment_status",
-                "any_of": [{"range": "fiducial_alignment_status_enum"}, {"range": "StringFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Whether the tomographic alignment was computed " "based on fiducial markers.",
+                        "exact_mappings": ["cdp-common:tomogram_fiducial_alignment_status"],
+                        "range": "fiducial_alignment_status_enum",
+                        "required": True,
+                    },
+                    {"range": "StringFormattedString"},
+                ],
                 "domain_of": ["Tomogram"],
             }
         },
@@ -2138,13 +2251,21 @@ class Tomogram(AuthoredEntity):
             }
         },
     )
-    reconstruction_method: Optional[Union[TomogromReconstructionMethodEnum, str]] = Field(
-        None,
+    reconstruction_method: Union[TomogromReconstructionMethodEnum, str] = Field(
+        ...,
         description="""Describe reconstruction method (WBP, SART, SIRT)""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "reconstruction_method",
-                "any_of": [{"range": "tomogrom_reconstruction_method_enum"}, {"range": "StringFormattedString"}],
+                "any_of": [
+                    {
+                        "description": "Describe reconstruction method (WBP, SART, SIRT)",
+                        "exact_mappings": ["cdp-common:tomogram_reconstruction_method"],
+                        "range": "tomogrom_reconstruction_method_enum",
+                        "required": True,
+                    },
+                    {"range": "StringFormattedString"},
+                ],
                 "domain_of": ["Tomogram"],
             }
         },

--- a/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.py
+++ b/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.py
@@ -2144,39 +2144,78 @@ class TomogramOffset(ConfiguredBaseModel):
 
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
 
-    x: int = Field(
+    x: Union[int, str] = Field(
         ...,
         description="""x offset data relative to the canonical tomogram in pixels""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "x",
+                "any_of": [{"range": "integer"}, {"range": "IntegerFormattedString"}],
                 "domain_of": ["TomogramSize", "TomogramOffset"],
                 "unit": {"descriptive_name": "pixels", "symbol": "px"},
             }
         },
     )
-    y: int = Field(
+    y: Union[int, str] = Field(
         ...,
         description="""y offset data relative to the canonical tomogram in pixels""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "y",
+                "any_of": [{"range": "integer"}, {"range": "IntegerFormattedString"}],
                 "domain_of": ["TomogramSize", "TomogramOffset"],
                 "unit": {"descriptive_name": "pixels", "symbol": "px"},
             }
         },
     )
-    z: int = Field(
+    z: Union[int, str] = Field(
         ...,
         description="""z offset data relative to the canonical tomogram in pixels""",
         json_schema_extra={
             "linkml_meta": {
                 "alias": "z",
+                "any_of": [{"range": "integer"}, {"range": "IntegerFormattedString"}],
                 "domain_of": ["TomogramSize", "TomogramOffset"],
                 "unit": {"descriptive_name": "pixels", "symbol": "px"},
             }
         },
     )
+
+    @field_validator("x")
+    def pattern_x(cls, v):
+        pattern = re.compile(r"^int[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$")
+        if isinstance(v, list):
+            for element in v:
+                if not pattern.match(element):
+                    raise ValueError(f"Invalid x format: {element}")
+        elif isinstance(v, str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid x format: {v}")
+        return v
+
+    @field_validator("y")
+    def pattern_y(cls, v):
+        pattern = re.compile(r"^int[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$")
+        if isinstance(v, list):
+            for element in v:
+                if not pattern.match(element):
+                    raise ValueError(f"Invalid y format: {element}")
+        elif isinstance(v, str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid y format: {v}")
+        return v
+
+    @field_validator("z")
+    def pattern_z(cls, v):
+        pattern = re.compile(r"^int[ ]*\{[a-zA-Z0-9_-]+\}[ ]*$")
+        if isinstance(v, list):
+            for element in v:
+                if not pattern.match(element):
+                    raise ValueError(f"Invalid z format: {element}")
+        elif isinstance(v, str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid z format: {v}")
+        return v
 
 
 class Tomogram(AuthoredEntity):

--- a/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.schema.json
+++ b/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.schema.json
@@ -831,7 +831,7 @@
                         }
                     ],
                     "description": "Camera acquisition mode",
-                    "pattern": "(^[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$)|(^counting$)|(^superresolution$)|(^linear$)|(^cds$)"
+                    "pattern": "(^[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$)|((^counting$)|(^superresolution$)|(^linear$)|(^cds$))"
                 },
                 "manufacturer": {
                     "description": "Name of the camera manufacturer",
@@ -2524,16 +2524,15 @@
                     ]
                 },
                 "manufacturer": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
-                            "$ref": "#/$defs/TiltseriesMicroscopeManufacturerEnum"
+                            "$ref": "#/$defs/TiltseriesMicroscopeManufacturerEnum",
+                            "description": "Name of the microscope manufacturer"
                         },
                         {
                             "pattern": "^[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Name of the microscope manufacturer",
@@ -2545,6 +2544,7 @@
                 }
             },
             "required": [
+                "manufacturer",
                 "model"
             ],
             "title": "MicroscopeDetails",
@@ -3047,8 +3047,10 @@
             "description": "The range of tilt angles in the tilt series.",
             "properties": {
                 "max": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
+                            "description": "Maximal tilt angle in degrees",
                             "maximum": 90,
                             "minimum": -90,
                             "type": "number"
@@ -3056,9 +3058,6 @@
                         {
                             "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Maximal tilt angle in degrees",
@@ -3067,8 +3066,10 @@
                     "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "min": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
+                            "description": "Minimal tilt angle in degrees",
                             "maximum": 90,
                             "minimum": -90,
                             "type": "number"
@@ -3076,9 +3077,6 @@
                         {
                             "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Minimal tilt angle in degrees",
@@ -3087,6 +3085,10 @@
                     "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 }
             },
+            "required": [
+                "min",
+                "max"
+            ],
             "title": "TiltRange",
             "type": "object"
         },
@@ -3102,6 +3104,7 @@
                 "aligned_tiltseries_binning": {
                     "anyOf": [
                         {
+                            "description": "Binning factor of the aligned tilt series",
                             "minimum": 0,
                             "type": "number"
                         },
@@ -3120,6 +3123,7 @@
                 "binning_from_frames": {
                     "anyOf": [
                         {
+                            "description": "Describes the binning factor from frames to tilt series file",
                             "minimum": 0,
                             "type": "number"
                         },
@@ -3163,17 +3167,16 @@
                     "description": "The optical setup of the microscope used to collect the tilt series."
                 },
                 "pixel_spacing": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
+                            "description": "Pixel spacing for the tilt series",
                             "minimum": 0.001,
                             "type": "number"
                         },
                         {
                             "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Pixel spacing for the tilt series",
@@ -3189,17 +3192,16 @@
                     ]
                 },
                 "spherical_aberration_constant": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
+                            "description": "Spherical Aberration Constant of the objective lens in millimeters",
                             "minimum": 0,
                             "type": "number"
                         },
                         {
                             "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Spherical Aberration Constant of the objective lens in millimeters",
@@ -3214,8 +3216,10 @@
                     ]
                 },
                 "tilt_axis": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
+                            "description": "Rotation angle in degrees",
                             "maximum": 360,
                             "minimum": -360,
                             "type": "number"
@@ -3223,9 +3227,6 @@
                         {
                             "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Rotation angle in degrees",
@@ -3238,8 +3239,10 @@
                     "description": "The range of tilt angles in the tilt series."
                 },
                 "tilt_series_quality": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
+                            "description": "Author assessment of tilt series quality within the dataset (1-5, 5 is best)",
                             "maximum": 5,
                             "minimum": 1,
                             "type": "integer"
@@ -3247,9 +3250,6 @@
                         {
                             "pattern": "^int[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Author assessment of tilt series quality within the dataset (1-5, 5 is best)",
@@ -3258,8 +3258,10 @@
                     "pattern": "^int[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "tilt_step": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
+                            "description": "Tilt step in degrees",
                             "maximum": 90,
                             "minimum": 0,
                             "type": "number"
@@ -3267,9 +3269,6 @@
                         {
                             "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Tilt step in degrees",
@@ -3282,17 +3281,16 @@
                     "type": "string"
                 },
                 "total_flux": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
+                            "description": "Number of Electrons reaching the specimen in a square Angstrom area for the entire tilt series",
                             "minimum": 0,
                             "type": "number"
                         },
                         {
                             "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Number of Electrons reaching the specimen in a square Angstrom area for the entire tilt series",
@@ -3307,8 +3305,14 @@
                 "is_aligned",
                 "microscope",
                 "microscope_optical_setup",
+                "spherical_aberration_constant",
+                "tilt_axis",
                 "tilt_range",
-                "tilting_scheme"
+                "tilt_series_quality",
+                "tilt_step",
+                "tilting_scheme",
+                "total_flux",
+                "pixel_spacing"
             ],
             "title": "TiltSeries",
             "type": "object"
@@ -3562,16 +3566,15 @@
                     ]
                 },
                 "fiducial_alignment_status": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
-                            "$ref": "#/$defs/FiducialAlignmentStatusEnum"
+                            "$ref": "#/$defs/FiducialAlignmentStatusEnum",
+                            "description": "Whether the tomographic alignment was computed based on fiducial markers."
                         },
                         {
                             "pattern": "^[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Whether the tomographic alignment was computed based on fiducial markers.",
@@ -3594,16 +3597,15 @@
                     ]
                 },
                 "reconstruction_method": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
-                            "$ref": "#/$defs/TomogromReconstructionMethodEnum"
+                            "$ref": "#/$defs/TomogromReconstructionMethodEnum",
+                            "description": "Describe reconstruction method (WBP, SART, SIRT)"
                         },
                         {
                             "pattern": "^[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Describe reconstruction method (WBP, SART, SIRT)",
@@ -3630,17 +3632,16 @@
                     "type": "number"
                 },
                 "voxel_spacing": {
+                    "$ref": "#/$defs/Any",
                     "anyOf": [
                         {
+                            "description": "Voxel spacing equal in all three axes in angstroms",
                             "minimum": 0.001,
                             "type": "number"
                         },
                         {
                             "pattern": "^float[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
                             "type": "string"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Voxel spacing equal in all three axes in angstroms",
@@ -3649,6 +3650,9 @@
                 }
             },
             "required": [
+                "voxel_spacing",
+                "fiducial_alignment_status",
+                "reconstruction_method",
                 "reconstruction_software",
                 "processing",
                 "tomogram_version",

--- a/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.schema.json
+++ b/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.schema.json
@@ -3726,16 +3726,46 @@
             "description": "The offset of a tomogram in voxels in each dimension relative to the canonical tomogram.",
             "properties": {
                 "x": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "pattern": "^int[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
+                            "type": "string"
+                        }
+                    ],
                     "description": "x offset data relative to the canonical tomogram in pixels",
-                    "type": "integer"
+                    "pattern": "^int[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "y": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "pattern": "^int[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
+                            "type": "string"
+                        }
+                    ],
                     "description": "y offset data relative to the canonical tomogram in pixels",
-                    "type": "integer"
+                    "pattern": "^int[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 },
                 "z": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "pattern": "^int[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$",
+                            "type": "string"
+                        }
+                    ],
                     "description": "z offset data relative to the canonical tomogram in pixels",
-                    "type": "integer"
+                    "pattern": "^int[ ]*\\{[a-zA-Z0-9_-]+\\}[ ]*$"
                 }
             },
             "required": [

--- a/schema/ingestion_config/v1.0.0/ingestion_config_models.yaml
+++ b/schema/ingestion_config/v1.0.0/ingestion_config_models.yaml
@@ -690,12 +690,12 @@ classes:
         multivalued: true
         required: true
         range: float
-        any_of:
-          # TODO: uncomment after this is fixed https://github.com/linkml/linkml/pull/2273
-          # - range: float
-          #   # TODO: uncomment after any_of is fixed https://github.com/linkml/linkml/issues/1521
-          #   # minimum_value: 0.0
-          # - range: FloatFormattedString
+        # TODO: uncomment after this is fixed https://github.com/linkml/linkml/pull/2273
+        # any_of:
+        #   - range: float
+        #     # TODO: uncomment after any_of is fixed https://github.com/linkml/linkml/issues/1521
+        #     # minimum_value: 0.0
+        #   - range: FloatFormattedString
 
   TomogramHeader:
     description: A tomogram header, a unique source attribute for voxel spacing.

--- a/schema/ingestion_config/v1.0.0/ingestion_config_models.yaml
+++ b/schema/ingestion_config/v1.0.0/ingestion_config_models.yaml
@@ -688,12 +688,14 @@ classes:
       value:
         description: The value for the voxel spacing literal.
         multivalued: true
-        range: float
         required: true
-        # TODO: uncomment after any_of is fixed https://github.com/linkml/linkml/issues/1521
-        # any_of:
-        #   - range: float
-        #   - range: FloatFormattedString
+        range: float
+        any_of:
+          # TODO: uncomment after this is fixed https://github.com/linkml/linkml/pull/2273
+          # - range: float
+          #   # TODO: uncomment after any_of is fixed https://github.com/linkml/linkml/issues/1521
+          #   # minimum_value: 0.0
+          # - range: FloatFormattedString
 
   TomogramHeader:
     description: A tomogram header, a unique source attribute for voxel spacing.


### PR DESCRIPTION
The schema.py script was quite difficult to understand with all of the messy patches to get the schema files materialized correctly. This PR cleans it up and also creates better rendered materialized file (with more of the fields / attributes properly carried over). It might be easier to read the schema.py without the diff, because there are some quite big refactors (but functionality more or less remains the same, with some non-breaking improvements).

This PR also fixes some metadata.yaml bugs and resolves some TODOs that weren't actually blocked.