### PR TITLE
chore: fix failing tests in ingestor-test-db cases for api v2

### DIFF
--- a/ingestion_tools/scripts/tests/db_import/conftest.py
+++ b/ingestion_tools/scripts/tests/db_import/conftest.py
@@ -123,6 +123,7 @@ def expected_dataset(http_prefix: str) -> dict[str, Any]:
         "cell_strain_name": "test value",
         "cell_type_id": "4321",
         "cell_name": "foo",
+        "other_setup": "Other Setup",
         "organism_taxid": "1111",
         "organism_name": "Foo Bar",
         "tissue_id": "1234",

--- a/ingestion_tools/scripts/tests/db_import/test_db_tiltseries_import.py
+++ b/ingestion_tools/scripts/tests/db_import/test_db_tiltseries_import.py
@@ -65,7 +65,7 @@ def expected_tiltseries(http_prefix: str) -> list[dict[str, Any]]:
             "https_angle_list": f"{http_prefix}/{DATASET_ID}/RUN3/TiltSeries/bar.tlt",
             "acceleration_voltage": 10000,
             "spherical_aberration_constant": 2.7,
-            "microscope_manufacturer": "DC",
+            "microscope_manufacturer": "FEI",
             "microscope_model": "Phantom",
             "microscope_energy_filter": "TFS",
             "camera_manufacturer": "FEI",

--- a/ingestion_tools/scripts/tests/db_import/test_db_tomo_import.py
+++ b/ingestion_tools/scripts/tests/db_import/test_db_tomo_import.py
@@ -98,7 +98,7 @@ def expected_tomograms_by_run(http_prefix: str) -> dict[str, dict[float, list[di
         "size_z": 400,
         "voxel_spacing": 3.456,
         "fiducial_alignment_status": "NON_FIDUCIAL",
-        "reconstruction_method": "Unknown",
+        "reconstruction_method": "SART",
         "reconstruction_software": "Unknown",
         "processing": "filtered",
         "tomogram_version": "1",


### PR DESCRIPTION
This fixes an issues causing the make recipe `ingestor-test-db`

## Suspected cause
Something from this  [PR](https://github.com/chanzuckerberg/cryoet-data-portal-backend/commit/f04e5f3df2482f8d8a630628cd8154f3e487a99) broke the ingest-db tests. It's associated with some of the test infra files like test_infra/test_files/30001/dataset_metadata.json. Here is the [run](https://github.com/chanzuckerberg/cryoet-data-portal-backend/actions/runs/11061158693/job/30733496664?pr=262) in my PR after merging in main.