### PR TITLE
fix: Make sure we're using DB connection pools properly.

### DIFF
--- a/apiv2/platformics/database/connect.py
+++ b/apiv2/platformics/database/connect.py
@@ -40,7 +40,7 @@ class SyncDB:
 
 
 def init_async_db(db_uri: str, **kwargs: dict[str, Any]) -> AsyncDB:
-    engine = create_async_engine(db_uri, pool_size=5, max_overflow=5, future=True, **kwargs)
+    engine = create_async_engine(db_uri, future=True, **kwargs)
     return AsyncDB(engine)
 
 

--- a/apiv2/platformics/graphql_api/core/strawberry_extensions.py
+++ b/apiv2/platformics/graphql_api/core/strawberry_extensions.py
@@ -61,27 +61,22 @@ class DependencyExtension(FieldExtension):
         except AttributeError:
             request.context = {"dependency_cache": {}}
 
-        if not request.scope.get("sberrystack"):
+        async with AsyncExitStack() as async_exit_stack:
             request.scope["sberrystack"] = AsyncExitStack()
 
-        solved_result = await deputils.solve_dependencies(
-            request=request,
-            dependant=self.dependant,
-            body={},
-            dependency_overrides_provider=request.app,
-            dependency_cache=request.context["dependency_cache"],
-            async_exit_stack=request.scope["sberrystack"],
-        )
-        (
-            solved_values,
-            _,  # solver_errors. It shouldn't be possible for it to contain
-            # anything relevant to this extension.
-            _,  # background tasks
-            _,  # the subdependency returns the same response we have
-            new_cache,  # sub_dependency_cache
-        ) = solved_result
+            solved_result = await deputils.solve_dependencies(
+                request=request,
+                dependant=self.dependant,
+                body={},
+                dependency_overrides_provider=request.app,
+                dependency_cache=request.context["dependency_cache"],
+                async_exit_stack=async_exit_stack,
+                embed_body_fields=False,
+            )
+            solved_values = solved_result.values
+            new_cache = solved_result.dependency_cache
+            request.context["dependency_cache"].update(new_cache)
 
-        request.context["dependency_cache"].update(new_cache)
-        kwargs = solved_values | kwargs  # solved_values has None values that need to be overridden by kwargs
-        res = await next_(source, info, **kwargs)
+            kwargs = solved_values | kwargs  # solved_values has None values that need to be overridden by kwargs
+            res = await next_(source, info, **kwargs)
         return res

--- a/apiv2/poetry.lock
+++ b/apiv2/poetry.lock
@@ -1116,22 +1116,23 @@ files = [
 
 [[package]]
 name = "fastapi"
-version = "0.110.3"
+version = "0.115.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fastapi-0.110.3-py3-none-any.whl", hash = "sha256:fd7600612f755e4050beb74001310b5a7e1796d149c2ee363124abdfa0289d32"},
-    {file = "fastapi-0.110.3.tar.gz", hash = "sha256:555700b0159379e94fdbfc6bb66a0f1c43f4cf7060f25239af3d84b63a656626"},
+    {file = "fastapi-0.115.0-py3-none-any.whl", hash = "sha256:17ea427674467486e997206a5ab25760f6b09e069f099b96f5b55a32fb6f1631"},
+    {file = "fastapi-0.115.0.tar.gz", hash = "sha256:f93b4ca3529a8ebc6fc3fcf710e5efa8de3df9b41570958abf1d97d843138004"},
 ]
 
 [package.dependencies]
 pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
-starlette = ">=0.37.2,<0.38.0"
+starlette = ">=0.37.2,<0.39.0"
 typing-extensions = ">=4.8.0"
 
 [package.extras]
-all = ["email_validator (>=2.0.0)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=2.11.2)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.7)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=2.11.2)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.7)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=2.11.2)", "python-multipart (>=0.0.7)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
 name = "fqdn"
@@ -3926,4 +3927,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "de4b2f358af2793836d77ec131bd5589e2d65a1e7428d578c06e61f20505279e"
+content-hash = "bda5752c8047954cba38525e07bcfb75147f6acf4e24b28498eb650eaff448bd"

--- a/apiv2/pyproject.toml
+++ b/apiv2/pyproject.toml
@@ -28,7 +28,7 @@ httpx = "^0.24.1"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-fastapi = "^0.110.0"
+fastapi = "^0.115.0"
 # biopython 1.83 fails installation on m1 macs. The issue is fixed upstream so we're pinning to a specific commit until the next release.
 biopython = { git = "https://github.com/biopython/biopython.git", rev = "e0731edc892b653dee10b1f68acf795086e6f3f0" }
 asyncpg = "^0.28.0"


### PR DESCRIPTION
This fixes two major bugs in apiv2:
1. The api was creating a new database connection pool on every request, which basically meant that we had no limit on the number of db connections between the app and the database. We're now creating the pool once at the startup of the app, and then fetching connections from that pool in the rest of the app. I've currently set the limit at 5 connections (which can burst up to 10 connections) per worker. Each pod has 4 workers, and we have two pods running in most environments, which means a max of 80 connections possible from the api, while the limit at the database server is around 200 connections, so we should be in good shape for awhile.
2. We weren't properly closing database sessions due to the way we were handling our integration with FastAPI's dependency injection system -- we needed to be using [AsyncExitStack](https://docs.python.org/3/library/contextlib.html#contextlib.AsyncExitStack) as a context manager to make sure any fastapi dependencies that `yield` control ([docs/examples here](https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-with-yield/)) had control returned back to them after they'd yielded.