### PR TITLE
chore: Update footer of release please PR's.

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "pull-request-footer": "Merging this PR will deploy these APIv2 changes to production. [See the docs](https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/main/apiv2/README.md#updating-stagingprod) for more information"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
This just adds a link to the APIv2 deployment doc to the footer of PR's created by the `release-please` action.

The docs for this feature are here: https://github.com/googleapis/release-please/blob/main/docs/customizing.md#pull-request-footer