### PR TITLE
chore: apply pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 24.4.0
+  rev: 24.8.0
   hooks:
   - id: black
     args:
     - --config
     - ingestion_tools/pyproject.toml
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.1
+  rev: v0.6.2
   hooks:
   - id: ruff
     # These files are codegen'd and non-compliant :'(
@@ -37,7 +37,7 @@ repos:
       #        click,
       #      ]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: check-toml
   - id: check-yaml

--- a/ingestion_tools/scripts/dataset_config_merge.py
+++ b/ingestion_tools/scripts/dataset_config_merge.py
@@ -97,6 +97,7 @@ def primitive_data_check(
         return False
 
     if keep_unique_values and original_value != new_value:
+        print(f"Warning: Data value conflict: {original_value} | {new_value}")
         return False
 
     return True

--- a/ingestion_tools/scripts/tests/s3_import/test_deposition.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_deposition.py
@@ -50,7 +50,7 @@ def test_invalid_deposition_metadata_import(
     config = create_config("tests/fixtures/depositions/deposition2.yaml")
     deposition = list(DepositionImporter.finder(config))[0]
     deposition.import_metadata()
-    assert [] == s3_fs.glob(f"{output_path}/depositions_metadata/10302/deposition_metadata.json")
+    assert s3_fs.glob(f"{output_path}/depositions_metadata/10302/deposition_metadata.json") == []
 
 
 def test_key_photo_import_http(


### PR DESCRIPTION
# Description
he pre-commit hooks are failing because some files were merge without pre-commit enabled. 

# Changes
- Apply pre-commit hooks to all files in the repository.