### PR TITLE
chore: removing key image specification in config

### DIFF
--- a/ingestion_tools/dataset_configs/gjensen/10014.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10014.yaml
@@ -68,10 +68,6 @@ depositions:
   - literal:
       value:
       - 10014
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10015.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10015.yaml
@@ -68,10 +68,6 @@ depositions:
   - literal:
       value:
       - 10014
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10016.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10016.yaml
@@ -68,10 +68,6 @@ depositions:
   - literal:
       value:
       - 10014
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10017.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10017.yaml
@@ -65,10 +65,6 @@ depositions:
   - literal:
       value:
       - 10014
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10018.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10018.yaml
@@ -64,10 +64,6 @@ depositions:
   - literal:
       value:
       - 10014
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10019.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10019.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10014
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10020.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10020.yaml
@@ -68,10 +68,6 @@ depositions:
   - literal:
       value:
       - 10014
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10021.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10021.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10049
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10022.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10022.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10023.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10023.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10024.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10024.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10025.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10025.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10026.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10026.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10027.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10027.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10028.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10028.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10029.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10029.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10030.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10030.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10031.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10031.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10032.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10032.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10033.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10033.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10034.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10034.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10035.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10035.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10036.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10036.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10037.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10037.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10018
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10038.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10038.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10023
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10039.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10039.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10023
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10040.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10040.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10023
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10041.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10041.yaml
@@ -53,10 +53,6 @@ depositions:
   - literal:
       value:
       - 10023
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10042.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10042.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10023
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10043.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10043.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10030
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10044.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10044.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10030
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10045.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10045.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10030
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10046.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10046.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10030
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10047.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10047.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10030
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10048.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10048.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10030
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10049.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10049.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10030
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10050.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10050.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10030
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10051.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10051.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10030
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10052.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10052.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10030
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10053.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10053.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10045
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10054.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10054.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10045
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10055.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10055.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10045
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10056.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10056.yaml
@@ -66,10 +66,6 @@ depositions:
   - literal:
       value:
       - 10045
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10057.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10057.yaml
@@ -67,10 +67,6 @@ depositions:
   - literal:
       value:
       - 10045
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10058.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10058.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10059.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10059.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10060.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10060.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10061.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10061.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10062.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10062.yaml
@@ -68,10 +68,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10063.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10063.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10064.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10064.yaml
@@ -68,10 +68,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10065.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10065.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10066.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10066.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10067.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10067.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10068.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10068.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10069.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10069.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10070.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10070.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10071.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10071.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10072.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10072.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10073.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10073.yaml
@@ -68,10 +68,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10074.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10074.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10075.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10075.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10076.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10076.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10077.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10077.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10078.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10078.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10079.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10079.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10080.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10080.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10081.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10081.yaml
@@ -70,10 +70,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10082.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10082.yaml
@@ -65,10 +65,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10083.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10083.yaml
@@ -65,10 +65,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10084.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10084.yaml
@@ -70,10 +70,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10085.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10085.yaml
@@ -69,10 +69,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10086.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10086.yaml
@@ -64,10 +64,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10087.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10087.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10088.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10088.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10089.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10089.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10090.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10090.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10091.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10091.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10092.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10092.yaml
@@ -64,10 +64,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10093.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10093.yaml
@@ -64,10 +64,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10094.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10094.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10095.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10095.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10096.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10096.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10097.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10097.yaml
@@ -70,10 +70,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10098.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10098.yaml
@@ -70,10 +70,6 @@ depositions:
   - literal:
       value:
       - 10038
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10099.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10099.yaml
@@ -54,10 +54,6 @@ depositions:
   - literal:
       value:
       - 10052
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10100.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10100.yaml
@@ -54,10 +54,6 @@ depositions:
   - literal:
       value:
       - 10015
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10101.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10101.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10034
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10102.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10102.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10034
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10103.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10103.yaml
@@ -51,10 +51,6 @@ depositions:
   - literal:
       value:
       - 10051
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10104.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10104.yaml
@@ -51,10 +51,6 @@ depositions:
   - literal:
       value:
       - 10051
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10105.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10105.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10036
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10106.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10106.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10036
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10107.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10107.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10036
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10108.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10108.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10036
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10109.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10109.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10016
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10110.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10110.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10016
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10111.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10111.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10016
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10112.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10112.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10016
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10113.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10113.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10016
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10114.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10114.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10016
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10115.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10115.yaml
@@ -53,10 +53,6 @@ depositions:
   - literal:
       value:
       - 10050
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10116.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10116.yaml
@@ -54,10 +54,6 @@ depositions:
   - literal:
       value:
       - 10027
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10117.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10117.yaml
@@ -54,10 +54,6 @@ depositions:
   - literal:
       value:
       - 10027
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10118.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10118.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10119.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10119.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10120.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10120.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10121.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10121.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10122.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10122.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10123.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10123.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10124.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10124.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10125.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10125.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10126.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10126.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10127.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10127.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10128.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10128.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10129.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10129.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10130.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10130.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10131.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10131.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10132.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10132.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10133.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10133.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10134.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10134.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10039
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10135.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10135.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10028
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10136.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10136.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10028
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10137.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10137.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10028
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10138.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10138.yaml
@@ -54,10 +54,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10139.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10139.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10140.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10140.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10141.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10141.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10142.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10142.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10143.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10143.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10144.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10144.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10145.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10145.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10146.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10146.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10147.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10147.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10148.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10148.yaml
@@ -54,10 +54,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10149.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10149.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10150.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10150.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10151.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10151.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10152.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10152.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10153.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10153.yaml
@@ -54,10 +54,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10154.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10154.yaml
@@ -57,10 +57,6 @@ depositions:
   - literal:
       value:
       - 10017
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10155.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10155.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10032
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10156.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10156.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10032
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10157.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10157.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10032
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10158.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10158.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10032
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10159.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10159.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10024
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10160.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10160.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10048
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10161.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10161.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10048
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10162.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10162.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10046
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10163.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10163.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10046
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10164.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10164.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10046
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10165.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10165.yaml
@@ -65,10 +65,6 @@ depositions:
   - literal:
       value:
       - 10046
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10166.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10166.yaml
@@ -62,10 +62,6 @@ depositions:
   - literal:
       value:
       - 10046
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10167.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10167.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10056
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10168.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10168.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10056
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10169.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10169.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10033
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10170.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10170.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10033
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10171.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10171.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10033
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10172.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10172.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10173.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10173.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10174.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10174.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10175.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10175.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10176.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10176.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10177.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10177.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10178.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10178.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10179.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10179.yaml
@@ -57,10 +57,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10180.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10180.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10181.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10181.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10182.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10182.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10183.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10183.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10184.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10184.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10185.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10185.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10186.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10186.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10187.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10187.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10188.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10188.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10025
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10189.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10189.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10057
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10190.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10190.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10057
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10191.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10191.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10057
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10192.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10192.yaml
@@ -57,10 +57,6 @@ depositions:
   - literal:
       value:
       - 10057
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10193.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10193.yaml
@@ -57,10 +57,6 @@ depositions:
   - literal:
       value:
       - 10057
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10194.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10194.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10031
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10195.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10195.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10031
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10196.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10196.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10031
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10197.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10197.yaml
@@ -54,10 +54,6 @@ depositions:
   - literal:
       value:
       - 10020
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10198.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10198.yaml
@@ -54,10 +54,6 @@ depositions:
   - literal:
       value:
       - 10055
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10199.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10199.yaml
@@ -54,10 +54,6 @@ depositions:
   - literal:
       value:
       - 10055
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10200.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10200.yaml
@@ -54,10 +54,6 @@ depositions:
   - literal:
       value:
       - 10055
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10201.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10201.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10202.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10202.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10203.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10203.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10204.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10204.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10205.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10205.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10206.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10206.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10207.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10207.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10208.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10208.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10209.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10209.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10210.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10210.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10211.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10211.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10212.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10212.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10213.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10213.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10214.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10214.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10215.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10215.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10216.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10216.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10217.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10217.yaml
@@ -63,10 +63,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10218.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10218.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10219.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10219.yaml
@@ -61,10 +61,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10220.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10220.yaml
@@ -65,10 +65,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10221.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10221.yaml
@@ -64,10 +64,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10222.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10222.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10223.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10223.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10224.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10224.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10029
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10225.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10225.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10226.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10226.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10227.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10227.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10228.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10228.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10229.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10229.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10230.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10230.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10231.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10231.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10232.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10232.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10233.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10233.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10234.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10234.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10235.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10235.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10236.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10236.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10237.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10237.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10238.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10238.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10239.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10239.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10240.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10240.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10241.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10241.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10022
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10242.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10242.yaml
@@ -52,10 +52,6 @@ depositions:
   - literal:
       value:
       - 10042
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10243.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10243.yaml
@@ -51,10 +51,6 @@ depositions:
   - literal:
       value:
       - 10047
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10244.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10244.yaml
@@ -51,10 +51,6 @@ depositions:
   - literal:
       value:
       - 10047
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10245.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10245.yaml
@@ -52,10 +52,6 @@ depositions:
   - literal:
       value:
       - 10047
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10246.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10246.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10019
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10247.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10247.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10019
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10248.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10248.yaml
@@ -60,10 +60,6 @@ depositions:
   - literal:
       value:
       - 10019
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10249.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10249.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10019
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10250.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10250.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10035
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10251.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10251.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10035
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10252.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10252.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10035
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10253.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10253.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10026
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10254.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10254.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10026
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10255.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10255.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10026
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10256.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10256.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10026
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10257.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10257.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10026
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10258.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10258.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10026
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10259.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10259.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10026
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10260.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10260.yaml
@@ -52,10 +52,6 @@ depositions:
   - literal:
       value:
       - 10044
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10261.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10261.yaml
@@ -52,10 +52,6 @@ depositions:
   - literal:
       value:
       - 10044
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10262.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10262.yaml
@@ -59,10 +59,6 @@ depositions:
   - literal:
       value:
       - 10037
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10263.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10263.yaml
@@ -57,10 +57,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10264.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10264.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10265.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10265.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10266.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10266.yaml
@@ -58,10 +58,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10267.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10267.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10268.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10268.yaml
@@ -57,10 +57,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10269.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10269.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10270.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10270.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10271.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10271.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10272.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10272.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10273.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10273.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10274.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10274.yaml
@@ -57,10 +57,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10275.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10275.yaml
@@ -57,10 +57,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10276.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10276.yaml
@@ -57,10 +57,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10277.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10277.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10021
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10278.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10278.yaml
@@ -51,10 +51,6 @@ depositions:
   - literal:
       value:
       - 10040
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10279.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10279.yaml
@@ -51,10 +51,6 @@ depositions:
   - literal:
       value:
       - 10040
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10280.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10280.yaml
@@ -51,10 +51,6 @@ depositions:
   - literal:
       value:
       - 10040
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10281.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10281.yaml
@@ -52,10 +52,6 @@ depositions:
   - literal:
       value:
       - 10040
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10282.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10282.yaml
@@ -53,10 +53,6 @@ depositions:
   - literal:
       value:
       - 10040
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10283.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10283.yaml
@@ -53,10 +53,6 @@ depositions:
   - literal:
       value:
       - 10040
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10284.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10284.yaml
@@ -53,10 +53,6 @@ depositions:
   - literal:
       value:
       - 10040
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10285.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10285.yaml
@@ -51,10 +51,6 @@ depositions:
   - literal:
       value:
       - 10040
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10286.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10286.yaml
@@ -52,10 +52,6 @@ depositions:
   - literal:
       value:
       - 10040
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10287.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10287.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10054
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10288.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10288.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10041
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10289.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10289.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10043
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10290.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10290.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10043
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10291.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10291.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10043
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10292.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10292.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10043
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10293.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10293.yaml
@@ -56,10 +56,6 @@ depositions:
   - literal:
       value:
       - 10043
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10294.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10294.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10043
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10295.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10295.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10043
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10296.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10296.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10043
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10297.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10297.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10043
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10298.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10298.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10043
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10299.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10299.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10043
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/dataset_configs/gjensen/10300.yaml
+++ b/ingestion_tools/dataset_configs/gjensen/10300.yaml
@@ -55,10 +55,6 @@ depositions:
   - literal:
       value:
       - 10053
