### PR TITLE
feat: transform_ingestion_configs.py support multiple versions

### DIFF
--- a/ingestion_tools/scripts/gjensen_config.py
+++ b/ingestion_tools/scripts/gjensen_config.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Optional, Union
 
 import click
 import yaml
-from transform_ingestion_configs import update_config
+from schema_migration.transform_ingestion_configs import update_config
 
 from common.fs import LocalFilesystem
 from common.normalize_fields import normalize_fiducial_alignment

--- a/ingestion_tools/scripts/schema_migration/__main__.py
+++ b/ingestion_tools/scripts/schema_migration/__main__.py
@@ -1,0 +1,4 @@
+from transform_ingestion_configs import cli
+
+if __name__ == "__main__":
+    cli()

--- a/ingestion_tools/scripts/schema_migration/transform_ingestion_configs.py
+++ b/ingestion_tools/scripts/schema_migration/transform_ingestion_configs.py
@@ -222,7 +222,7 @@ def update_config(data: dict[str, Any]) -> dict[str, Any]:
         {
             # current_version: (update_function, next_version)
             "0.0.0": (update_config_to_v1, "1.0.0"),
-            "1.0.0": (update_config_to_v1_1, "1.1.0"),})
+            "1.0.0": (update_config_to_v1_1, "1.1.0")})
 
     if not data.get("version"):
         logger.warning("No version found in config file. Assuming version 0.0.0.")
@@ -234,19 +234,19 @@ def update_config(data: dict[str, Any]) -> dict[str, Any]:
         update_func, result_version = item
         if data["version"] == current_version:
             data = update_func(data)
-    logger.info(f"Updated config from {initial_version} to {result_version}")
+    logger.info("Updated config from %s to %s", initial_version, result_version)
     return data
 
 
 def update_file(filename: str) -> None:
     with open(filename, "r") as fh:
-        logger.debug(f"Reading {filename}")
+        logger.debug("Reading %s", filename)
         data = yaml.safe_load(fh.read())
 
     update_config(data)
 
     with open(filename, "w") as fh:
-        logger.debug(f"Writing {filename}")
+        logger.debug("Writing %s", filename)
         fh.write(yaml.dump(data))
 
 

--- a/ingestion_tools/scripts/transform_ingestion_configs.py
+++ b/ingestion_tools/scripts/transform_ingestion_configs.py
@@ -220,7 +220,6 @@ def update_file(filename: str) -> None:
     if not data.get("version"):
         data["version"] = "0.0.0"
 
-    # get the current version do determine where to start upgrading
     for version, update_func in VERSION_MAP.items():
         if convert_version(data["version"]) == version:
             data = update_func(data)


### PR DESCRIPTION
- Add a docstring and description for the upgrade command
- Update transform_ingestion_configs to be extended to support upgrading an ingest config from version 0.0.0 and beyond.
- move schema migrations code to ingest_tools/schema_migration
- update gjensen_config.py to run with reorganization.
- related to #262 

# Testing

Test manually by modifying an existing ingest config to a previous version.