### PR TITLE
fix: Support running v2 db import via batch job.

### DIFF
--- a/apiv2/db_import/importer.py
+++ b/apiv2/db_import/importer.py
@@ -75,6 +75,7 @@ def db_import_options(func):
 @click.option("--filter-dataset", type=str, default=None, multiple=True)
 @click.option("--s3-prefix", required=True, default="", type=str)
 @click.option("--endpoint-url", type=str, default=None)
+@click.option("--debug", is_flag=True, default=False)
 @db_import_options
 def load(
     s3_bucket: str,
@@ -100,6 +101,7 @@ def load(
     import_everything: bool,
     deposition_id: list[str],
     endpoint_url: str,
+    debug: bool,  # Just included for compatibility with the old script.
 ):
     load_func(
         s3_bucket,

--- a/ingestion_tools/docs/enqueue_runs.md
+++ b/ingestion_tools/docs/enqueue_runs.md
@@ -81,8 +81,8 @@ EXPORT AWS_PROFILE=cryoet-dev
 # Get information on what types of stuff we can import
 python3 enqueue_runs.py db-import --help
 
-# Staging Example
-python3 enqueue_runs.py db-import --import-everything --include-dataset 10001 --include-dataset 10002
+# Staging Example, importing two depositions and two datasets
+python3 enqueue_runs.py db-import --import-everything --include-dataset 10001 --include-dataset 10002 --import-depositions --deposition-id 10001 --deposition-id 10002
 
 # Prod example
 export AWS_PROFILE=cryoet-prod
@@ -106,6 +106,7 @@ python3 enqueue_runs.py db-import --environment prod --import-annotation-authors
 | --include-dataset | null | Specify specific datasets to import. This option can be specified multiple times with multiple dataset id's                                                                                        |
 | --exclude-dataset | null | Supply a regular expression to exclude a list of dataset ID's the import. This option can be specified multiple times with multiple regular expressions.                                           |
 | --s3-prefix       | null | Only look for datasets in a particular subdirectory (this is faster than the filter/include filters) when importing a single dataset                                                               |
+| --import-depositions   | false | Whether to import deposition metadata. It's necessary to include this flag the first time we import data for a new deposition!                                                                                                            |
 | --deposition-id   | null | To be used with the --import-depositions flag to specify the depositions to be imported                                                                                                            |
 
 

--- a/ingestion_tools/infra/db_import-v0.0.2.wdl
+++ b/ingestion_tools/infra/db_import-v0.0.2.wdl
@@ -1,0 +1,114 @@
+version 1.0
+
+task cryoet_data_dbimport_workflow {
+    input {
+        String docker_image_id
+        String aws_region
+        String s3_bucket
+        String https_prefix
+        String environment
+        String flags
+    }
+
+    command <<<
+        set -euxo pipefail
+        export PYTHONUNBUFFERED=1
+        python --version 1>&2
+        ls -l 1>&2
+        original_dir=$(pwd)
+        cd /usr/src/app/ingestion_tools/scripts
+        set +x
+        POSTGRES_URL=$(aws secretsmanager get-secret-value --secret-id ~{environment}/db_uri | jq -r .SecretString | jq -r .db_uri)
+        echo python db_import.py load ~{s3_bucket} ~{https_prefix} POSTGRES_URL ~{flags} 1>&2
+        python db_import.py load ~{s3_bucket} ~{https_prefix} $POSTGRES_URL ~{flags} 1>&2
+        cd $original_dir
+        echo "done" > done.txt
+    >>>
+
+    runtime {
+        docker: docker_image_id
+    }
+    output {
+        String done = read_string("done.txt")
+    }
+}
+
+task cryoet_data_dbimport_v2_workflow {
+    input {
+        String done
+        String docker_image_id = "apiv2-x86:latest"
+        String aws_region
+        String s3_bucket
+        String https_prefix
+        String environment
+        String scrape_flags
+        String flags
+    }
+
+    command <<<
+        set -euxo pipefail
+        export PYTHONUNBUFFERED=1
+        python --version 1>&2
+        ls -l 1>&2
+        pwd 1>&2
+        set +x
+        apt install -y curl unzip jq
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip -q awscliv2.zip && ./aws/install && rm -rf ./aws
+        pip install psycopg2-binary
+        POSTGRES_URL=$(aws secretsmanager get-secret-value --secret-id ~{environment}/v2_db_uri | jq -r .SecretString | jq -r .db_uri)
+        # TODO - Scrape ID's from the v1 api so we keep things in sync
+        pip install cryoet-data-portal==3.1.1
+        cd /app
+        # Scrape ID's from the v1 api so we keep things in sync
+        echo "Scrape v1 IDs"
+        echo python3 -m scripts.scrape ~{environment} --db-uri POSTGRES_URL ~{scrape_flags} 1>&2
+        python3 -m scripts.scrape ~{environment} --db-uri $POSTGRES_URL ~{scrape_flags} 1>&2
+        # Read data from s3 into the v2 db.
+        echo "Load data from s3" 1>&2
+        echo  python3 -m db_import.importer load --postgres_url POSTGRES_URL ~{s3_bucket} ~{https_prefix} ~{flags} 1>&2
+        python3 -m db_import.importer load --postgres_url $POSTGRES_URL ~{s3_bucket} ~{https_prefix} ~{flags} 1>&2
+    >>>
+
+    runtime {
+        docker: docker_image_id
+    }
+}
+
+workflow cryoet_data_dbimport {
+    input {
+        String v2_docker_image_id = "cryoet_data_ingestion:latest"
+        String docker_image_id = "cryoet_data_ingestion:latest"
+        String aws_region = "us-west-2"
+        String s3_bucket = "cryoet-data-portal-staging"
+        String https_prefix
+        String environment
+        String flags
+        String scrape_flags
+    }
+
+    call cryoet_data_dbimport_workflow {
+        input:
+        docker_image_id = docker_image_id,
+        aws_region = aws_region,
+        s3_bucket = s3_bucket,
+        https_prefix = https_prefix,
+        environment = environment,
+        flags = flags
+    }
+
+    call cryoet_data_dbimport_v2_workflow {
+        input:
+        done = cryoet_data_dbimport_workflow.done,
+        docker_image_id = v2_docker_image_id,
+        aws_region = aws_region,
+        s3_bucket = s3_bucket,
+        https_prefix = https_prefix,
+        environment = environment,
+        scrape_flags = scrape_flags,
+        flags = flags
+    }
+
+    output {
+        File log = "output.txt"
+    }
+}

--- a/ingestion_tools/scripts/enqueue_runs.py
+++ b/ingestion_tools/scripts/enqueue_runs.py
@@ -127,6 +127,7 @@ def run_job(
 
     session = Session(region_name=aws_region)
     client = session.client(service_name="stepfunctions")
+    print(json.dumps(sfn_input_json, indent=4))
     return client.start_execution(
         stateMachineArn=state_machine_arn,
         name=execution_name,
@@ -241,7 +242,7 @@ def to_args(**kwargs) -> list[str]:
     "--swipe-wdl-key",
     type=str,
     required=True,
-    default="db_import-v0.0.1.wdl",
+    default="db_import-v0.0.2.wdl",
     help="Specify wdl key for custom workload",
 )
 @db_import_options
@@ -294,6 +295,11 @@ def db_import(
             new_args.append(f"--s3-prefix {dataset_id}")
             if debug:
                 new_args.append("--debug")
+            scrape_args = ["--import-dataset", f"{dataset_id}"]
+            for idx, arg in enumerate(new_args):
+                if arg == "--deposition-id":
+                    scrape_args.append("--import-deposition")
+                    scrape_args.append(new_args[idx + 1])
 
             execution_name = f"{int(time.time())}-dbimport-{dataset_id}"
 
@@ -301,11 +307,15 @@ def db_import(
             if len(execution_name) > 80:
                 execution_name = execution_name[-80:]
 
+            aws_region = ctx.obj["aws_region"]
+            ecr_tag = ctx.obj["ecr_tag"]
             wdl_args = {
                 "s3_bucket": s3_bucket,
                 "https_prefix": https_prefix,
                 "flags": " ".join(new_args),
+                "scrape_flags": " ".join(scrape_args),
                 "environment": ctx.obj["environment"],
+                "v2_docker_image_id": f"908710317728.dkr.ecr.{aws_region}.amazonaws.com/apiv2-x86:{ecr_tag}",
             }
             futures.append(
                 workerpool.submit(

--- a/ingestion_tools/scripts/enqueue_runs.py
+++ b/ingestion_tools/scripts/enqueue_runs.py
@@ -127,7 +127,6 @@ def run_job(
 
     session = Session(region_name=aws_region)
     client = session.client(service_name="stepfunctions")
-    print(json.dumps(sfn_input_json, indent=4))
     return client.start_execution(
         stateMachineArn=state_machine_arn,
         name=execution_name,


### PR DESCRIPTION
This adds a new WDL file that supports ingesting data into the v1 and v2 db's with the same `enqueue_runs.py` command. The docker image necessary to do this has already been added to our CI workflows.

NOTE: the WDL files have already been uploaded to s3, so this is ready to go.
