### PR TITLE
fix: handle formatted voxel spacing string in tomo metadata

### DIFF
--- a/ingestion_tools/scripts/importers/tomogram.py
+++ b/ingestion_tools/scripts/importers/tomogram.py
@@ -33,10 +33,16 @@ class TomogramIdentifierHelper(IdentifierHelper):
         *args,
         **kwargs,
     ) -> str:
+        voxel_spacing = metadata.get("voxel_spacing")
+        # Handles the case where voxel_spacing in the config metadata is a formatted string
+        if not voxel_spacing or isinstance(voxel_spacing, str) and not voxel_spacing.isdigit():
+            voxel_spacing = parents["voxel_spacing"].name
+        elif isinstance(voxel_spacing, float):
+            voxel_spacing = f"{voxel_spacing:.3f}"
         return "-".join(
             [
                 container_key,
-                str(metadata.get("voxel_spacing", parents["voxel_spacing"].name)),
+                str(voxel_spacing),
                 metadata.get("alignment_metadata_path", kwargs.get("alignment_metadata_path", "")),
                 metadata.get("reconstruction_method", ""),
                 metadata.get("processing", ""),


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
Handles the voxel spacing being a formatted string in the ingestion config
<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
