### PR TITLE
fix: remove tiltseries_id check from alignment importer

### DIFF
--- a/apiv2/db_import/importers/alignment.py
+++ b/apiv2/db_import/importers/alignment.py
@@ -52,8 +52,6 @@ class AlignmentItem(ItemDBImporter):
         self.model_args["https_alignment_metadata"] = self.get_https_url(self.input_data["file"])
         if self.input_data.get("tiltseries_path"):
             self.model_args["tiltseries_id"] = self.config.get_tiltseries_by_path(self.input_data["tiltseries_path"])
-        if not self.model_args["tiltseries_id"]:
-            raise Exception("tiltseries id is required")
         self.model_args["run_id"] = self.input_data["run"].id
 
 


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to

https://github.com/chanzuckerberg/cryoet-data-portal-backend/pull/369

## Description

Removes `tiltseries_id` verification from the alignment importer
