### PR TITLE
feat: Expand the Tomgram importer hash function to include processing software

### DIFF
--- a/apiv2/db_import/importers/tomogram.py
+++ b/apiv2/db_import/importers/tomogram.py
@@ -9,9 +9,15 @@ from db_import.importers.base import IntegratedDBImporter, ItemDBImporter
 
 
 class TomogramItem(ItemDBImporter):
-    # TODO - add the alignment_id field once that data is added the first time.
-    # id_fields = ["run_id", "tomogram_voxel_spacing_id", "deposition_id", "alignment_id", "processing", "reconstruction_method""]
-    id_fields = ["run_id", "tomogram_voxel_spacing_id", "deposition_id", "processing", "reconstruction_method"]
+    id_fields = [
+        "alignment_id",
+        "deposition_id",
+        "processing",
+        "processing_software",
+        "reconstruction_method",
+        "run_id",
+        "tomogram_voxel_spacing_id",
+    ]
     model_class = models.Tomogram
     direct_mapped_fields = {
         "name": ["run_name"],
@@ -101,8 +107,6 @@ class TomogramImporter(IntegratedDBImporter):
 
 
 class TomogramAuthorItem(ItemDBImporter):
-    # TODO - add the alignment_id field once that data is added the first time.
-    # id_fields = ["run_id", "tomogram_voxel_spacing_id", "deposition_id", "alignment_id", "processing", "reconstruction_method""]
     id_fields = ["tomogram_id", "name"]
     model_class = models.TomogramAuthor
     direct_mapped_fields = {

--- a/apiv2/db_import/importers/tomogram.py
+++ b/apiv2/db_import/importers/tomogram.py
@@ -9,8 +9,9 @@ from db_import.importers.base import IntegratedDBImporter, ItemDBImporter
 
 
 class TomogramItem(ItemDBImporter):
+    # TODO - add the alignment_id field once that data is added the first time.
     id_fields = [
-        "alignment_id",
+        # "alignment_id",
         "deposition_id",
         "processing",
         "processing_software",

--- a/apiv2/db_import/tests/populate_db.py
+++ b/apiv2/db_import/tests/populate_db.py
@@ -294,6 +294,7 @@ def populate_tomograms(session: sa.orm.Session) -> Tomogram:
         scale1_dimensions="",
         scale2_dimensions="",
         processing="raw",
+        processing_software="tomo3D",
         offset_x=0,
         offset_y=0,
         offset_z=0,
@@ -440,7 +441,9 @@ def populate_annotations(session: sa.orm.Session) -> Annotation:
         id=ANNOTATION_ID,
         run_id=RUN1_ID,
         deposition_id=DEPOSITION_ID2,
-        s3_metadata_path="s3://test-public-bucket/30001/RUN1/Reconstructions/VoxelSpacing12.300/Annotations/100/foo-1.0.json",
+        s3_metadata_path=(
+            "s3://test-public-bucket/30001/RUN1/Reconstructions/VoxelSpacing12.300/Annotations/100/foo-1.0.json"
+        ),
         https_metadata_path="foo",
         deposition_date="2025-04-01",
         release_date="2025-06-01",

--- a/ingestion_tools/scripts/importers/db/tomogram.py
+++ b/ingestion_tools/scripts/importers/db/tomogram.py
@@ -39,7 +39,13 @@ class TomogramDBImporter(BaseDBImporter):
 
     @classmethod
     def get_id_fields(cls) -> list[str]:
-        return ["tomogram_voxel_spacing_id", "deposition_id", "processing", "reconstruction_method"]
+        return [
+            "tomogram_voxel_spacing_id",
+            "deposition_id",
+            "processing",
+            "processing_software",
+            "reconstruction_method",
+        ]
 
     @classmethod
     def get_db_model_class(cls) -> type[BaseModel]:

--- a/ingestion_tools/scripts/importers/tomogram.py
+++ b/ingestion_tools/scripts/importers/tomogram.py
@@ -46,6 +46,7 @@ class TomogramIdentifierHelper(IdentifierHelper):
                 metadata.get("alignment_metadata_path", kwargs.get("alignment_metadata_path", "")),
                 metadata.get("reconstruction_method", ""),
                 metadata.get("processing", ""),
+                metadata.get("processing_software", ""),
                 str(metadata.get("deposition_id", int(parents["deposition"].name))),
             ],
         )
@@ -79,7 +80,9 @@ class TomogramImporter(VolumeImporter):
             allow_imports=allow_imports,
         )
 
-        self.alignment_metadata_path = config.to_formatted_path(alignment_metadata_path or self.get_alignment_metadata_path())
+        self.alignment_metadata_path = config.to_formatted_path(
+            alignment_metadata_path or self.get_alignment_metadata_path(),
+        )
         self.identifier = TomogramIdentifierHelper.get_identifier(
             config,
             self.get_base_metadata(),

--- a/ingestion_tools/scripts/tests/db_import/populate_db.py
+++ b/ingestion_tools/scripts/tests/db_import/populate_db.py
@@ -231,6 +231,7 @@ def populate_tomograms() -> None:
         scale1_dimensions="",
         scale2_dimensions="",
         processing="raw",
+        processing_software="tomo3D",
         deposition_id=DEPOSITION_ID1,
         offset_x=0,
         offset_y=0,


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->
 
Relates to N/A
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

Tomograms are considered unique based on these fields during S3 ingestion: 

```
[
                container_key,
                str(voxel_spacing),
                metadata.get("alignment_metadata_path", kwargs.get("alignment_metadata_path", "")),
                metadata.get("reconstruction_method", ""),
                metadata.get("processing", ""),
                str(metadata.get("deposition_id", int(parents["deposition"].name))),
]
``` 

This PR adds `processing_software` to the hash function to be able to distinguish tomograms denoised using different tools. It also expands the ID fields for the `TomogramDBImporter`. 
            

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
