### PR TITLE
fix: Ensure ingestor image uses the latest cryoet-data-portal-neuroglancer main branch

### DIFF
--- a/ingestion_tools/Dockerfile
+++ b/ingestion_tools/Dockerfile
@@ -31,6 +31,7 @@ RUN python3 -m pip install --no-cache-dir poetry==$POETRY_VERSION
 COPY pyproject.toml poetry.lock ./
 RUN poetry config virtualenvs.create false
 ENV PYTHONPATH=.
+RUN poetry update cryoet-data-portal-neuroglancer
 RUN poetry install
 
 COPY . ./ingestion_tools/


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to
https://github.com/chanzuckerberg/cryoet-data-portal-neuroglancer/issues/17
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
Poetry stores the commit ID that was pulled whenever the lock file is created. We want to use the most recent version of the `cryoet-data-portal-neuroglancer` main branch, so we should explicitely update the dependency when building the image. The alternative is to hardcode a specific commit in a non-codegen'ed place (i.e. the pyproject.toml), so it's more obvious. 

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
