### PR TITLE
fix: Fixing the values for key photo literals

### DIFF
--- a/ingestion_tools/dataset_configs/10000.yaml
+++ b/ingestion_tools/dataset_configs/10000.yaml
@@ -453,11 +453,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: frames/CountRef.dm4
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/10001.yaml
+++ b/ingestion_tools/dataset_configs/10001.yaml
@@ -423,11 +423,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: VPP/frames/CountRef_{run_name}.dm4
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/10002.yaml
+++ b/ingestion_tools/dataset_configs/10002.yaml
@@ -161,11 +161,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: CountRef_{mapped_frame_name}-range.dm4
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/10003.yaml
+++ b/ingestion_tools/dataset_configs/10003.yaml
@@ -115,11 +115,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: frames/{run_name}/*.dm4
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 runs:
 - sources:
   - source_glob:

--- a/ingestion_tools/dataset_configs/10004.yaml
+++ b/ingestion_tools/dataset_configs/10004.yaml
@@ -158,11 +158,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: gain/gain.mrc
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/10005.yaml
+++ b/ingestion_tools/dataset_configs/10005.yaml
@@ -127,11 +127,6 @@ depositions:
   - literal:
       value:
       - 10005
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 runs:
 - sources:
   - source_glob:

--- a/ingestion_tools/dataset_configs/10006.yaml
+++ b/ingestion_tools/dataset_configs/10006.yaml
@@ -158,11 +158,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: gainRef/CountRef_mapped-{run_name}_acquisition-order_-0.0.dm4
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 runs:
 - sources:
   - source_glob:

--- a/ingestion_tools/dataset_configs/10007.yaml
+++ b/ingestion_tools/dataset_configs/10007.yaml
@@ -120,11 +120,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: '{run_name}/*.gain'
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/10008.yaml
+++ b/ingestion_tools/dataset_configs/10008.yaml
@@ -162,11 +162,6 @@ frames:
 - sources:
   - source_glob:
       list_glob: tomo/raw_stacks/{mapped_ts_name}/frames/*{mapped_frame_name}_*.tif
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/10009.yaml
+++ b/ingestion_tools/dataset_configs/10009.yaml
@@ -292,11 +292,6 @@ frames:
 - sources:
   - source_glob:
       list_glob: Tomo{run_name}/raw_data/raw_frames/*.mrc.bz2
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/10010.yaml
+++ b/ingestion_tools/dataset_configs/10010.yaml
@@ -145,11 +145,6 @@ frames:
 - sources:
   - source_glob:
       list_glob: frames/{run_name}_*.tif
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 runs:
 - sources:
   - source_glob:

--- a/ingestion_tools/dataset_configs/10011_draft.yaml
+++ b/ingestion_tools/dataset_configs/10011_draft.yaml
@@ -92,11 +92,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: frames/CountRef.dm4
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/scripts/tests/fixtures/annotations/anno_config.yaml
+++ b/ingestion_tools/scripts/tests/fixtures/annotations/anno_config.yaml
@@ -55,11 +55,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: ''
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/scripts/tests/fixtures/dataset1.yaml
+++ b/ingestion_tools/scripts/tests/fixtures/dataset1.yaml
@@ -129,11 +129,6 @@ gains:
       list_globs:
       - VPP/frames/CountRef_{run_name}.dm4
       - VPP/frames/CountRef_{run_name}.gain
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/scripts/tests/fixtures/voxel_spacing/mrc_header.yaml
+++ b/ingestion_tools/scripts/tests/fixtures/voxel_spacing/mrc_header.yaml
@@ -43,11 +43,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: ''
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/scripts/tests/fixtures/voxel_spacing/overrides_by_run.yaml
+++ b/ingestion_tools/scripts/tests/fixtures/voxel_spacing/overrides_by_run.yaml
@@ -43,11 +43,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: ''
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/scripts/tests/fixtures/voxel_spacing/tomo_metadata.yaml
+++ b/ingestion_tools/scripts/tests/fixtures/voxel_spacing/tomo_metadata.yaml
@@ -43,11 +43,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: ''
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/scripts/tests/fixtures/voxel_spacing/tomo_run_data_map.yaml
+++ b/ingestion_tools/scripts/tests/fixtures/voxel_spacing/tomo_run_data_map.yaml
@@ -43,11 +43,6 @@ gains:
 - sources:
   - source_glob:
       list_glob: ''
-key_images:
-- sources:
-  - literal:
-      value:
-      - from_tomogram
 rawtilts:
 - sources:
   - source_multi_glob:


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
Fixing the values for the key images literal to valid photo key names.

In the past, the config's incorrect literal values were being overwritten with correct values. But, that has been replaced with adding the source only if a config doesn't already contain an entry for the entity. 

Removing the incorrect values will default to adding the correct values in the config. 