### PR TITLE
feat: Standardizing paths in metadata

### DIFF
--- a/ingestion_tools/scripts/common/config.py
+++ b/ingestion_tools/scripts/common/config.py
@@ -246,3 +246,9 @@ class DepositionImportConfig:
         if not results:
             results = []
         return results
+
+    def to_formatted_path(self, path: str) -> str:
+        """
+        Returns the s3 key, without the bucket name, for the given path. Helpful for formatting paths in metadata.
+        """
+        return os.path.relpath(path, self.output_prefix) if path else None

--- a/ingestion_tools/scripts/common/exceptions.py
+++ b/ingestion_tools/scripts/common/exceptions.py
@@ -1,0 +1,6 @@
+
+
+class TomogramNotFoundError(FileNotFoundError):
+    def __init__(self, message: str = None) -> None:
+        message = message or "No source tomogram found"
+        super().__init__(message)

--- a/ingestion_tools/scripts/importers/alignment.py
+++ b/ingestion_tools/scripts/importers/alignment.py
@@ -102,11 +102,11 @@ class AlignmentImporter(BaseFileImporter):
     def get_extra_metadata(self) -> dict:
         extra_metadata = {
             "per_section_alignment_parameters": self.converter.get_per_section_alignment_parameters(),
-            "alignment_path": self.to_formatted_path(self.converter.get_alignment_path()),
-            "tilt_path": self.to_formatted_path(self.converter.get_tilt_path()),
-            "tiltx_path": self.to_formatted_path(self.converter.get_tiltx_path()),
-            "tiltseries_path": self.to_formatted_path(self.get_tiltseries_path()),
-            "files": [self.to_formatted_path(self.get_dest_filename(path)) for path in self.file_paths.values()],
+            "alignment_path": self.config.to_formatted_path(self.converter.get_alignment_path()),
+            "tilt_path": self.config.to_formatted_path(self.converter.get_tilt_path()),
+            "tiltx_path": self.config.to_formatted_path(self.converter.get_tiltx_path()),
+            "tiltseries_path": self.config.to_formatted_path(self.get_tiltseries_path()),
+            "files": [self.config.to_formatted_path(self.get_dest_filename(path)) for path in self.file_paths.values()],
         }
         if "volume_dimension" not in self.metadata:
             extra_metadata["volume_dimension"] = self.get_tomogram_volume_dimension()

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -74,7 +74,7 @@ class AnnotationImporterFactory(DepositionObjectImporterFactory):
         parents: dict[str, Any] | None,
     ):
         source_args = {k: v for k, v in self.source.items() if k not in {"shape", "glob_string", "glob_strings"}}
-        alignment_path = self._get_alignment_metadata_path(config, parents)
+        alignment_path = config.to_formatted_path(self._get_alignment_metadata_path(config, parents))
         identifier = AnnotationIdentifierHelper.get_identifier(
             config,
             metadata,

--- a/ingestion_tools/scripts/importers/base_importer.py
+++ b/ingestion_tools/scripts/importers/base_importer.py
@@ -114,6 +114,12 @@ class BaseImporter:
     def is_import_allowed(self):
         return self.allow_imports
 
+    def to_formatted_path(self, path: str) -> str:
+        """
+        Returns the s3 key, without the bucket name, for the given path. Helpful for formatting paths in metadata.
+        """
+        return os.path.relpath(path, self.config.output_prefix) if path else None
+
     @classmethod
     def finder(cls, config: DepositionImportConfig, **parents: dict[str, "BaseImporter"]) -> list["BaseImporter"]:
         finder_configs = config.get_object_configs(cls.type_key)

--- a/ingestion_tools/scripts/importers/base_importer.py
+++ b/ingestion_tools/scripts/importers/base_importer.py
@@ -114,12 +114,6 @@ class BaseImporter:
     def is_import_allowed(self):
         return self.allow_imports
 
-    def to_formatted_path(self, path: str) -> str:
-        """
-        Returns the s3 key, without the bucket name, for the given path. Helpful for formatting paths in metadata.
-        """
-        return os.path.relpath(path, self.config.output_prefix) if path else None
-
     @classmethod
     def finder(cls, config: DepositionImportConfig, **parents: dict[str, "BaseImporter"]) -> list["BaseImporter"]:
         finder_configs = config.get_object_configs(cls.type_key)

--- a/ingestion_tools/scripts/importers/base_importer.py
+++ b/ingestion_tools/scripts/importers/base_importer.py
@@ -196,7 +196,7 @@ class VolumeImporter(BaseImporter):
     def load_extra_metadata(self) -> dict[str, Any]:
         run: RunImporter = self.get_run()
         output_prefix = self.get_output_path()
-        metadata = get_volume_metadata(self.config.fs, output_prefix)
+        metadata = get_volume_metadata(self.config, output_prefix)
         metadata["run_name"] = run.name
         return metadata
 

--- a/ingestion_tools/scripts/importers/run.py
+++ b/ingestion_tools/scripts/importers/run.py
@@ -32,7 +32,6 @@ class RunImporter(BaseImporter):
             print(f"Skipping import of {self.name} metadata")
             return
         dest_run_metadata = self.get_metadata_path()
-        print(dest_run_metadata)
         metadata = RunMetadata(self.config.fs, self.get_deposition().name, self.metadata)
         merge_data = {"run_name": self.name}
         metadata.write_metadata(dest_run_metadata, merge_data)

--- a/ingestion_tools/scripts/importers/tomogram.py
+++ b/ingestion_tools/scripts/importers/tomogram.py
@@ -71,7 +71,7 @@ class TomogramImporter(VolumeImporter):
             parents=parents,
             allow_imports=allow_imports,
         )
