### PR TITLE
Rename db comment for annotation object_id 

### DIFF
--- a/api_server/migrations/cryoetdataportal/1724881704024_alter_table_public_annotations_object_id_comment/down.sql
+++ b/api_server/migrations/cryoetdataportal/1724881704024_alter_table_public_annotations_object_id_comment/down.sql
@@ -1,0 +1,1 @@
+comment on column "public"."annotations"."object_id" is E'Gene Ontology Cellular Component identifier for the annotation object';

--- a/api_server/migrations/cryoetdataportal/1724881704024_alter_table_public_annotations_object_id_comment/up.sql
+++ b/api_server/migrations/cryoetdataportal/1724881704024_alter_table_public_annotations_object_id_comment/up.sql
@@ -1,0 +1,1 @@
+comment on column "public"."annotations"."object_id" is E'Gene Ontology Cellular Component identifier or UniProtKB accession for the annotation object.';


### PR DESCRIPTION
Follows up on supporting UniProtKB (which was done here https://github.com/chanzuckerberg/cryoet-data-portal-backend/pull/213)

Question: how do I actually get the migration run? 