### PR TITLE
fix: make sure bool comparators don't require int input.

### DIFF
--- a/apiv2/platformics/graphql_api/core/query_input_types.py
+++ b/apiv2/platformics/graphql_api/core/query_input_types.py
@@ -68,14 +68,10 @@ class EnumComparators(TypedDict, Generic[T]):
 
 @strawberry.input
 class BoolComparators(TypedDict):
-    _eq: Optional[int]
-    _neq: Optional[int]
-    _in: Optional[list[int]]
-    _nin: Optional[list[int]]
-    _gt: Optional[int]
-    _gte: Optional[int]
-    _lt: Optional[int]
-    _lte: Optional[int]
+    _eq: Optional[bool]
+    _neq: Optional[bool]
+    _in: Optional[list[bool]]
+    _nin: Optional[list[bool]]
     _is_null: Optional[bool]
 
 


### PR DESCRIPTION
The Frrontend team noticed that query filters for boolean values were erroneously requiring integer values as input. This updates the GraphQL interface to require bools as input instead. I also removed the comparisons (gt, lt) that looked irrelevant to boolean comparisons
![Screenshot 2024-09-19 at 12 51 07 PM](https://github.com/user-attachments/assets/654de136-fd7a-4e0a-9661-95bab452b8bd)
