### PR TITLE
feat: Add alignment conversion for IMOD and AreTomo3

### DIFF
--- a/ingestion_tools/poetry.lock
+++ b/ingestion_tools/poetry.lock
@@ -1568,6 +1568,31 @@ files = [
 ]
 
 [[package]]
+name = "cryoet-alignment"
+version = "0.0.4"
+description = "Alignment format conversion for cryoET."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "cryoet_alignment-0.0.4-py3-none-any.whl", hash = "sha256:98e4cf2b73fac72ee92eb84b3ad8f873742abac8be4f495d6c82daf425042d0e"},
+    {file = "cryoet_alignment-0.0.4.tar.gz", hash = "sha256:e9083bd94c91ee20518fd1b3f2c77c36883a15bc498aaabaca9cd1493f4b0e6e"},
+]
+
+[package.dependencies]
+click = "*"
+fsspec = ">=2024.6.0"
+mrcfile = "*"
+numpy = "<2"
+pandas = "*"
+pydantic = ">=2"
+s3fs = "*"
+
+[package.extras]
+dev = ["black", "ipython", "notebook", "pre-commit", "ruff"]
+docs = ["mkdocs", "mkdocs-autorefs", "mkdocs-material", "mkdocstrings[python]"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "cryoet-data-portal-neuroglancer"
 version = "0.1.0"
 description = "Utility package for working with Neuroglancer data in the CZI Cryo-ET Data Portal"
@@ -5795,4 +5820,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5279f29b9c33850c93246d09346a630b394254b8f14f7f0a99b4abba23adfa3c"
+content-hash = "f2c83a9162e92b38ef813d75bf4d5ab406ed0e65af7e08c359077035f8edb17d"

--- a/ingestion_tools/poetry.lock
+++ b/ingestion_tools/poetry.lock
@@ -1569,13 +1569,13 @@ files = [
 
 [[package]]
 name = "cryoet-alignment"
-version = "0.0.4"
+version = "0.0.5"
 description = "Alignment format conversion for cryoET."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "cryoet_alignment-0.0.4-py3-none-any.whl", hash = "sha256:98e4cf2b73fac72ee92eb84b3ad8f873742abac8be4f495d6c82daf425042d0e"},
-    {file = "cryoet_alignment-0.0.4.tar.gz", hash = "sha256:e9083bd94c91ee20518fd1b3f2c77c36883a15bc498aaabaca9cd1493f4b0e6e"},
+    {file = "cryoet_alignment-0.0.5-py3-none-any.whl", hash = "sha256:54812b822159092bc60f0e3ccd2efd5662b15b77a63ca298303c3f097f5ef623"},
+    {file = "cryoet_alignment-0.0.5.tar.gz", hash = "sha256:98d2216641184f83eef6917b790afb56e83d6a42d43e92b7cecd4c3a3bced8b0"},
 ]
 
 [package.dependencies]
@@ -5820,4 +5820,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "f2c83a9162e92b38ef813d75bf4d5ab406ed0e65af7e08c359077035f8edb17d"
+content-hash = "bff7d02ae387dd0d2962d0c627c193adf0435b021a98ab4559c80a66e84bc24f"

--- a/ingestion_tools/pyproject.toml
+++ b/ingestion_tools/pyproject.toml
@@ -55,6 +55,7 @@ numpy = "^1.22.0"
 pytest-xdist = "^3.6.1"
 h5py = "^3.11.0"
 allure-pytest = "^2.13.5"
+cryoet-alignment = "0.0.4"
 
 [tool.black]
 line-length = 120

--- a/ingestion_tools/pyproject.toml
+++ b/ingestion_tools/pyproject.toml
@@ -55,7 +55,7 @@ numpy = "^1.22.0"
 pytest-xdist = "^3.6.1"
 h5py = "^3.11.0"
 allure-pytest = "^2.13.5"
-cryoet-alignment = "0.0.4"
+cryoet-alignment = "0.0.5"
 
 [tool.black]
 line-length = 120

--- a/ingestion_tools/scripts/common/alignment_converter.py
+++ b/ingestion_tools/scripts/common/alignment_converter.py
@@ -75,6 +75,9 @@ class IMODAlignmentConverter(BaseAlignmentConverter):
         return self._get_files_with_suffix(["newst.com"])
 
     def get_per_section_alignment_parameters(self) -> list[dict]:
