### PR TITLE
chore: Build an x86 version of the apiv2 image to execute in aws batch.

### DIFF
--- a/.github/workflows/push-ingestor-build.yaml
+++ b/.github/workflows/push-ingestor-build.yaml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy-to-staging:
+  push-ingestor-build:
     name: build and push ingestor to remote
     runs-on: ubuntu-latest
     environment: staging
@@ -38,5 +38,31 @@ jobs:
           context: ./ingestion_tools
           file: ./ingestion_tools/Dockerfile
           tags: ${{ secrets.ECR_REPO }}:${{ github.head_ref || github.ref_name }}
+          push: true
+          provenance: false
+  push-ingestorv2-build:
+    name: build and push apiv2 ingestor to remote
+    runs-on: ubuntu-latest
+    environment: staging
+    if: github.repository == 'chanzuckerberg/cryoet-data-portal-backend'
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          mask-aws-account-id: true
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1200
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Docker build & Push
+        uses: docker/build-push-action@v4
+        with:
+          context: ./apiv2
+          file: ./apiv2/Dockerfile
+          tags: ${{ secrets.ECR_REPO_V2 }}:${{ github.head_ref || github.ref_name }}
           push: true
           provenance: false

--- a/.github/workflows/push-ingestor-build.yaml
+++ b/.github/workflows/push-ingestor-build.yaml
@@ -43,8 +43,8 @@ jobs:
       - name: Docker build & Push
         uses: docker/build-push-action@v4
         with:
-          context: ./${{build_dir}}
-          file: ./${{build_dir}}/Dockerfile
+          context: ./${{ build_dir }}
+          file: ./${{ build_dir }}/Dockerfile
           tags: ${{ repo }}:${{ github.head_ref || github.ref_name }}
           push: true
           provenance: false

--- a/.github/workflows/push-ingestor-build.yaml
+++ b/.github/workflows/push-ingestor-build.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "ingestion_tools/**"
+      - "apiv2/**"
       - ".github/workflows/push-ingestor-build.yaml"
 
 # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
@@ -14,7 +15,14 @@ permissions:
   contents: read
 
 jobs:
-  push-ingestor-build:
+  push-images:
+    strategy:
+      matrix:
+        include:
+          - build_dir: ingestion_tools
+            repo: ${{ secrets.ECR_REPO }}
+          - build_dir: apiv2
+            repo: ${{ secrets.ECR_REPO_V2 }}
     name: build and push ingestor to remote
     runs-on: ubuntu-latest
     environment: staging
@@ -35,34 +43,8 @@ jobs:
       - name: Docker build & Push
         uses: docker/build-push-action@v4
         with:
-          context: ./ingestion_tools
-          file: ./ingestion_tools/Dockerfile
-          tags: ${{ secrets.ECR_REPO }}:${{ github.head_ref || github.ref_name }}
-          push: true
-          provenance: false
-  push-ingestorv2-build:
-    name: build and push apiv2 ingestor to remote
-    runs-on: ubuntu-latest
-    environment: staging
-    if: github.repository == 'chanzuckerberg/cryoet-data-portal-backend'
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          mask-aws-account-id: true
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1200
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Docker build & Push
-        uses: docker/build-push-action@v4
-        with:
-          context: ./apiv2
-          file: ./apiv2/Dockerfile
-          tags: ${{ secrets.ECR_REPO_V2 }}:${{ github.head_ref || github.ref_name }}
+          context: ./${{build_dir}}
+          file: ./${{build_dir}}/Dockerfile
+          tags: ${{ repo }}:${{ github.head_ref || github.ref_name }}
           push: true
           provenance: false

--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,17 @@ push-local-ingestor-build:
 	aws_region=$$(aws configure get region); \
 	account_id=$$(aws sts get-caller-identity | jq -r ".Account"); \
 	ecr_repo=$$account_id.dkr.ecr.$$aws_region.amazonaws.com; \
-	$(MAKE) push-ingestor-build ecr_repo=$$ecr_repo/cryoet-staging tag=$(tag) aws_region=$$aws_region;
+	$(MAKE) push-ingestor-build ecr_repo=$$ecr_repo/cryoet-staging tag=$(tag) aws_region=$$aws_region; \
+	$(MAKE) push-ingestor-build-apiv2 ecr_repo=$$ecr_repo/apiv2-x86 tag=$(tag) aws_region=$$aws_region;
 
 .PHONY: push-ingestor-build
 push-ingestor-build:
 	cd ./ingestion_tools/; docker build . -t $(ecr_repo):$(tag) --platform linux/amd64;
+	aws ecr get-login-password --region $(aws_region) | docker login --username AWS --password-stdin $(ecr_repo); \
+	docker push $(ecr_repo):$(tag);
+
+.PHONY: push-ingestor-build-apiv2
+push-ingestor-build-apiv2:
+	cd ./apiv2/; docker build . -t $(ecr_repo):$(tag) --platform linux/amd64;
 	aws ecr get-login-password --region $(aws_region) | docker login --username AWS --password-stdin $(ecr_repo); \
 	docker push $(ecr_repo):$(tag);


### PR DESCRIPTION
This updates our `push-local-ingestor-build` make target to build both an apiv2 image (for db ingestion) and an ingestion_tools image (for s3 ingestion and apiv1 db ingestion) and also updates the GitHub action that pushes our ingestion_tools docker image to build an apiv2 image as well.

It's important to note that we've taken on this extra step because we run db ingestion in an x86-only environment in AWS batch, while our apiv2 service runs on ARM. We're using python and libraries that generally aren't tied to CPU architecture, so I don't expect any major differences in behavior between the different images