### PR TITLE
fix: Updating the tomogram key photo path

### DIFF
--- a/ingestion_tools/scripts/importers/key_image.py
+++ b/ingestion_tools/scripts/importers/key_image.py
@@ -23,7 +23,7 @@ class KeyImageImporter(BaseImporter):
         "snapshot": 512,  # small detail expand
         "expanded": 1024,  # large detail expand
     }
-    dir_path = "{dataset_name}/{run_name}/Reconstructions/VoxelSpacing{voxel_spacing_name}/Images"
+    dir_path = "{dataset_name}/{run_name}/Reconstructions/VoxelSpacing{voxel_spacing_name}/Images/{tomogram_id}/"
 
     def get_metadata(self) -> dict[str, str]:
         return {
@@ -93,8 +93,7 @@ class KeyImageImporter(BaseImporter):
         return preview, data.shape[-1]
 
     def get_file_name(self, image_type: str) -> str:
-        tomogram_id = self.get_tomogram().get_identifier()
-        return f"{tomogram_id}-key-photo-{image_type}.png"
+        return f"key-photo-{image_type}.png"
 
     @classmethod
     def get_default_config(cls) -> list[dict] | None:

--- a/ingestion_tools/scripts/tests/s3_import/test_tomograms.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_tomograms.py
@@ -157,7 +157,7 @@ def test_tomogram_import_metadata(
     prefix = f"{vs_path}/Tomograms/{id_prefix}"
     tomogram_files = get_children(s3_client, test_output_bucket,  f"output/{prefix}")
     assert "tomogram_metadata.json" in tomogram_files
-    image_path = f"{parents['dataset'].name}/{run_name}/Reconstructions/VoxelSpacing{voxel_spacing:.3f}/Images/{id_prefix}-key-photo-"
+    image_path = f"{vs_path}/Images/{id_prefix}/key-photo-"
     expected = {
         "omezarr_dir": os.path.join(prefix, f"{run_name}.zarr"),
         "mrc_file": os.path.join(prefix, f"{run_name}.mrc"),


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

Migrates `{dataset_name}/{run_name}/Reconstructions/VoxelSpacing{voxel_spacing_name}/Images/{tomogram_id}-key-photo-{image_type}.png` -> `{dataset_name}/{run_name}/Reconstructions/VoxelSpacing{voxel_spacing_name}/Images/{tomogram_id}/key-photo-{image_type}.png`
<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