-        self.alignment_metadata_path = self.get_alignment_metadata_path()
+        self.alignment_metadata_path = config.to_formatted_path(self.get_alignment_metadata_path())
         self.identifier = TomogramIdentifierHelper.get_identifier(
             config,
             self.get_base_metadata(),
@@ -112,7 +112,7 @@ class TomogramImporter(VolumeImporter):
             base_metadata.get("fiducial_alignment_status"),
         )
         merge_data["alignment_metadata_path"] = self.alignment_metadata_path
-        merge_data["neuroglancer_config_path"] = self.get_neuroglancer_config_path()
+        merge_data["neuroglancer_config_path"] = self.config.to_formatted_path(self.get_neuroglancer_config_path())
         metadata = TomoMetadata(self.config.fs, self.get_deposition().name, base_metadata)
         metadata.write_metadata(dest_tomo_metadata, merge_data)
 

--- a/ingestion_tools/scripts/tests/s3_import/test_alignments.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_alignments.py
@@ -110,9 +110,10 @@ def test_alignment_import_item(
     parents = get_parents(config)
     dataset_name = parents.get("dataset").name
     run_name = parents.get("run").name
-    prefix = f"output/{dataset_name}/{run_name}/Alignments/"
+    prefix = f"{dataset_name}/{run_name}/Alignments"
+
     if deposition_id:
-        existing_prefix = os.path.join(prefix, "100/")
+        existing_prefix = os.path.join("output", prefix, "100/")
         add_alignment_metadata(existing_prefix, deposition_id)
 
     alignments = list(AlignmentImporter.finder(config, **parents))
@@ -120,14 +121,14 @@ def test_alignment_import_item(
         alignment.import_item()
         alignment.import_metadata()
 
-    output_prefix = os.path.join(prefix, str(id_prefix))
+    output_prefix = os.path.join("output", prefix, str(id_prefix))
     validate_dataframe(output_prefix, "TS_run1.xf")
     validate_dataframe(output_prefix, "TS_run1.tlt")
     validate_dataframe(output_prefix, "TS_run1.xtilt")
 
     expected = {
         "affine_transformation_matrix": [[2, 0, 0, 0], [0, 3, 0, 0], [0, 4, 1, 0], [0, 0, 0, 5]],
-        "alignment_path": f"{test_output_bucket}/{output_prefix}/TS_run1.xf",
+        "alignment_path": f"{prefix}/{id_prefix}/TS_run1.xf",
         "alignment_type": "LOCAL",
         "deposition_id": "10301",
         "is_portal_standard": True,
@@ -158,8 +159,8 @@ def test_alignment_import_item(
             },
         ],
         "tilt_offset": -0.3,
-        "tilt_path": f"{test_output_bucket}/{output_prefix}/TS_run1.tlt",
-        "tiltx_path": f"{test_output_bucket}/{output_prefix}/TS_run1.xtilt",
+        "tilt_path": f"{prefix}/{id_prefix}/TS_run1.tlt",
+        "tiltx_path": f"{prefix}/{id_prefix}/TS_run1.xtilt",
         "volume_dimension": {"x": 6, "y": 8, "z": 10},
         "volume_offset": {"x": -1, "y": 2, "z": -3},
         "x_rotation_offset": -2.3,
@@ -261,11 +262,11 @@ def test_custom_alignment_with_dimensions_import_without_tomograms(
 
     dataset_name = parents.get("dataset").name
     run_name = parents.get("run").name
-    prefix = f"output/{dataset_name}/{run_name}/Alignments/100"
-    validate_dataframe(prefix, "TS_run1.xf")
+    prefix = f"{dataset_name}/{run_name}/Alignments/100"
+    validate_dataframe(f"output/{prefix}", "TS_run1.xf")
     expected = {
         "affine_transformation_matrix": [[2, 0, 0, 0], [0, 3, 0, 0], [0, 4, 1, 0], [0, 0, 0, 5]],
-        "alignment_path": f"{test_output_bucket}/{prefix}/TS_run1.xf",
+        "alignment_path": f"{prefix}/TS_run1.xf",
         "alignment_type": "LOCAL",
         "deposition_id": "10301",
         "is_canonical": True,
@@ -302,7 +303,7 @@ def test_custom_alignment_with_dimensions_import_without_tomograms(
         "volume_offset": {"x": -1, "y": 2, "z": -3},
         "x_rotation_offset": -2.3,
     }
-    validate_metadata(expected, prefix)
+    validate_metadata(expected, f"output/{prefix}")
 
 
 def test_allow_import_is_false(

--- a/ingestion_tools/scripts/tests/s3_import/test_tiltseries.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_tiltseries.py
@@ -101,8 +101,8 @@ def test_tiltseries_import_metadata(
     assert "tiltseries_metadata.json" in tilt_series_files
     expected = {
         "frames_count": expected_frames_count,
-        "omezarr_dir": f"{run_name}.zarr",
-        "mrc_files": [f"{run_name}.mrc"],
+        "omezarr_dir": f"{parents['dataset'].name}/{run_name}/TiltSeries/100/{run_name}.zarr",
+        "mrc_file": f"{parents['dataset'].name}/{run_name}/TiltSeries/100/{run_name}.mrc",
         "pixel_spacing": expected_pixel_spacing,
         "scales": [{"z": 4, "y": 10, "x": 20}, {"z": 4, "y": 5, "x": 10}, {"z": 4, "y": 3, "x": 5}],
         "size": {"z": 4, "y": 10, "x": 20},

--- a/ingestion_tools/scripts/tests/s3_import/test_tomograms.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_tomograms.py
@@ -116,7 +116,7 @@ def test_tomogram_import(
     if deposition_id and existing_metadata:
         if alignment_path:
             existing_metadata["alignment_metadata_path"] = os.path.join(
-                test_output_bucket, f"output/{parents['dataset'].name}/{run_name}/Alignments", alignment_path,
+                f"{parents['dataset'].name}/{run_name}/Alignments", alignment_path,
             )
         existing_prefix = prefix.format(voxel_spacing=existing_metadata.get("voxel_spacing", voxel_spacing))
         add_tomogram_metadata(existing_prefix, deposition_id, existing_metadata)
@@ -152,28 +152,27 @@ def test_tomogram_import_metadata(
         item.import_metadata()
     run_name = parents["run"].name
     voxel_spacing = 13.48
-    run_path = f"output/{parents['dataset'].name}/{run_name}"
-    vs_path = f"{run_path}/Reconstructions/VoxelSpacing{voxel_spacing:.3f}"
+    vs_path = f"{parents['dataset'].name}/{run_name}/Reconstructions/VoxelSpacing{voxel_spacing:.3f}"
     id_prefix = 100
     prefix = f"{vs_path}/Tomograms/{id_prefix}"
-    tomogram_files = get_children(s3_client, test_output_bucket, prefix)
+    tomogram_files = get_children(s3_client, test_output_bucket,  f"output/{prefix}")
     assert "tomogram_metadata.json" in tomogram_files
     image_path = f"{parents['dataset'].name}/{run_name}/Reconstructions/VoxelSpacing{voxel_spacing:.3f}/Images/{id_prefix}-key-photo-"
     expected = {
-        "omezarr_dir": f"{run_name}.zarr",
-        "mrc_files": [f"{run_name}.mrc"],
+        "omezarr_dir": os.path.join(prefix, f"{run_name}.zarr"),
+        "mrc_file": os.path.join(prefix, f"{run_name}.mrc"),
         "voxel_spacing": 13.48,
         "scales": [{"x": 6, "y": 8, "z": 10}, {"x": 3, "y": 4, "z": 5}, {"x": 2, "y": 2, "z": 3}],
         "size": {"x": 6, "y": 8, "z": 10},
-        "alignment_metadata_path": f"{test_output_bucket}/{run_path}/Alignments/100/alignment_metadata.json",
-        "neuroglancer_config_path": f"{test_output_bucket}/{vs_path}/NeuroglancerPrecompute/"
+        "alignment_metadata_path": f"{parents['dataset'].name}/{run_name}/Alignments/100/alignment_metadata.json",
+        "neuroglancer_config_path": f"{vs_path}/NeuroglancerPrecompute/"
                                     f"{id_prefix}-neuroglancer_config.json",
         "key_photo": {
             "snapshot": f"{image_path}snapshot.png",
             "thumbnail": f"{image_path}thumbnail.png",
         },
     }
-    validate_metadata(expected, prefix)
+    validate_metadata(expected, f"output/{prefix}")
 
 
 def test_tomogram_no_import(


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

Updates all the paths specified in the metadata to follow the same pattern. 

### Alignment
The paths for `tiltseries_path`, `alignment_path`, `tilt_path`, `tiltx_path`, `files` no longer specify the bucket.

### TiltSeries
- The paths for `omezarr_dir`, `mrc_file` are the complete path instead of just the file name
- The `mrc_files` property is renamed to `mrc_file`, and the value of a single element list is now just a string.

### Tomogram
- The paths for `omezarr_dir`, `mrc_file` are the complete path instead of just the file name
- The `mrc_files` property is renamed to `mrc_file`, and the value of a single element list is now just a string.
- The `alignment_metadata_path` and `neuroglancer_config_path` no longer specifies the bucket name.

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
