### PR TITLE
fix: db_import updates for alignments

### DIFF
--- a/ingestion_tools/scripts/db_import.py
+++ b/ingestion_tools/scripts/db_import.py
@@ -27,6 +27,7 @@ def cli():
 
 def db_import_options(func):
     options = []
+    options.append(click.option("--import-alignments", is_flag=True, default=False))
     options.append(click.option("--import-annotations", is_flag=True, default=False))
     options.append(click.option("--import-annotation-authors", is_flag=True, default=False))
     options.append(click.option("--import-dataset-authors", is_flag=True, default=False))
@@ -78,6 +79,7 @@ def load(
     anonymous: bool,
     debug: bool,
     filter_dataset: list[str],
+    import_alignments: bool, # noqa
     import_annotations: bool,
     import_annotation_authors: bool,
     import_dataset_authors: bool,


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
When running `enqueue_runs.py` with `--import-alignments` flag it will fail for v1 since that flag doesn't exist. This adds this flag to the function definition as a workaround to make sure the job does not fail when importing with the alignments flag.

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
