### PR TITLE
fix: Retrieve Zarr shape without having to load data

### DIFF
--- a/ingestion_tools/scripts/common/image.py
+++ b/ingestion_tools/scripts/common/image.py
@@ -209,6 +209,7 @@ class OMEZarrReader(VolumeReader):
 
         nodes = list(reader())
         self._attrs = self.loc.root_attrs
+        self._shape = nodes[0].data[0].shape
         self._header_only = header_only
 
         if not header_only:
@@ -226,7 +227,7 @@ class OMEZarrReader(VolumeReader):
         #     rms = np.sqrt(np.mean((self.data - np.mean(self.data)) ** 2))  # Calculate RMS,
         #     dmean = np.mean(self.data)  # Calculate dmean
 
-        z, y, x = self.data.shape
+        z, y, x = self._shape
         return VolumeInfo(
             self._attrs["multiscales"][0]["datasets"][0]["coordinateTransformations"][0]["scale"][1],
             0,


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to N/A
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

When Zarr-volumes are already ingested, the Importers attempt to get the shape from the `VolumeReader`. In the case of `OMEZarrReader`, even when `header_only=True`, it was attempted to use the unset `data` attribute. This PR adds private attribute `_shape` to the reader that stores the array shape without loading the data.

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
