### PR TITLE
fix: workaround for docker compose bugs.

### DIFF
--- a/apiv2/Makefile
+++ b/apiv2/Makefile
@@ -19,7 +19,7 @@ export docker_compose:=docker compose
 # just hangs on OSX trying to launch itself in a container if it can't figure out
 # which one to use, so it's *VERY* important to include the --rm flag when invoking
 # docker compose run.
-export docker_compose_run:=docker compose run --rm
+export docker_compose_run:=docker compose run --rm --no-deps
 
 ### HELPFUL #################################################
 .PHONY: help


### PR DESCRIPTION
Docker compose has had a [variety of issues](https://github.com/docker/compose/issues?q=is%3Aissue+run+recreates) (spanning several years!) with recreating containers in situations where it shouldn't, especially when executing `docker compose run`. I've had problems launching the apiv2 dev environment in some cases, where `make alembic-upgrade` will erroneously tear down the db container and recreate it from scratch, but since we're reliant on an additional DB being added to postgres before running alembic upgrades, this db container recreate causes the startup of the dev environment to fail. Adding this `--no-deps` flag seems to fix the problem on my laptop, so I'm hoping it doesn't break anything in CI.