### PR TITLE
add extended validation check for collection metadata

### DIFF
--- a/ingestion_tools/dataset_configs/10010.yaml
+++ b/ingestion_tools/dataset_configs/10010.yaml
@@ -149,9 +149,9 @@ key_images:
       value:
       - from_tomogram
 rawtilts:
-- sources:
-  - source_multi_glob:
-      list_globs: []
+# - sources:
+#   - source_multi_glob:
+#       list_globs:
 runs:
 - sources:
   - source_glob:

--- a/schema/ingestion_config/v1.0.0/ingestion_config_models_extended.py
+++ b/schema/ingestion_config/v1.0.0/ingestion_config_models_extended.py
@@ -22,6 +22,8 @@ from codegen.ingestion_config_models import (
     CellComponent,
     CellStrain,
     CellType,
+    CollectionMetadataEntity,
+    CollectionMetadataSource,
     Container,
     CrossReferences,
     Dataset,
@@ -661,6 +663,18 @@ class ExtendedValidationAnnotationEntity(AnnotationEntity):
 
 
 # ==============================================================================
+# Collection Metadata Validation
+# ==============================================================================
+
+
+class ExtendedValidationCollectionMetadataEntity(CollectionMetadataEntity):
+    @field_validator("sources")
+    @classmethod
+    def valid_sources(cls: Self, source_list: List[CollectionMetadataSource]) -> List[CollectionMetadataSource]:
+        return validate_sources(source_list)
+
+
+# ==============================================================================
 # Dataset Key Photo Validation
 # ==============================================================================
 
@@ -974,6 +988,9 @@ class ExtendedValidationContainer(Container):
         super().__init__(**data)
 
     annotations: Optional[List[ExtendedValidationAnnotationEntity]] = Container.model_fields["annotations"]
+    collection_metadata: Optional[List[ExtendedValidationCollectionMetadataEntity]] = Container.model_fields[
+        "collection_metadata"
+    ]
     dataset_keyphotos: Optional[List[ExtendedValidationDatasetKeyPhotoEntity]] = Container.model_fields[
         "dataset_keyphotos"
     ]


### PR DESCRIPTION
The rawtilts entry for 10010.yaml was also failing (the list_globs array must have at least one element if it exists), so i just commented it out. We can also remove it, if that seems fit. 