### PR TITLE
fix: hide generated schema and poetry files in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+**/poetry.lock linguist-generated
+**/codegen/* linguist-generated


### PR DESCRIPTION

## Description
Reviewing code with lots of generated code is time consuming. To make that process easier, generated files in the schema and poetry will be hidden in the Pull request and will need to be manually expanded to view. 