+        if self.get_alignment_path() is None or self.get_tilt_path() is None:
+            return []
+
         with self.config.fs.open(self.get_alignment_path(), "r") as file:
             xf = ImodXF.from_stream(file)
 
@@ -104,7 +107,7 @@ class IMODAlignmentConverter(BaseAlignmentConverter):
         return [psap.model_dump() for psap in ali.per_section_alignment_parameters]
 
 
-class AreTomoAlignmentConverter(BaseAlignmentConverter):
+class AreTomo3AlignmentConverter(BaseAlignmentConverter):
     def get_alignment_path(self) -> str | None:
         return self._get_files_with_suffix([".aln"])
 
@@ -127,6 +130,6 @@ def alignment_converter_factory(
     if alignment_format == "IMOD":
         return IMODAlignmentConverter(paths, config, parents, output_prefix)
     elif alignment_format == "ARETOMO3":
-        return AreTomoAlignmentConverter(paths, config, parents, output_prefix)
+        return AreTomo3AlignmentConverter(paths, config, parents, output_prefix)
 
     return BaseAlignmentConverter()

--- a/ingestion_tools/scripts/tests/fixtures/alignments/alignment3.yaml
+++ b/ingestion_tools/scripts/tests/fixtures/alignments/alignment3.yaml
@@ -29,6 +29,7 @@ alignments:
   sources:
   - source_multi_glob:
       list_globs:
+      - alignments/{run_name}.tlt
       - alignments/{run_name}.xf
 datasets:
 - sources:

--- a/ingestion_tools/scripts/tests/fixtures/alignments/alignment4.yaml
+++ b/ingestion_tools/scripts/tests/fixtures/alignments/alignment4.yaml
@@ -33,6 +33,7 @@ alignments:
   sources:
   - source_multi_glob:
       list_globs:
+      - alignments/{run_name}.tlt
       - alignments/{run_name}.xf
 datasets:
 - sources:

--- a/ingestion_tools/scripts/tests/fixtures/dataset2.yaml
+++ b/ingestion_tools/scripts/tests/fixtures/dataset2.yaml
@@ -1,0 +1,220 @@
+annotations:
+- metadata:
+    annotation_method: Manual annotation
+    annotation_object:
+      id: GO:000000!
+      name: Ribosome 1
+    annotation_publications: EMPIAR-00002, EMD-00002
+    annotation_software: pyTOM + Keras
+    authors:
+    - ORCID: 0000-0001-0001-0001
+      name: Author 1
+    - ORCID: 0000-0004-0004-0004
+      name: Author 4
+      primary_author_status: true
+    dates: &id001
+      deposition_date: '2023-04-01'
+      last_modified_date: '2023-06-01'
+      release_date: '2023-06-01'
+    ground_truth_status: true
+    version: 1.0
+  sources:
+  - columns: xyz
+    file_format: csv
+    glob_string: particle_lists/{run_name}_fas.csv
+    shape: Point
+collection_metadata:
+- sources:
+  - source_multi_glob:
+      list_globs:
+      - metadata/mdocs_modified/foo-{run_name}.mdoc
+alignments:
+- metadata:
+    affine_transformation_matrix:
+    - - 2
+      - 0
+      - 0
+      - 0
+    - - 0
+      - 3
+      - 0
+      - 0
+    - - 0
+      - 4
+      - 1
+      - 0
+    - - 0
+      - 0
+      - 0
+      - 5
+    alignment_type: LOCAL
+    format: ARETOMO3
+    is_portal_standard: true
+    tilt_offset: -0.3
+    volume_offset:
+      x: -1
+      y: 2
+      z: -3
+    x_rotation_offset: -2.3
+  sources:
+  - source_multi_glob:
+      list_globs:
+      - alignments/{run_name}.aln
+dataset_keyphotos:
+- sources:
+  - literal:
+      value:
+        snapshot: http://nginx:80/input_bucket/snapshot.gif
+        thumbnail: http://nginx:80/input_bucket/thumbnail.gif
+datasets:
+- metadata:
+    authors: &id002
+    - ORCID: 0000-0001-0001-0001
+      name: Author 1
+      primary_author_status: true
+    - ORCID: 0000-0002-0002-0002
+      name: Author 2
+    - ORCID: 0000-0003-0003-0003
+      corresponding_author_status: true
+      name: Author 3
+    cell_component:
+      id: null
+      name: null
+    cell_strain:
+      id: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=88888
+      name: Strain 1
+    cross_references: &id003
+      publications: doi:10.1101/2022.01.01.00001
+      related_database_entries: EMPIAR-00001, EMD-00001, EMD-00002
+    dataset_description: Description for Dataset 1
+    dataset_identifier: 10001
+    dataset_title: Dataset 1
+    dates: *id001
+    funding:
+    - funding_agency_name: Super Funding Agency
+      grant_id: '100001'
+    grid_preparation: 'material: COPPER,'
+    organism:
+      name: Organism 1
+      taxonomy_id: 9999
+    sample_preparation: 'buffer_ph: 7.0'
+    sample_type: organism
+  sources:
+  - literal:
+      value:
+      - '10001'
+depositions:
+- metadata:
+    authors: *id002
+    cross_references: *id003
+    deposition_description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed"
+    deposition_identifier: 10301
+    deposition_title: Deposition 1
+    dates: *id001
+  sources:
+  - literal:
+      value:
+      - '10301'
+deposition_keyphotos:
+- sources:
+  - literal:
+      value:
+        snapshot: http://nginx:80/input_bucket/snapshot.gif
+        thumbnail: http://nginx:80/input_bucket/thumbnail.gif
+frames:
+- sources:
+  - source_multi_glob:
+      list_globs:
+      - VPP/frames/{run_name}_*.tiff
+gains:
+- sources:
+  - source_multi_glob:
+      list_globs:
+      - VPP/frames/CountRef_{run_name}.dm4
+      - VPP/frames/CountRef_{run_name}.gain
+rawtilts:
+- sources:
+  - source_multi_glob:
+      list_globs:
+      - metadata/{run_name}.rawtlt
+runs:
+- sources:
+  - source_glob:
+      list_glob: tomograms/TS_*.rec
+      match_regex: .*
+      name_regex: (.*).rec
+standardization_config:
+  deposition_id: 10001
+  run_to_tomo_map_csv: null
+  source_prefix: input_bucket/10001_input
+tiltseries:
+- metadata:
+    acceleration_voltage: 300000
+    binning_from_frames: 1
+    camera:
+      manufacturer: Gatan
+      model: K2 SUMMIT
+    data_acquisition_software: SerialEM
+    is_aligned: false
+    microscope:
+      manufacturer: TFS
+      model: Krios
+    microscope_optical_setup:
+      energy_filter: GIF Quantum LS
+      image_corrector: null
+      phase_plate: Volta Phase Plate
+    pixel_spacing: 3.3702
+    related_empiar_entry: EMPIAR-10988
+    spherical_aberration_constant: 2.7
+    tilt_axis: 70.1
+    tilt_range:
+      max: 60
+      min: -40
+    tilt_series_quality: 5
+    tilt_step: 2
+    tilting_scheme: Dose symmetric from 0.0 degrees
+    total_flux: 122
+  sources:
+  - source_glob:
+      list_glob: metadata/{run_name}.st
+      name_regex: (.*)\.st
+tomograms:
+- metadata:
+    affine_transformation_matrix:
+    - - 1
+      - 0
+      - 0
+      - 0
+    - - 0
+      - 1
+      - 0
+      - 0
+    - - 0
+      - 0
+      - 1
+      - 0
+    - - 0
+      - 0
+      - 0
+      - 1
+    authors: *id002
+    ctf_corrected: false
+    fiducial_alignment_status: NON_FIDUCIAL
+    offset:
+      x: 0
+      y: 0
+      z: 0
+    processing: raw
+    reconstruction_method: WBP
+    reconstruction_software: IMOD
+    is_visualization_default: true
+    tomogram_version: 1
+  sources:
+  - source_glob:
+      list_glob: tomograms/{run_name}.rec
+      match_regex: .*\.rec
+voxel_spacings:
+- sources:
+  - literal:
+      value:
+      - 13.48

--- a/ingestion_tools/scripts/tests/s3_import/test_alignments.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_alignments.py
@@ -134,27 +134,102 @@ def test_alignment_import_item(
         "per_section_alignment_parameters": [
             {
                 "z_index": 0,
-                "in_plane_rotation": [0.029, 1.0, -1.0, 0.029],
-                "x_offset": 55.43,
-                "y_offset": 25.56,
-                "tilt_angle": -5,
+                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
+                "x_offset": 23.95253,
+                "y_offset": -56.17124,
+                "tilt_angle": -5.0,
                 "volume_x_rotation": 0.23,
             },
             {
                 "z_index": 1,
-                "in_plane_rotation": [0.029, 1.0, -1.0, 0.029],
-                "x_offset": -75.84,
-                "y_offset": 55.1,
-                "tilt_angle": 0,
+                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
+                "x_offset": 57.29936,
+                "y_offset": 74.24210000000001,
+                "tilt_angle": 0.0,
                 "volume_x_rotation": 2.12,
             },
             {
                 "z_index": 2,
-                "in_plane_rotation": [0.029, 1.0, -1.0, 0.029],
-                "x_offset": -93.8,
-                "y_offset": 77.79,
-                "tilt_angle": 5,
+                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
+                "x_offset": 80.51020000000001,
+                "y_offset": 91.54409,
+                "tilt_angle": 5.0,
                 "volume_x_rotation": 1.97,
+            },
+        ],
+        "tilt_offset": -0.3,
+        "tilt_path": f"{test_output_bucket}/{output_prefix}/TS_run1.tlt",
+        "tiltx_path": f"{test_output_bucket}/{output_prefix}/TS_run1.xtilt",
+        "volume_dimension": {"x": 6, "y": 8, "z": 10},
+        "volume_offset": {"x": -1, "y": 2, "z": -3},
+        "x_rotation_offset": -2.3,
+    }
+    validate_metadata(expected, output_prefix)
+
+
+@pytest.mark.parametrize(
+    "deposition_id, id_prefix",
+    [
+        (None, 100),  # No alignment metadata exists
+        (100001, 101),  # alignment metadata exists for a different deposition
+        (10301, 100),  # alignment metadata exists for the same deposition as test
+    ],
+)
+def test_alignment_import_item_aretomo(
+    create_config: Callable[[str], DepositionImportConfig],
+    add_alignment_metadata: Callable[[str, int], None],
+    validate_dataframe: Callable[[str, str], None],
+    validate_metadata: Callable[[dict, str], None],
+    test_output_bucket: str,
+    deposition_id: int,
+    id_prefix: int,
+) -> None:
+    config = create_config("dataset2.yaml")
+    parents = get_parents(config)
+    dataset_name = parents.get("dataset").name
+    run_name = parents.get("run").name
+    prefix = f"output/{dataset_name}/{run_name}/Alignments/"
+    if deposition_id:
+        existing_prefix = os.path.join(prefix, "100/")
+        add_alignment_metadata(existing_prefix, deposition_id)
+
+    alignments = list(AlignmentImporter.finder(config, **parents))
+    for alignment in alignments:
+        alignment.import_item()
+        alignment.import_metadata()
+
+    output_prefix = os.path.join(prefix, str(id_prefix))
+
+    expected = {
+        "affine_transformation_matrix": [[2, 0, 0, 0], [0, 3, 0, 0], [0, 4, 1, 0], [0, 0, 0, 5]],
+        "alignment_path": f"{test_output_bucket}/{output_prefix}/TS_run1.aln",
+        "alignment_type": "LOCAL",
+        "deposition_id": "10301",
+        "is_portal_standard": True,
+        "per_section_alignment_parameters": [
+            {
+                "z_index": 0,
+                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
+                "x_offset": 23.95253,
+                "y_offset": -56.17124,
+                "tilt_angle": -5.0,
+                "volume_x_rotation": 0.0,
+            },
+            {
+                "z_index": 1,
+                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
+                "x_offset": 57.29936,
+                "y_offset": 74.24210000000001,
+                "tilt_angle": 0.0,
+                "volume_x_rotation": 0.0,
+            },
+            {
+                "z_index": 2,
+                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
+                "x_offset": 80.51020000000001,
+                "y_offset": 91.54409,
+                "tilt_angle": 5.0,
+                "volume_x_rotation": 0.0,
             },
         ],
         "tilt_offset": -0.3,
@@ -272,31 +347,31 @@ def test_custom_alignment_with_dimensions_import_without_tomograms(
         "per_section_alignment_parameters": [
             {
                 "z_index": 0,
-                "in_plane_rotation": [0.029, 1.0, -1.0, 0.029],
-                "x_offset": 55.43,
-                "y_offset": 25.56,
-                "tilt_angle": None,
-                "volume_x_rotation": 0,
+                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
+                "x_offset": 23.95253,
+                "y_offset": -56.17124,
+                "tilt_angle": -5.0,
+                "volume_x_rotation": 0.0,
             },
             {
                 "z_index": 1,
-                "in_plane_rotation": [0.029, 1.0, -1.0, 0.029],
-                "x_offset": -75.84,
-                "y_offset": 55.1,
-                "tilt_angle": None,
-                "volume_x_rotation": 0,
+                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
+                "x_offset": 57.29936,
+                "y_offset": 74.24210000000001,
+                "tilt_angle": 0.0,
+                "volume_x_rotation": 0.0,
             },
             {
                 "z_index": 2,
-                "in_plane_rotation": [0.029, 1.0, -1.0, 0.029],
-                "x_offset": -93.8,
-                "y_offset": 77.79,
-                "tilt_angle": None,
-                "volume_x_rotation": 0,
+                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
+                "x_offset": 80.51020000000001,
+                "y_offset": 91.54409,
+                "tilt_angle": 5.0,
+                "volume_x_rotation": 0.0,
             },
         ],
         "tilt_offset": -0.3,
-        "tilt_path": None,
+        "tilt_path": f"{test_output_bucket}/{prefix}/TS_run1.tlt",
         "tiltx_path": None,
         "volume_dimension": {"x": 6, "y": 8, "z": 10},
         "volume_offset": {"x": -1, "y": 2, "z": -3},

--- a/ingestion_tools/scripts/tests/s3_import/test_alignments.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_alignments.py
@@ -194,9 +194,10 @@ def test_alignment_import_item_aretomo(
     parents = get_parents(config)
     dataset_name = parents.get("dataset").name
     run_name = parents.get("run").name
-    prefix = f"output/{dataset_name}/{run_name}/Alignments/"
+    prefix = f"{dataset_name}/{run_name}/Alignments"
+
     if deposition_id:
-        existing_prefix = os.path.join(prefix, "100/")
+        existing_prefix = os.path.join("output", prefix, "100/")
         add_alignment_metadata(existing_prefix, deposition_id)
 
     alignments = list(AlignmentImporter.finder(config, **parents))
@@ -204,12 +205,12 @@ def test_alignment_import_item_aretomo(
         alignment.import_item()
         alignment.import_metadata()
 
-    output_prefix = os.path.join(prefix, str(id_prefix))
+    output_prefix = os.path.join("output", prefix, str(id_prefix))
 
     tol = 10e-3
     expected = {
         "affine_transformation_matrix": [[2, 0, 0, 0], [0, 3, 0, 0], [0, 4, 1, 0], [0, 0, 0, 5]],
-        "alignment_path": f"{test_output_bucket}/{output_prefix}/TS_run1.aln",
+        "alignment_path": f"{prefix}/{id_prefix}/TS_run1.aln",
         "alignment_type": "LOCAL",
         "deposition_id": "10301",
         "is_portal_standard": True,
@@ -378,7 +379,7 @@ def test_custom_alignment_with_dimensions_import_without_tomograms(
             },
         ],
         "tilt_offset": -0.3,
-        "tilt_path": f"{test_output_bucket}/{prefix}/TS_run1.tlt",
+        "tilt_path": f"{prefix}/TS_run1.tlt",
         "tiltx_path": None,
         "volume_dimension": {"x": 6, "y": 8, "z": 10},
         "volume_offset": {"x": -1, "y": 2, "z": -3},

--- a/ingestion_tools/scripts/tests/s3_import/test_alignments.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_alignments.py
@@ -66,7 +66,9 @@ def validate_dataframe(
 
 @pytest.fixture
 def validate_metadata(
-    s3_client: S3Client, test_output_bucket: str, precision: float = 10e-5,
+    s3_client: S3Client,
+    test_output_bucket: str,
+    precision: float = 10e-5,
 ) -> Callable[[dict, str, int], None]:
     def validate(expected: dict, prefix: str) -> None:
         key = os.path.join(prefix, "alignment_metadata.json")

--- a/ingestion_tools/scripts/tests/s3_import/test_alignments.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_alignments.py
@@ -72,14 +72,6 @@ def validate_metadata(
         key = os.path.join(prefix, "alignment_metadata.json")
         actual = json.loads(get_data_from_s3(s3_client, test_output_bucket, key).read())
         for key in expected:
-            # # Assert with precision for psap values
-            # if key == "per_section_alignment_parameters":
-            #     for i, psap in enumerate(expected[key]):
-            #         for psap_key in psap:
-            #             assert actual[key][i][psap_key] == pytest.approx(
-            #                 expected[key][i][psap_key], abs=precision
-            #             ), f"Key {key},{i},{psap_key} does not match"
-            # else:
             assert actual[key] == expected[key], f"Key {key} does not match"
 
     return validate

--- a/ingestion_tools/scripts/tests/s3_import/test_alignments.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_alignments.py
@@ -65,11 +65,21 @@ def validate_dataframe(
 
 
 @pytest.fixture
-def validate_metadata(s3_client: S3Client, test_output_bucket: str) -> Callable[[dict, str, int], None]:
+def validate_metadata(
+    s3_client: S3Client, test_output_bucket: str, precision: float = 10e-5,
+) -> Callable[[dict, str, int], None]:
     def validate(expected: dict, prefix: str) -> None:
         key = os.path.join(prefix, "alignment_metadata.json")
         actual = json.loads(get_data_from_s3(s3_client, test_output_bucket, key).read())
         for key in expected:
+            # # Assert with precision for psap values
+            # if key == "per_section_alignment_parameters":
+            #     for i, psap in enumerate(expected[key]):
+            #         for psap_key in psap:
+            #             assert actual[key][i][psap_key] == pytest.approx(
+            #                 expected[key][i][psap_key], abs=precision
+            #             ), f"Key {key},{i},{psap_key} does not match"
+            # else:
             assert actual[key] == expected[key], f"Key {key} does not match"
 
     return validate
@@ -125,6 +135,7 @@ def test_alignment_import_item(
     validate_dataframe(output_prefix, "TS_run1.tlt")
     validate_dataframe(output_prefix, "TS_run1.xtilt")
 
+    tol = 10e-5
     expected = {
         "affine_transformation_matrix": [[2, 0, 0, 0], [0, 3, 0, 0], [0, 4, 1, 0], [0, 0, 0, 5]],
         "alignment_path": f"{test_output_bucket}/{output_prefix}/TS_run1.xf",
@@ -134,25 +145,25 @@ def test_alignment_import_item(
         "per_section_alignment_parameters": [
             {
                 "z_index": 0,
-                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
-                "x_offset": 23.95253,
-                "y_offset": -56.17124,
+                "in_plane_rotation": [pytest.approx([0.029, -1.0], abs=tol), pytest.approx([1.0, 0.029], abs=tol)],
+                "x_offset": pytest.approx(23.95253, abs=tol),
+                "y_offset": pytest.approx(-56.17124, abs=tol),
                 "tilt_angle": -5.0,
                 "volume_x_rotation": 0.23,
             },
             {
                 "z_index": 1,
-                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
-                "x_offset": 57.29936,
-                "y_offset": 74.24210000000001,
+                "in_plane_rotation": [pytest.approx([0.029, -1.0], abs=tol), pytest.approx([1.0, 0.029], abs=tol)],
+                "x_offset": pytest.approx(57.29936, abs=tol),
+                "y_offset": pytest.approx(74.24210, abs=tol),
                 "tilt_angle": 0.0,
                 "volume_x_rotation": 2.12,
             },
             {
                 "z_index": 2,
-                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
-                "x_offset": 80.51020000000001,
-                "y_offset": 91.54409,
+                "in_plane_rotation": [pytest.approx([0.029, -1.0], abs=tol), pytest.approx([1.0, 0.029], abs=tol)],
+                "x_offset": pytest.approx(80.51020, abs=tol),
+                "y_offset": pytest.approx(91.54409, abs=tol),
                 "tilt_angle": 5.0,
                 "volume_x_rotation": 1.97,
             },
@@ -200,6 +211,7 @@ def test_alignment_import_item_aretomo(
 
     output_prefix = os.path.join(prefix, str(id_prefix))
 
+    tol = 10e-3
     expected = {
         "affine_transformation_matrix": [[2, 0, 0, 0], [0, 3, 0, 0], [0, 4, 1, 0], [0, 0, 0, 5]],
         "alignment_path": f"{test_output_bucket}/{output_prefix}/TS_run1.aln",
@@ -209,32 +221,32 @@ def test_alignment_import_item_aretomo(
         "per_section_alignment_parameters": [
             {
                 "z_index": 0,
-                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
-                "x_offset": 23.95253,
-                "y_offset": -56.17124,
+                "in_plane_rotation": [pytest.approx([0.029, -1.0], abs=tol), pytest.approx([1.0, 0.029], abs=tol)],
+                "x_offset": pytest.approx(23.95253, abs=tol),
+                "y_offset": pytest.approx(-56.17124, abs=tol),
                 "tilt_angle": -5.0,
                 "volume_x_rotation": 0.0,
             },
             {
                 "z_index": 1,
-                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
-                "x_offset": 57.29936,
-                "y_offset": 74.24210000000001,
+                "in_plane_rotation": [pytest.approx([0.029, -1.0], abs=tol), pytest.approx([1.0, 0.029], abs=tol)],
+                "x_offset": pytest.approx(57.29936, abs=tol),
+                "y_offset": pytest.approx(74.24210, abs=tol),
                 "tilt_angle": 0.0,
                 "volume_x_rotation": 0.0,
             },
             {
                 "z_index": 2,
-                "in_plane_rotation": [[0.029, -1.0], [1.0, 0.029]],
-                "x_offset": 80.51020000000001,
-                "y_offset": 91.54409,
+                "in_plane_rotation": [pytest.approx([0.029, -1.0], abs=tol), pytest.approx([1.0, 0.029], abs=tol)],
+                "x_offset": pytest.approx(80.51020, abs=tol),
+                "y_offset": pytest.approx(91.54409, abs=tol),
                 "tilt_angle": 5.0,
                 "volume_x_rotation": 0.0,
             },
         ],
         "tilt_offset": -0.3,
-        "tilt_path": f"{test_output_bucket}/{output_prefix}/TS_run1.tlt",
-        "tiltx_path": f"{test_output_bucket}/{output_prefix}/TS_run1.xtilt",
+        "tilt_path": None,
+        "tiltx_path": None,
         "volume_dimension": {"x": 6, "y": 8, "z": 10},
         "volume_offset": {"x": -1, "y": 2, "z": -3},
         "x_rotation_offset": -2.3,

--- a/test_infra/test_files/input_bucket/10001_input/alignments/TS_run1.aln
+++ b/test_infra/test_files/input_bucket/10001_input/alignments/TS_run1.aln
@@ -1,0 +1,11 @@
+# AreTomo Alignment / Priims bprmMn
+# RawSize = 10 20 3
+# NumPatches = 0
+
+# AlphaOffset =     0.00
+# BetaOffset =     0.00
+# SEC     ROT         GMAG       TX          TY      SMEAN     SFIT    SCALE     BASE     TILT
+    0    88.3389    1.00000     23.953    -56.171     1.00     1.00     1.00     0.00     -5.00
+    1    88.3389    1.00000     57.299     74.242     1.00     1.00     1.00     0.00      0.00
+    2    88.3389    1.00000     80.510     91.544     1.00     1.00     1.00     0.00      5.00
+# Local Alignment


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to https://github.com/chanzuckerberg/cryoet-data-portal/issues/1208
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

Adds conversion for IMOD and AreTomo3 alignments to the AlignmentConverter class. This is based on the alignment conversions in [cryoet-alignment](https://pypi.org/project/cryoet-alignment/0.0.5/). 

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
