### PR TITLE
fix: Upgrade cryoet-alignment package to 0.0.7

### DIFF
--- a/ingestion_tools/poetry.lock
+++ b/ingestion_tools/poetry.lock
@@ -1569,13 +1569,13 @@ files = [
 
 [[package]]
 name = "cryoet-alignment"
-version = "0.0.6"
+version = "0.0.7"
 description = "Alignment format conversion for cryoET."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "cryoet_alignment-0.0.6-py3-none-any.whl", hash = "sha256:550997ebb1deffd7ba5bb557f45e37137470618ebda6a99a266393daaff9c931"},
-    {file = "cryoet_alignment-0.0.6.tar.gz", hash = "sha256:c47b83e0007cf50cc9f6b7a7fc546b5d2018a28fcc6d4dd96293a1a6ccfcf703"},
+    {file = "cryoet_alignment-0.0.7-py3-none-any.whl", hash = "sha256:1cec50541b0a2afe5f40ce74ed0206fe6cf31555db5db0a5d4b6ffc94892a5c8"},
+    {file = "cryoet_alignment-0.0.7.tar.gz", hash = "sha256:e351c3d07f75f04ba6a715777206c61c75f58aee81a7082b85189d13bf4b14aa"},
 ]
 
 [package.dependencies]
@@ -5820,4 +5820,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "6eb047578f2b5cd70d643eacdea9aae41613b7bcaa4fc7551f23c56b3bf70e87"
+content-hash = "42f73221ac3c45278834e15d39bd2d2a48e9067b18a3af41cbba45c17a579cba"

--- a/ingestion_tools/pyproject.toml
+++ b/ingestion_tools/pyproject.toml
@@ -55,7 +55,7 @@ numpy = "^1.22.0"
 pytest-xdist = "^3.6.1"
 h5py = "^3.11.0"
 allure-pytest = "^2.13.5"
-cryoet-alignment = "0.0.6"
+cryoet-alignment = "0.0.7"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to N/A
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

Upgrade `cryoet-alignment` to 0.0.7, which contains a fix for reading newst.com files missing the AntialiasFilter option.

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