-key_images:
-- sources:
-  - source_glob:
-      list_glob: '{run_name}/keyimg_{run_name}.jpg'
 rawtilts:
 - sources:
   - source_multi_glob:

--- a/ingestion_tools/scripts/gjensen_config.py
+++ b/ingestion_tools/scripts/gjensen_config.py
@@ -184,7 +184,7 @@ def to_standardization_config(
         "tomo_glob": f"{{run_name}}/{tomo_path}",
         "tomo_regex": r".*\.(mrc|rec)$",
         "tomo_voxel_size": "",
-        "tomo_key_photo_glob": "{run_name}/keyimg_{run_name}.jpg",
+        # "tomo_key_photo_glob": "{run_name}/keyimg_{run_name}.jpg",
         "run_glob": "*",
         "run_regex": f'({"|".join(run_names)})$',
         "run_name_regex": "(.*)",


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

Removing the key image config specification in the Grant Jensen configs, as they are not being handled as expected. This is a temp fix that should be reverted once a more cleaner long term solution is in place.

Case 1: The file does not exist
In this case, the default values are not applied as a source already exists.

Case 2: The file exists
This will not be included in the tomogram metadata, because of [this line here](https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/f155e0bc24317257da9e0b7f45b2bf5f1f7dd796/ingestion_tools/scripts/importers/tomogram.py#L112). 

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
