### PR TITLE
fix: Prevent creating glob patterns as directories.

### DIFF
--- a/ingestion_tools/scripts/common/config.py
+++ b/ingestion_tools/scripts/common/config.py
@@ -228,6 +228,11 @@ class DepositionImportConfig:
         if extra_glob_vars:
             glob_vars.update(extra_glob_vars)
         path = os.path.join(output_prefix, get_importer_output_path(key).format(**glob_vars))
+
+        # If the path contains a wildcard, we don't want to create the directory
+        if '*' in path or '?' in path:
+            return path
+
         if ".json" in path or ".mrc" in path or ".zarr" in path:
             self.fs.makedirs(os.path.dirname(path))
         else:


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to N/A
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

In some cases `config.resolve_output_path` is used to resolve glob patterns, e.g:

- https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/9cf033ab930a7a11e971eac65efcbf6644a0b935/ingestion_tools/scripts/importers/tomogram.py#L23
- https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/9cf033ab930a7a11e971eac65efcbf6644a0b935/ingestion_tools/scripts/importers/alignment.py#L26
- https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/9cf033ab930a7a11e971eac65efcbf6644a0b935/ingestion_tools/scripts/importers/annotation.py#L28

These patterns should never be passed to` fs.makedirs()`. This is inconsequential on S3 (because this method is not implemented there), but creates spurious directories when used in `standardize_dirs.py convert ... --local-fs`.

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
