### PR TITLE
chore: upate the argus stack helm chart

### DIFF
--- a/.infra/prod/Chart.yaml
+++ b/.infra/prod/Chart.yaml
@@ -5,5 +5,5 @@ version: 1.0.0
 
 dependencies:
 - name: stack
-  version: 1.8.0
+  version: 1.20.1
   repository: https://chanzuckerberg.github.io/argo-helm-charts

--- a/.infra/rdev/Chart.yaml
+++ b/.infra/rdev/Chart.yaml
@@ -5,5 +5,5 @@ version: 1.0.0
 
 dependencies:
 - name: stack
-  version: 1.8.0
+  version: 1.20.1
   repository: https://chanzuckerberg.github.io/argo-helm-charts

--- a/.infra/staging/Chart.yaml
+++ b/.infra/staging/Chart.yaml
@@ -5,5 +5,5 @@ version: 1.0.0
 
 dependencies:
 - name: stack
-  version: 1.8.0
+  version: 1.20.1
   repository: https://chanzuckerberg.github.io/argo-helm-charts


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-3465

## Summary

Upgrade argus helm chart to make way for LetsEncrypt TLS certificates


