### PR TITLE
fix: matrix build variables behave oddly

### DIFF
--- a/.github/workflows/push-ingestor-build.yaml
+++ b/.github/workflows/push-ingestor-build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - jgadling/fix-image-build
     paths:
       - "ingestion_tools/**"
       - "apiv2/**"
@@ -20,9 +21,9 @@ jobs:
       matrix:
         include:
           - build_dir: ingestion_tools
-            repo: ${{ secrets.ECR_REPO }}
+            repo_key: ECR_REPO
           - build_dir: apiv2
-            repo: ${{ secrets.ECR_REPO_V2 }}
+            repo_key: ECR_REPO_V2
     name: build and push ingestor to remote
     runs-on: ubuntu-latest
     environment: staging
@@ -45,6 +46,6 @@ jobs:
         with:
           context: ./${{ build_dir }}
           file: ./${{ build_dir }}/Dockerfile
-          tags: ${{ repo }}:${{ github.head_ref || github.ref_name }}
+          tags: ${{ secrets[matrix.repo_key] }}:${{ github.head_ref || github.ref_name }}
           push: true
           provenance: false

--- a/.github/workflows/push-ingestor-build.yaml
+++ b/.github/workflows/push-ingestor-build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - jgadling-image-build
     paths:
       - "ingestion_tools/**"
       - "apiv2/**"

--- a/.github/workflows/push-ingestor-build.yaml
+++ b/.github/workflows/push-ingestor-build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - jgadling/fix-image-build
+      - jgadling-image-build
     paths:
       - "ingestion_tools/**"
       - "apiv2/**"
@@ -44,8 +44,8 @@ jobs:
       - name: Docker build & Push
         uses: docker/build-push-action@v4
         with:
-          context: ./${{ build_dir }}
-          file: ./${{ build_dir }}/Dockerfile
+          context: ./${{ matrix.build_dir }}
+          file: ./${{ matrix.build_dir }}/Dockerfile
           tags: ${{ secrets[matrix.repo_key] }}:${{ github.head_ref || github.ref_name }}
           push: true
           provenance: false


### PR DESCRIPTION
Secrets can't be specified as inputs to matrix builds, so we need to send the name of the secret KEY to the build job. Matrix values are also nested under a top level `matrix` object, so I updated the docker-build job accordingly. I tested this on a dev branch here:
https://github.com/chanzuckerberg/cryoet-data-portal-backend/actions/runs/11746537051/job/32726517971

Reference: https://sbulav.github.io/terraform/github-actions-matrix-secrets/