### PR TITLE
chore: Workaround for py3.12 on osx issue.

### DIFF
--- a/ingestion_tools/scripts/db_import.py
+++ b/ingestion_tools/scripts/db_import.py
@@ -27,6 +27,7 @@ def cli():
 
 def db_import_options(func):
     options = []
+    options.append(click.option("--import-alignments", is_flag=True, default=False))
     options.append(click.option("--import-annotations", is_flag=True, default=False))
     options.append(click.option("--import-annotation-authors", is_flag=True, default=False))
     options.append(click.option("--import-dataset-authors", is_flag=True, default=False))
@@ -78,6 +79,7 @@ def load(
     anonymous: bool,
     debug: bool,
     filter_dataset: list[str],
+    import_alignments: bool, # noqa
     import_annotations: bool,
     import_annotation_authors: bool,
     import_dataset_authors: bool,

--- a/ingestion_tools/scripts/db_import.py
+++ b/ingestion_tools/scripts/db_import.py
@@ -27,7 +27,6 @@ def cli():
 
 def db_import_options(func):
     options = []
-    options.append(click.option("--import-alignments", is_flag=True, default=False))
     options.append(click.option("--import-annotations", is_flag=True, default=False))
     options.append(click.option("--import-annotation-authors", is_flag=True, default=False))
     options.append(click.option("--import-dataset-authors", is_flag=True, default=False))
@@ -79,7 +78,6 @@ def load(
     anonymous: bool,
     debug: bool,
     filter_dataset: list[str],
-    import_alignments: bool, # noqa
     import_annotations: bool,
     import_annotation_authors: bool,
     import_dataset_authors: bool,

--- a/ingestion_tools/scripts/importers/visualization_precompute.py
+++ b/ingestion_tools/scripts/importers/visualization_precompute.py
@@ -88,6 +88,8 @@ class PointAnnotationPrecompute(BaseAnnotationPrecompute):
         precompute_path = self._get_neuroglancer_precompute_path(annotation_path, output_prefix)
         metadata = self.annotation.metadata
         tmp_path = fs.localwritable(precompute_path)
+        # Importing this at runtime instead of compile time since the dependencies of this
+        # module prevent any of our data ingestion scripts from being executed on darwin/ARM
         from cryoet_data_portal_neuroglancer.precompute import points
 
         points.encode_annotation(

--- a/ingestion_tools/scripts/importers/visualization_precompute.py
+++ b/ingestion_tools/scripts/importers/visualization_precompute.py
@@ -88,8 +88,8 @@ class PointAnnotationPrecompute(BaseAnnotationPrecompute):
         precompute_path = self._get_neuroglancer_precompute_path(annotation_path, output_prefix)
         metadata = self.annotation.metadata
         tmp_path = fs.localwritable(precompute_path)
-        # Importing this at runtime instead of compile time since the dependencies of this
-        # module prevent any of our data ingestion scripts from being executed on darwin/ARM
+        # Importing this at runtime instead of compile time since zfpy (a dependency of this
+        # module) cannot be imported successfully on darwin/ARM machines.
         from cryoet_data_portal_neuroglancer.precompute import points
 
         points.encode_annotation(
@@ -138,6 +138,8 @@ class SegmentationMaskAnnotationPrecompute(BaseAnnotationPrecompute):
         precompute_path = self._get_neuroglancer_precompute_path(annotation_path, output_prefix)
         tmp_path = fs.localwritable(precompute_path)
         zarr_file_path = fs.destformat(self.annotation.get_output_filename(annotation_path, "zarr"))
+        # Importing this at runtime instead of compile time since zfpy (a dependency of this
+        # module) cannot be imported successfully on darwin/ARM machines.
         from cryoet_data_portal_neuroglancer.precompute import segmentation_mask
 
         segmentation_mask.encode_segmentation(

--- a/ingestion_tools/scripts/importers/visualization_precompute.py
+++ b/ingestion_tools/scripts/importers/visualization_precompute.py
@@ -2,8 +2,6 @@ import os
 from pathlib import Path
 from typing import Any
 
-from cryoet_data_portal_neuroglancer.precompute import points, segmentation_mask
-
 from common import colors
 from common.config import DepositionImportConfig
 from common.finders import DefaultImporterFactory
@@ -90,6 +88,8 @@ class PointAnnotationPrecompute(BaseAnnotationPrecompute):
         precompute_path = self._get_neuroglancer_precompute_path(annotation_path, output_prefix)
         metadata = self.annotation.metadata
         tmp_path = fs.localwritable(precompute_path)
+        from cryoet_data_portal_neuroglancer.precompute import points
+
         points.encode_annotation(
             self.annotation.get_output_data(annotation_path),
             metadata,
@@ -136,6 +136,8 @@ class SegmentationMaskAnnotationPrecompute(BaseAnnotationPrecompute):
         precompute_path = self._get_neuroglancer_precompute_path(annotation_path, output_prefix)
         tmp_path = fs.localwritable(precompute_path)
         zarr_file_path = fs.destformat(self.annotation.get_output_filename(annotation_path, "zarr"))
+        from cryoet_data_portal_neuroglancer.precompute import segmentation_mask
+
         segmentation_mask.encode_segmentation(
             zarr_file_path,
             Path(tmp_path),


### PR DESCRIPTION
zfpy is a sub-sub-sub-dependency of our ingestion scripts, and it does not work properly with Python 3.12 on ARM macs. This workaround only imports the module when it's actually required and allows us to keep running enqueue scripts from our laptops.

(more traceback and info will be added to this ticket later)