### PR TITLE
fix: Correct prefix for deposition sync in enqueue_runs.py

### DIFF
--- a/ingestion_tools/scripts/enqueue_runs.py
+++ b/ingestion_tools/scripts/enqueue_runs.py
@@ -483,7 +483,7 @@ def execute_sync(ctx, input_bucket, output_bucket, new_args, entities, swipe_wdl
         for entity_id, _ in entities:
             print(f"Processing {path_prefix} {entity_id}...")
 
-            name_prefix = "dep" if path_prefix == "deposition_metadata" else "ds"
+            name_prefix = "dep" if path_prefix == "depositions_metadata" else "ds"
             execution_name = f"{int(time.time())}-sync-{name_prefix}-{entity_id}"
 
             # execution name greater than 80 chars causes boto ValidationException
@@ -586,7 +586,7 @@ def sync(
             new_args,
             deposition_entities,
             swipe_wdl_key,
-            "deposition_metadata",
+            "depositions_metadata",
         )
 
 


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
Fixing a typo in the prefix for depositions metadata sync.
<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
