### PR TITLE
fix: support __typename fields in gql queries

### DIFF
--- a/apiv2/conftest.py
+++ b/apiv2/conftest.py
@@ -3,6 +3,7 @@ Fixtures for API tests
 """
 
 import json
+import operator
 import os
 import typing
 from typing import Optional
@@ -69,7 +70,6 @@ def get_db_uri(
 
 @pytest.fixture()
 def test_db_uri(test_db: NoopExecutor) -> str:
-
     return get_db_uri(
         db_host=test_db.host,
         db_port=test_db.port,
@@ -234,3 +234,37 @@ async def api_test_schema(async_db: AsyncDB) -> FastAPI:
     api = get_app(settings, schema)
     overwrite_api(api, async_db)
     return api
+
+
+# Helper for checking deep equality of python dict/list objects
+# Source: https://gist.github.com/samuraisam/901117/521ed1ff8937cb43d7fcdbc1a6f6d0ed2c723bae
+def deep_eq(_v1, _v2):
+    def _deep_dict_eq(d1, d2):
+        k1 = sorted(d1.keys())
+        k2 = sorted(d2.keys())
+        if k1 != k2:  # keys should be exactly equal
+            return False
+        return sum(deep_eq(d1[k], d2[k]) for k in k1) == len(k1)
+
+    def _deep_iter_eq(l1, l2):
+        if len(l1) != len(l2):
+            return False
+        return sum(deep_eq(v1, v2) for v1, v2 in zip(l1, l2, strict=False)) == len(l1)
+
+    op = operator.eq
+    c1, c2 = (_v1, _v2)
+
+    # guard against strings because they are also iterable
+    # and will consistently cause a RuntimeError (maximum recursion limit reached)
+    if not isinstance(_v1, str):
+        if isinstance(_v1, dict):
+            op = _deep_dict_eq
+        else:
+            try:
+                c1, c2 = (list(iter(_v1)), list(iter(_v2)))
+            except TypeError:
+                c1, c2 = _v1, _v2
+            else:
+                op = _deep_iter_eq
+
+    return op(c1, c2)

--- a/apiv2/conftest.py
+++ b/apiv2/conftest.py
@@ -3,7 +3,6 @@ Fixtures for API tests
 """
 
 import json
-import operator
 import os
 import typing
 from typing import Optional
@@ -234,37 +233,3 @@ async def api_test_schema(async_db: AsyncDB) -> FastAPI:
     api = get_app(settings, schema)
     overwrite_api(api, async_db)
     return api
-
-
-# Helper for checking deep equality of python dict/list objects
-# Source: https://gist.github.com/samuraisam/901117/521ed1ff8937cb43d7fcdbc1a6f6d0ed2c723bae
-def deep_eq(_v1, _v2):
-    def _deep_dict_eq(d1, d2):
-        k1 = sorted(d1.keys())
-        k2 = sorted(d2.keys())
-        if k1 != k2:  # keys should be exactly equal
-            return False
-        return sum(deep_eq(d1[k], d2[k]) for k in k1) == len(k1)
-
-    def _deep_iter_eq(l1, l2):
-        if len(l1) != len(l2):
-            return False
-        return sum(deep_eq(v1, v2) for v1, v2 in zip(l1, l2, strict=False)) == len(l1)
-
-    op = operator.eq
-    c1, c2 = (_v1, _v2)
-
-    # guard against strings because they are also iterable
-    # and will consistently cause a RuntimeError (maximum recursion limit reached)
-    if not isinstance(_v1, str):
-        if isinstance(_v1, dict):
-            op = _deep_dict_eq
-        else:
-            try:
-                c1, c2 = (list(iter(_v1)), list(iter(_v2)))
-            except TypeError:
-                c1, c2 = _v1, _v2
-            else:
-                op = _deep_iter_eq
-
-    return op(c1, c2)

--- a/apiv2/graphql_api/types/alignment.py
+++ b/apiv2/graphql_api/types/alignment.py
@@ -53,35 +53,62 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.annotation_file import AnnotationFile, AnnotationFileOrderByClause, AnnotationFileWhereClause
-    from graphql_api.types.deposition import Deposition, DepositionOrderByClause, DepositionWhereClause
+    from graphql_api.types.annotation_file import (
+        AnnotationFile,
+        AnnotationFileAggregateWhereClause,
+        AnnotationFileOrderByClause,
+        AnnotationFileWhereClause,
+    )
+    from graphql_api.types.deposition import (
+        Deposition,
+        DepositionAggregateWhereClause,
+        DepositionOrderByClause,
+        DepositionWhereClause,
+    )
     from graphql_api.types.per_section_alignment_parameters import (
         PerSectionAlignmentParameters,
+        PerSectionAlignmentParametersAggregateWhereClause,
         PerSectionAlignmentParametersOrderByClause,
         PerSectionAlignmentParametersWhereClause,
     )
-    from graphql_api.types.run import Run, RunOrderByClause, RunWhereClause
-    from graphql_api.types.tiltseries import Tiltseries, TiltseriesOrderByClause, TiltseriesWhereClause
-    from graphql_api.types.tomogram import Tomogram, TomogramOrderByClause, TomogramWhereClause
+    from graphql_api.types.run import Run, RunAggregateWhereClause, RunOrderByClause, RunWhereClause
+    from graphql_api.types.tiltseries import (
+        Tiltseries,
+        TiltseriesAggregateWhereClause,
+        TiltseriesOrderByClause,
+        TiltseriesWhereClause,
+    )
+    from graphql_api.types.tomogram import (
+        Tomogram,
+        TomogramAggregateWhereClause,
+        TomogramOrderByClause,
+        TomogramWhereClause,
+    )
 
     pass
 else:
     AnnotationFileWhereClause = "AnnotationFileWhereClause"
+    AnnotationFileAggregateWhereClause = "AnnotationFileAggregateWhereClause"
     AnnotationFile = "AnnotationFile"
     AnnotationFileOrderByClause = "AnnotationFileOrderByClause"
     PerSectionAlignmentParametersWhereClause = "PerSectionAlignmentParametersWhereClause"
+    PerSectionAlignmentParametersAggregateWhereClause = "PerSectionAlignmentParametersAggregateWhereClause"
     PerSectionAlignmentParameters = "PerSectionAlignmentParameters"
     PerSectionAlignmentParametersOrderByClause = "PerSectionAlignmentParametersOrderByClause"
     DepositionWhereClause = "DepositionWhereClause"
+    DepositionAggregateWhereClause = "DepositionAggregateWhereClause"
     Deposition = "Deposition"
     DepositionOrderByClause = "DepositionOrderByClause"
     TiltseriesWhereClause = "TiltseriesWhereClause"
+    TiltseriesAggregateWhereClause = "TiltseriesAggregateWhereClause"
     Tiltseries = "Tiltseries"
     TiltseriesOrderByClause = "TiltseriesOrderByClause"
     TomogramWhereClause = "TomogramWhereClause"
+    TomogramAggregateWhereClause = "TomogramAggregateWhereClause"
     Tomogram = "Tomogram"
     TomogramOrderByClause = "TomogramOrderByClause"
     RunWhereClause = "RunWhereClause"
+    RunAggregateWhereClause = "RunAggregateWhereClause"
     Run = "Run"
     RunOrderByClause = "RunOrderByClause"
     pass
@@ -289,10 +316,23 @@ class AlignmentWhereClause(TypedDict):
     annotation_files: (
         Optional[Annotated["AnnotationFileWhereClause", strawberry.lazy("graphql_api.types.annotation_file")]] | None
     )
+    annotation_files_aggregate: (
+        Optional[Annotated["AnnotationFileAggregateWhereClause", strawberry.lazy("graphql_api.types.annotation_file")]]
+        | None
+    )
     per_section_alignments: (
         Optional[
             Annotated[
                 "PerSectionAlignmentParametersWhereClause",
+                strawberry.lazy("graphql_api.types.per_section_alignment_parameters"),
+            ]
+        ]
+        | None
+    )
+    per_section_alignments_aggregate: (
+        Optional[
+            Annotated[
+                "PerSectionAlignmentParametersAggregateWhereClause",
                 strawberry.lazy("graphql_api.types.per_section_alignment_parameters"),
             ]
         ]
@@ -303,6 +343,9 @@ class AlignmentWhereClause(TypedDict):
     tiltseries: Optional[Annotated["TiltseriesWhereClause", strawberry.lazy("graphql_api.types.tiltseries")]] | None
     tiltseries_id: Optional[IntComparators] | None
     tomograms: Optional[Annotated["TomogramWhereClause", strawberry.lazy("graphql_api.types.tomogram")]] | None
+    tomograms_aggregate: (
+        Optional[Annotated["TomogramAggregateWhereClause", strawberry.lazy("graphql_api.types.tomogram")]] | None
+    )
     run: Optional[Annotated["RunWhereClause", strawberry.lazy("graphql_api.types.run")]] | None
     run_id: Optional[IntComparators] | None
     alignment_type: Optional[EnumComparators[alignment_type_enum]] | None
@@ -491,12 +534,6 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class AlignmentCountColumns(enum.Enum):
-    annotationFiles = "annotation_files"
-    perSectionAlignments = "per_section_alignments"
-    deposition = "deposition"
-    tiltseries = "tiltseries"
-    tomograms = "tomograms"
-    run = "run"
     alignmentType = "alignment_type"
     alignmentMethod = "alignment_method"
     volumeXDimension = "volume_x_dimension"
@@ -512,6 +549,24 @@ class AlignmentCountColumns(enum.Enum):
     httpsAlignmentMetadata = "https_alignment_metadata"
     isPortalStandard = "is_portal_standard"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class AlignmentAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["AlignmentCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[AlignmentWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class AlignmentAggregateWhereClause(TypedDict):
+    count: AlignmentAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/annotation.py
+++ b/apiv2/graphql_api/types/annotation.py
@@ -56,37 +56,50 @@ T = typing.TypeVar("T")
 if TYPE_CHECKING:
     from graphql_api.types.annotation_author import (
         AnnotationAuthor,
+        AnnotationAuthorAggregateWhereClause,
         AnnotationAuthorOrderByClause,
         AnnotationAuthorWhereClause,
     )
     from graphql_api.types.annotation_method_link import (
         AnnotationMethodLink,
+        AnnotationMethodLinkAggregateWhereClause,
         AnnotationMethodLinkOrderByClause,
         AnnotationMethodLinkWhereClause,
     )
     from graphql_api.types.annotation_shape import (
         AnnotationShape,
+        AnnotationShapeAggregateWhereClause,
         AnnotationShapeOrderByClause,
         AnnotationShapeWhereClause,
     )
-    from graphql_api.types.deposition import Deposition, DepositionOrderByClause, DepositionWhereClause
-    from graphql_api.types.run import Run, RunOrderByClause, RunWhereClause
+    from graphql_api.types.deposition import (
+        Deposition,
+        DepositionAggregateWhereClause,
+        DepositionOrderByClause,
+        DepositionWhereClause,
+    )
+    from graphql_api.types.run import Run, RunAggregateWhereClause, RunOrderByClause, RunWhereClause
 
     pass
 else:
     RunWhereClause = "RunWhereClause"
+    RunAggregateWhereClause = "RunAggregateWhereClause"
     Run = "Run"
     RunOrderByClause = "RunOrderByClause"
     AnnotationShapeWhereClause = "AnnotationShapeWhereClause"
+    AnnotationShapeAggregateWhereClause = "AnnotationShapeAggregateWhereClause"
     AnnotationShape = "AnnotationShape"
     AnnotationShapeOrderByClause = "AnnotationShapeOrderByClause"
     AnnotationMethodLinkWhereClause = "AnnotationMethodLinkWhereClause"
+    AnnotationMethodLinkAggregateWhereClause = "AnnotationMethodLinkAggregateWhereClause"
     AnnotationMethodLink = "AnnotationMethodLink"
     AnnotationMethodLinkOrderByClause = "AnnotationMethodLinkOrderByClause"
     AnnotationAuthorWhereClause = "AnnotationAuthorWhereClause"
+    AnnotationAuthorAggregateWhereClause = "AnnotationAuthorAggregateWhereClause"
     AnnotationAuthor = "AnnotationAuthor"
     AnnotationAuthorOrderByClause = "AnnotationAuthorOrderByClause"
     DepositionWhereClause = "DepositionWhereClause"
+    DepositionAggregateWhereClause = "DepositionAggregateWhereClause"
     Deposition = "Deposition"
     DepositionOrderByClause = "DepositionOrderByClause"
     pass
@@ -270,14 +283,34 @@ class AnnotationWhereClause(TypedDict):
     annotation_shapes: (
         Optional[Annotated["AnnotationShapeWhereClause", strawberry.lazy("graphql_api.types.annotation_shape")]] | None
     )
+    annotation_shapes_aggregate: (
+        Optional[
+            Annotated["AnnotationShapeAggregateWhereClause", strawberry.lazy("graphql_api.types.annotation_shape")]
+        ]
+        | None
+    )
     method_links: (
         Optional[
             Annotated["AnnotationMethodLinkWhereClause", strawberry.lazy("graphql_api.types.annotation_method_link")]
         ]
         | None
     )
+    method_links_aggregate: (
+        Optional[
+            Annotated[
+                "AnnotationMethodLinkAggregateWhereClause", strawberry.lazy("graphql_api.types.annotation_method_link"),
+            ]
+        ]
+        | None
+    )
     authors: (
         Optional[Annotated["AnnotationAuthorWhereClause", strawberry.lazy("graphql_api.types.annotation_author")]]
+        | None
+    )
+    authors_aggregate: (
+        Optional[
+            Annotated["AnnotationAuthorAggregateWhereClause", strawberry.lazy("graphql_api.types.annotation_author")]
+        ]
         | None
     )
     deposition: Optional[Annotated["DepositionWhereClause", strawberry.lazy("graphql_api.types.deposition")]] | None
@@ -484,11 +517,6 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class AnnotationCountColumns(enum.Enum):
-    run = "run"
-    annotationShapes = "annotation_shapes"
-    methodLinks = "method_links"
-    authors = "authors"
-    deposition = "deposition"
     s3MetadataPath = "s3_metadata_path"
     httpsMetadataPath = "https_metadata_path"
     annotationPublication = "annotation_publication"
@@ -509,6 +537,24 @@ class AnnotationCountColumns(enum.Enum):
     releaseDate = "release_date"
     lastModifiedDate = "last_modified_date"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class AnnotationAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["AnnotationCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[AnnotationWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class AnnotationAggregateWhereClause(TypedDict):
+    count: AnnotationAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/annotation_author.py
+++ b/apiv2/graphql_api/types/annotation_author.py
@@ -37,6 +37,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -450,10 +451,7 @@ async def resolve_annotation_authors_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/annotation_author.py
+++ b/apiv2/graphql_api/types/annotation_author.py
@@ -43,11 +43,17 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.annotation import Annotation, AnnotationOrderByClause, AnnotationWhereClause
+    from graphql_api.types.annotation import (
+        Annotation,
+        AnnotationAggregateWhereClause,
+        AnnotationOrderByClause,
+        AnnotationWhereClause,
+    )
 
     pass
 else:
     AnnotationWhereClause = "AnnotationWhereClause"
+    AnnotationAggregateWhereClause = "AnnotationAggregateWhereClause"
     Annotation = "Annotation"
     AnnotationOrderByClause = "AnnotationOrderByClause"
     pass
@@ -221,7 +227,6 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class AnnotationAuthorCountColumns(enum.Enum):
-    annotation = "annotation"
     id = "id"
     authorListOrder = "author_list_order"
     orcid = "orcid"
@@ -232,6 +237,24 @@ class AnnotationAuthorCountColumns(enum.Enum):
     affiliationIdentifier = "affiliation_identifier"
     correspondingAuthorStatus = "corresponding_author_status"
     primaryAuthorStatus = "primary_author_status"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class AnnotationAuthorAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["AnnotationAuthorCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[AnnotationAuthorWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class AnnotationAuthorAggregateWhereClause(TypedDict):
+    count: AnnotationAuthorAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/annotation_file.py
+++ b/apiv2/graphql_api/types/annotation_file.py
@@ -39,6 +39,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -485,10 +486,7 @@ async def resolve_annotation_files_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/annotation_file.py
+++ b/apiv2/graphql_api/types/annotation_file.py
@@ -45,14 +45,21 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.alignment import Alignment, AlignmentOrderByClause, AlignmentWhereClause
+    from graphql_api.types.alignment import (
+        Alignment,
+        AlignmentAggregateWhereClause,
+        AlignmentOrderByClause,
+        AlignmentWhereClause,
+    )
     from graphql_api.types.annotation_shape import (
         AnnotationShape,
+        AnnotationShapeAggregateWhereClause,
         AnnotationShapeOrderByClause,
         AnnotationShapeWhereClause,
     )
     from graphql_api.types.tomogram_voxel_spacing import (
         TomogramVoxelSpacing,
+        TomogramVoxelSpacingAggregateWhereClause,
         TomogramVoxelSpacingOrderByClause,
         TomogramVoxelSpacingWhereClause,
     )
@@ -60,12 +67,15 @@ if TYPE_CHECKING:
     pass
 else:
     AlignmentWhereClause = "AlignmentWhereClause"
+    AlignmentAggregateWhereClause = "AlignmentAggregateWhereClause"
     Alignment = "Alignment"
     AlignmentOrderByClause = "AlignmentOrderByClause"
     AnnotationShapeWhereClause = "AnnotationShapeWhereClause"
+    AnnotationShapeAggregateWhereClause = "AnnotationShapeAggregateWhereClause"
     AnnotationShape = "AnnotationShape"
     AnnotationShapeOrderByClause = "AnnotationShapeOrderByClause"
     TomogramVoxelSpacingWhereClause = "TomogramVoxelSpacingWhereClause"
+    TomogramVoxelSpacingAggregateWhereClause = "TomogramVoxelSpacingAggregateWhereClause"
     TomogramVoxelSpacing = "TomogramVoxelSpacing"
     TomogramVoxelSpacingOrderByClause = "TomogramVoxelSpacingOrderByClause"
     pass
@@ -276,15 +286,30 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class AnnotationFileCountColumns(enum.Enum):
-    alignment = "alignment"
-    annotationShape = "annotation_shape"
-    tomogramVoxelSpacing = "tomogram_voxel_spacing"
     format = "format"
     s3Path = "s3_path"
     httpsPath = "https_path"
     isVisualizationDefault = "is_visualization_default"
     source = "source"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class AnnotationFileAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["AnnotationFileCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[AnnotationFileWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class AnnotationFileAggregateWhereClause(TypedDict):
+    count: AnnotationFileAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/annotation_method_link.py
+++ b/apiv2/graphql_api/types/annotation_method_link.py
@@ -50,11 +50,17 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.annotation import Annotation, AnnotationOrderByClause, AnnotationWhereClause
+    from graphql_api.types.annotation import (
+        Annotation,
+        AnnotationAggregateWhereClause,
+        AnnotationOrderByClause,
+        AnnotationWhereClause,
+    )
 
     pass
 else:
     AnnotationWhereClause = "AnnotationWhereClause"
+    AnnotationAggregateWhereClause = "AnnotationAggregateWhereClause"
     Annotation = "Annotation"
     AnnotationOrderByClause = "AnnotationOrderByClause"
     pass
@@ -193,11 +199,28 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class AnnotationMethodLinkCountColumns(enum.Enum):
-    annotation = "annotation"
     linkType = "link_type"
     name = "name"
     link = "link"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class AnnotationMethodLinkAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["AnnotationMethodLinkCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[AnnotationMethodLinkWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class AnnotationMethodLinkAggregateWhereClause(TypedDict):
+    count: AnnotationMethodLinkAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/annotation_method_link.py
+++ b/apiv2/graphql_api/types/annotation_method_link.py
@@ -44,6 +44,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -376,10 +377,7 @@ async def resolve_annotation_method_links_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/annotation_shape.py
+++ b/apiv2/graphql_api/types/annotation_shape.py
@@ -45,15 +45,27 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.annotation import Annotation, AnnotationOrderByClause, AnnotationWhereClause
-    from graphql_api.types.annotation_file import AnnotationFile, AnnotationFileOrderByClause, AnnotationFileWhereClause
+    from graphql_api.types.annotation import (
+        Annotation,
+        AnnotationAggregateWhereClause,
+        AnnotationOrderByClause,
+        AnnotationWhereClause,
+    )
+    from graphql_api.types.annotation_file import (
+        AnnotationFile,
+        AnnotationFileAggregateWhereClause,
+        AnnotationFileOrderByClause,
+        AnnotationFileWhereClause,
+    )
 
     pass
 else:
     AnnotationWhereClause = "AnnotationWhereClause"
+    AnnotationAggregateWhereClause = "AnnotationAggregateWhereClause"
     Annotation = "Annotation"
     AnnotationOrderByClause = "AnnotationOrderByClause"
     AnnotationFileWhereClause = "AnnotationFileWhereClause"
+    AnnotationFileAggregateWhereClause = "AnnotationFileAggregateWhereClause"
     AnnotationFile = "AnnotationFile"
     AnnotationFileOrderByClause = "AnnotationFileOrderByClause"
     pass
@@ -146,6 +158,10 @@ class AnnotationShapeWhereClause(TypedDict):
     annotation_files: (
         Optional[Annotated["AnnotationFileWhereClause", strawberry.lazy("graphql_api.types.annotation_file")]] | None
     )
+    annotation_files_aggregate: (
+        Optional[Annotated["AnnotationFileAggregateWhereClause", strawberry.lazy("graphql_api.types.annotation_file")]]
+        | None
+    )
     shape_type: Optional[EnumComparators[annotation_file_shape_type_enum]] | None
     id: Optional[IntComparators] | None
 
@@ -226,10 +242,26 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class AnnotationShapeCountColumns(enum.Enum):
-    annotation = "annotation"
-    annotationFiles = "annotation_files"
     shapeType = "shape_type"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class AnnotationShapeAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["AnnotationShapeCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[AnnotationShapeWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class AnnotationShapeAggregateWhereClause(TypedDict):
+    count: AnnotationShapeAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/dataset.py
+++ b/apiv2/graphql_api/types/dataset.py
@@ -7,7 +7,6 @@ Make changes to the template codegen/templates/graphql_api/types/class_name.py.j
 
 # ruff: noqa: E501 Line too long
 
-
 import datetime
 import enum
 import typing
@@ -52,7 +51,7 @@ if TYPE_CHECKING:
     from graphql_api.types.dataset_author import DatasetAuthor, DatasetAuthorOrderByClause, DatasetAuthorWhereClause
     from graphql_api.types.dataset_funding import DatasetFunding, DatasetFundingOrderByClause, DatasetFundingWhereClause
     from graphql_api.types.deposition import Deposition, DepositionOrderByClause, DepositionWhereClause
-    from graphql_api.types.run import Run, RunOrderByClause, RunWhereClause
+    from graphql_api.types.run import Run, RunOrderByClause, RunAggregateWhereClause, RunWhereClause
 
     pass
 else:
@@ -66,6 +65,7 @@ else:
     DatasetAuthor = "DatasetAuthor"
     DatasetAuthorOrderByClause = "DatasetAuthorOrderByClause"
     RunWhereClause = "RunWhereClause"
+    RunAggregateWhereClause = "RunAggregateWhereClause"
     Run = "Run"
     RunOrderByClause = "RunOrderByClause"
     pass
@@ -95,9 +95,7 @@ async def load_deposition_rows(
 
 
 @relay.connection(
-    relay.ListConnection[
-        Annotated["DatasetFunding", strawberry.lazy("graphql_api.types.dataset_funding")]
-    ],  # type:ignore
+    relay.ListConnection[Annotated["DatasetFunding", strawberry.lazy("graphql_api.types.dataset_funding")]],  # type:ignore
 )
 async def load_dataset_funding_rows(
     root: "Dataset",
@@ -222,6 +220,7 @@ class DatasetWhereClause(TypedDict):
     )
     authors: Optional[Annotated["DatasetAuthorWhereClause", strawberry.lazy("graphql_api.types.dataset_author")]] | None
     runs: Optional[Annotated["RunWhereClause", strawberry.lazy("graphql_api.types.run")]] | None
+    runs_aggregate: Optional[Annotated["RunAggregateWhereClause", strawberry.lazy("graphql_api.types.run")]] | None
     title: Optional[StrComparators] | None
     description: Optional[StrComparators] | None
     organism_name: Optional[StrComparators] | None
@@ -294,25 +293,25 @@ Define Dataset type
 @strawberry.type(description="A collection of imaging experiments on the same organism")
 class Dataset(EntityInterface):
     deposition: Optional[Annotated["Deposition", strawberry.lazy("graphql_api.types.deposition")]] = (
-        load_deposition_rows
-    )  # type:ignore
+        load_deposition_rows  # type:ignore
+    )
     deposition_id: int
     funding_sources: Sequence[Annotated["DatasetFunding", strawberry.lazy("graphql_api.types.dataset_funding")]] = (
-        load_dataset_funding_rows
-    )  # type:ignore
+        load_dataset_funding_rows  # type:ignore
+    )
     funding_sources_aggregate: Optional[
         Annotated["DatasetFundingAggregate", strawberry.lazy("graphql_api.types.dataset_funding")]
     ] = load_dataset_funding_aggregate_rows  # type:ignore
     authors: Sequence[Annotated["DatasetAuthor", strawberry.lazy("graphql_api.types.dataset_author")]] = (
-        load_dataset_author_rows
-    )  # type:ignore
+        load_dataset_author_rows  # type:ignore
+    )
     authors_aggregate: Optional[
         Annotated["DatasetAuthorAggregate", strawberry.lazy("graphql_api.types.dataset_author")]
     ] = load_dataset_author_aggregate_rows  # type:ignore
     runs: Sequence[Annotated["Run", strawberry.lazy("graphql_api.types.run")]] = load_run_rows  # type:ignore
     runs_aggregate: Optional[Annotated["RunAggregate", strawberry.lazy("graphql_api.types.run")]] = (
-        load_run_aggregate_rows
-    )  # type:ignore
+        load_run_aggregate_rows  # type:ignore
+    )
     title: str = strawberry.field(description="Title of a CryoET dataset")
     description: str = strawberry.field(
         description="A short description of a CryoET dataset, similar to an abstract for a journal article or dataset.",
@@ -322,7 +321,8 @@ class Dataset(EntityInterface):
         default=None,
     )
     organism_taxid: Optional[int] = strawberry.field(
-        description="NCBI taxonomy identifier for the organism, e.g. 9606", default=None,
+        description="NCBI taxonomy identifier for the organism, e.g. 9606",
+        default=None,
     )
     tissue_name: Optional[str] = strawberry.field(
         description="Name of the tissue from which a biological sample used in a CryoET study is derived from.",
@@ -334,18 +334,21 @@ class Dataset(EntityInterface):
         default=None,
     )
     cell_type_id: Optional[str] = strawberry.field(
-        description="Cell Ontology identifier for the cell type", default=None,
+        description="Cell Ontology identifier for the cell type",
+        default=None,
     )
     cell_strain_name: Optional[str] = strawberry.field(description="Cell line or strain for the sample.", default=None)
     cell_strain_id: Optional[str] = strawberry.field(
-        description="Link to more information about the cell strain", default=None,
+        description="Link to more information about the cell strain",
+        default=None,
     )
     sample_type: Optional[sample_type_enum] = strawberry.field(
         description="Type of samples used in a CryoET study. (cell, tissue, organism, intact organelle, in-vitro mixture, in-silico synthetic data, other)",
         default=None,
     )
     sample_preparation: Optional[str] = strawberry.field(
-        description="Describe how the sample was prepared.", default=None,
+        description="Describe how the sample was prepared.",
+        default=None,
     )
     grid_preparation: Optional[str] = strawberry.field(description="Describe Cryo-ET grid preparation.", default=None)
     other_setup: Optional[str] = strawberry.field(
@@ -354,11 +357,13 @@ class Dataset(EntityInterface):
     )
     key_photo_url: Optional[str] = strawberry.field(description="URL for the dataset preview image.", default=None)
     key_photo_thumbnail_url: Optional[str] = strawberry.field(
-        description="URL for the thumbnail of preview image.", default=None,
+        description="URL for the thumbnail of preview image.",
+        default=None,
     )
     cell_component_name: Optional[str] = strawberry.field(description="Name of the cellular component", default=None)
     cell_component_id: Optional[str] = strawberry.field(
-        description="If the dataset focuses on a specific part of a cell, the subset is included here", default=None,
+        description="If the dataset focuses on a specific part of a cell, the subset is included here",
+        default=None,
     )
     deposition_date: datetime.datetime = strawberry.field(
         description="Date when a dataset is initially received by the Data Portal.",
@@ -370,7 +375,8 @@ class Dataset(EntityInterface):
         description="Date when a released dataset is last modified.",
     )
     dataset_publications: Optional[str] = strawberry.field(
-        description="Comma-separated list of DOIs for publications associated with the dataset.", default=None,
+        description="Comma-separated list of DOIs for publications associated with the dataset.",
+        default=None,
     )
     related_database_entries: Optional[str] = strawberry.field(
         description="If a CryoET dataset is also deposited into another database, enter the database identifier here (e.g. EMPIAR-11445). Use a comma to separate multiple identifiers.",
@@ -533,7 +539,8 @@ class DatasetCreateInput:
         default=None,
     )
     organism_taxid: Optional[int] = strawberry.field(
-        description="NCBI taxonomy identifier for the organism, e.g. 9606", default=None,
+        description="NCBI taxonomy identifier for the organism, e.g. 9606",
+        default=None,
     )
     tissue_name: Optional[str] = strawberry.field(
         description="Name of the tissue from which a biological sample used in a CryoET study is derived from.",
@@ -545,18 +552,21 @@ class DatasetCreateInput:
         default=None,
     )
     cell_type_id: Optional[str] = strawberry.field(
-        description="Cell Ontology identifier for the cell type", default=None,
+        description="Cell Ontology identifier for the cell type",
+        default=None,
     )
     cell_strain_name: Optional[str] = strawberry.field(description="Cell line or strain for the sample.", default=None)
     cell_strain_id: Optional[str] = strawberry.field(
-        description="Link to more information about the cell strain", default=None,
+        description="Link to more information about the cell strain",
+        default=None,
     )
     sample_type: Optional[sample_type_enum] = strawberry.field(
         description="Type of samples used in a CryoET study. (cell, tissue, organism, intact organelle, in-vitro mixture, in-silico synthetic data, other)",
         default=None,
     )
     sample_preparation: Optional[str] = strawberry.field(
-        description="Describe how the sample was prepared.", default=None,
+        description="Describe how the sample was prepared.",
+        default=None,
     )
     grid_preparation: Optional[str] = strawberry.field(description="Describe Cryo-ET grid preparation.", default=None)
     other_setup: Optional[str] = strawberry.field(
@@ -565,11 +575,13 @@ class DatasetCreateInput:
     )
     key_photo_url: Optional[str] = strawberry.field(description="URL for the dataset preview image.", default=None)
     key_photo_thumbnail_url: Optional[str] = strawberry.field(
-        description="URL for the thumbnail of preview image.", default=None,
+        description="URL for the thumbnail of preview image.",
+        default=None,
     )
     cell_component_name: Optional[str] = strawberry.field(description="Name of the cellular component", default=None)
     cell_component_id: Optional[str] = strawberry.field(
-        description="If the dataset focuses on a specific part of a cell, the subset is included here", default=None,
+        description="If the dataset focuses on a specific part of a cell, the subset is included here",
+        default=None,
     )
     deposition_date: datetime.datetime = strawberry.field(
         description="Date when a dataset is initially received by the Data Portal.",
@@ -581,7 +593,8 @@ class DatasetCreateInput:
         description="Date when a released dataset is last modified.",
     )
     dataset_publications: Optional[str] = strawberry.field(
-        description="Comma-separated list of DOIs for publications associated with the dataset.", default=None,
+        description="Comma-separated list of DOIs for publications associated with the dataset.",
+        default=None,
     )
     related_database_entries: Optional[str] = strawberry.field(
         description="If a CryoET dataset is also deposited into another database, enter the database identifier here (e.g. EMPIAR-11445). Use a comma to separate multiple identifiers.",
@@ -608,7 +621,8 @@ class DatasetUpdateInput:
         default=None,
     )
     organism_taxid: Optional[int] = strawberry.field(
-        description="NCBI taxonomy identifier for the organism, e.g. 9606", default=None,
+        description="NCBI taxonomy identifier for the organism, e.g. 9606",
+        default=None,
     )
     tissue_name: Optional[str] = strawberry.field(
         description="Name of the tissue from which a biological sample used in a CryoET study is derived from.",
@@ -620,18 +634,21 @@ class DatasetUpdateInput:
         default=None,
     )
     cell_type_id: Optional[str] = strawberry.field(
-        description="Cell Ontology identifier for the cell type", default=None,
+        description="Cell Ontology identifier for the cell type",
+        default=None,
     )
     cell_strain_name: Optional[str] = strawberry.field(description="Cell line or strain for the sample.", default=None)
     cell_strain_id: Optional[str] = strawberry.field(
-        description="Link to more information about the cell strain", default=None,
+        description="Link to more information about the cell strain",
+        default=None,
     )
     sample_type: Optional[sample_type_enum] = strawberry.field(
         description="Type of samples used in a CryoET study. (cell, tissue, organism, intact organelle, in-vitro mixture, in-silico synthetic data, other)",
         default=None,
     )
     sample_preparation: Optional[str] = strawberry.field(
-        description="Describe how the sample was prepared.", default=None,
+        description="Describe how the sample was prepared.",
+        default=None,
     )
     grid_preparation: Optional[str] = strawberry.field(description="Describe Cryo-ET grid preparation.", default=None)
     other_setup: Optional[str] = strawberry.field(
@@ -640,11 +657,13 @@ class DatasetUpdateInput:
     )
     key_photo_url: Optional[str] = strawberry.field(description="URL for the dataset preview image.", default=None)
     key_photo_thumbnail_url: Optional[str] = strawberry.field(
-        description="URL for the thumbnail of preview image.", default=None,
+        description="URL for the thumbnail of preview image.",
+        default=None,
     )
     cell_component_name: Optional[str] = strawberry.field(description="Name of the cellular component", default=None)
     cell_component_id: Optional[str] = strawberry.field(
-        description="If the dataset focuses on a specific part of a cell, the subset is included here", default=None,
+        description="If the dataset focuses on a specific part of a cell, the subset is included here",
+        default=None,
     )
     deposition_date: Optional[datetime.datetime] = strawberry.field(
         description="Date when a dataset is initially received by the Data Portal.",
@@ -656,7 +675,8 @@ class DatasetUpdateInput:
         description="Date when a released dataset is last modified.",
     )
     dataset_publications: Optional[str] = strawberry.field(
-        description="Comma-separated list of DOIs for publications associated with the dataset.", default=None,
+        description="Comma-separated list of DOIs for publications associated with the dataset.",
+        default=None,
     )
     related_database_entries: Optional[str] = strawberry.field(
         description="If a CryoET dataset is also deposited into another database, enter the database identifier here (e.g. EMPIAR-11445). Use a comma to separate multiple identifiers.",
@@ -694,7 +714,9 @@ async def resolve_datasets(
     offset = limit_offset["offset"] if limit_offset and "offset" in limit_offset else None
     if offset and not limit:
         raise PlatformicsError("Cannot use offset without limit")
-    return await get_db_rows(db.Dataset, session, authz_client, principal, where, order_by, AuthzAction.VIEW, limit, offset)  # type: ignore
+    return await get_db_rows(
+        db.Dataset, session, authz_client, principal, where, order_by, AuthzAction.VIEW, limit, offset
+    )  # type: ignore
 
 
 def format_dataset_aggregate_output(query_results: Sequence[RowMapping] | RowMapping) -> DatasetAggregate:
@@ -763,7 +785,9 @@ async def resolve_datasets_aggregate(
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")
 
-    rows = await get_aggregate_db_rows(db.Dataset, session, authz_client, principal, where, aggregate_selections, [], groupby_selections)  # type: ignore
+    rows = await get_aggregate_db_rows(
+        db.Dataset, session, authz_client, principal, where, aggregate_selections, [], groupby_selections
+    )  # type: ignore
     aggregate_output = format_dataset_aggregate_output(rows)
     return aggregate_output
 

--- a/apiv2/graphql_api/types/dataset.py
+++ b/apiv2/graphql_api/types/dataset.py
@@ -43,6 +43,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections, get_nested_selected_fields
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -138,7 +139,7 @@ async def load_dataset_funding_aggregate_rows(
     info: Info,
     where: Annotated["DatasetFundingWhereClause", strawberry.lazy("graphql_api.types.dataset_funding")] | None = None,
 ) -> Optional[Annotated["DatasetFundingAggregate", strawberry.lazy("graphql_api.types.dataset_funding")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Dataset)
     relationship = mapper.relationships["funding_sources"]
@@ -170,7 +171,7 @@ async def load_dataset_author_aggregate_rows(
     info: Info,
     where: Annotated["DatasetAuthorWhereClause", strawberry.lazy("graphql_api.types.dataset_author")] | None = None,
 ) -> Optional[Annotated["DatasetAuthorAggregate", strawberry.lazy("graphql_api.types.dataset_author")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Dataset)
     relationship = mapper.relationships["authors"]
@@ -200,7 +201,7 @@ async def load_run_aggregate_rows(
     info: Info,
     where: Annotated["RunWhereClause", strawberry.lazy("graphql_api.types.run")] | None = None,
 ) -> Optional[Annotated["RunAggregate", strawberry.lazy("graphql_api.types.run")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Dataset)
     relationship = mapper.relationships["runs"]
@@ -797,10 +798,7 @@ async def resolve_datasets_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/dataset.py
+++ b/apiv2/graphql_api/types/dataset.py
@@ -7,6 +7,7 @@ Make changes to the template codegen/templates/graphql_api/types/class_name.py.j
 
 # ruff: noqa: E501 Line too long
 
+
 import datetime
 import enum
 import typing
@@ -48,20 +49,38 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.dataset_author import DatasetAuthor, DatasetAuthorOrderByClause, DatasetAuthorWhereClause
-    from graphql_api.types.dataset_funding import DatasetFunding, DatasetFundingOrderByClause, DatasetFundingWhereClause
-    from graphql_api.types.deposition import Deposition, DepositionOrderByClause, DepositionWhereClause
-    from graphql_api.types.run import Run, RunOrderByClause, RunAggregateWhereClause, RunWhereClause
+    from graphql_api.types.dataset_author import (
+        DatasetAuthor,
+        DatasetAuthorAggregateWhereClause,
+        DatasetAuthorOrderByClause,
+        DatasetAuthorWhereClause,
+    )
+    from graphql_api.types.dataset_funding import (
+        DatasetFunding,
+        DatasetFundingAggregateWhereClause,
+        DatasetFundingOrderByClause,
+        DatasetFundingWhereClause,
+    )
+    from graphql_api.types.deposition import (
+        Deposition,
+        DepositionAggregateWhereClause,
+        DepositionOrderByClause,
+        DepositionWhereClause,
+    )
+    from graphql_api.types.run import Run, RunAggregateWhereClause, RunOrderByClause, RunWhereClause
 
     pass
 else:
     DepositionWhereClause = "DepositionWhereClause"
+    DepositionAggregateWhereClause = "DepositionAggregateWhereClause"
     Deposition = "Deposition"
     DepositionOrderByClause = "DepositionOrderByClause"
     DatasetFundingWhereClause = "DatasetFundingWhereClause"
+    DatasetFundingAggregateWhereClause = "DatasetFundingAggregateWhereClause"
     DatasetFunding = "DatasetFunding"
     DatasetFundingOrderByClause = "DatasetFundingOrderByClause"
     DatasetAuthorWhereClause = "DatasetAuthorWhereClause"
+    DatasetAuthorAggregateWhereClause = "DatasetAuthorAggregateWhereClause"
     DatasetAuthor = "DatasetAuthor"
     DatasetAuthorOrderByClause = "DatasetAuthorOrderByClause"
     RunWhereClause = "RunWhereClause"
@@ -95,7 +114,9 @@ async def load_deposition_rows(
 
 
 @relay.connection(
-    relay.ListConnection[Annotated["DatasetFunding", strawberry.lazy("graphql_api.types.dataset_funding")]],  # type:ignore
+    relay.ListConnection[
+        Annotated["DatasetFunding", strawberry.lazy("graphql_api.types.dataset_funding")]
+    ],  # type:ignore
 )
 async def load_dataset_funding_rows(
     root: "Dataset",
@@ -218,7 +239,15 @@ class DatasetWhereClause(TypedDict):
     funding_sources: (
         Optional[Annotated["DatasetFundingWhereClause", strawberry.lazy("graphql_api.types.dataset_funding")]] | None
     )
+    funding_sources_aggregate: (
+        Optional[Annotated["DatasetFundingAggregateWhereClause", strawberry.lazy("graphql_api.types.dataset_funding")]]
+        | None
+    )
     authors: Optional[Annotated["DatasetAuthorWhereClause", strawberry.lazy("graphql_api.types.dataset_author")]] | None
+    authors_aggregate: (
+        Optional[Annotated["DatasetAuthorAggregateWhereClause", strawberry.lazy("graphql_api.types.dataset_author")]]
+        | None
+    )
     runs: Optional[Annotated["RunWhereClause", strawberry.lazy("graphql_api.types.run")]] | None
     runs_aggregate: Optional[Annotated["RunAggregateWhereClause", strawberry.lazy("graphql_api.types.run")]] | None
     title: Optional[StrComparators] | None
@@ -293,25 +322,25 @@ Define Dataset type
 @strawberry.type(description="A collection of imaging experiments on the same organism")
 class Dataset(EntityInterface):
     deposition: Optional[Annotated["Deposition", strawberry.lazy("graphql_api.types.deposition")]] = (
-        load_deposition_rows  # type:ignore
-    )
+        load_deposition_rows
+    )  # type:ignore
     deposition_id: int
     funding_sources: Sequence[Annotated["DatasetFunding", strawberry.lazy("graphql_api.types.dataset_funding")]] = (
-        load_dataset_funding_rows  # type:ignore
-    )
+        load_dataset_funding_rows
+    )  # type:ignore
     funding_sources_aggregate: Optional[
         Annotated["DatasetFundingAggregate", strawberry.lazy("graphql_api.types.dataset_funding")]
     ] = load_dataset_funding_aggregate_rows  # type:ignore
     authors: Sequence[Annotated["DatasetAuthor", strawberry.lazy("graphql_api.types.dataset_author")]] = (
-        load_dataset_author_rows  # type:ignore
-    )
+        load_dataset_author_rows
+    )  # type:ignore
     authors_aggregate: Optional[
         Annotated["DatasetAuthorAggregate", strawberry.lazy("graphql_api.types.dataset_author")]
     ] = load_dataset_author_aggregate_rows  # type:ignore
     runs: Sequence[Annotated["Run", strawberry.lazy("graphql_api.types.run")]] = load_run_rows  # type:ignore
     runs_aggregate: Optional[Annotated["RunAggregate", strawberry.lazy("graphql_api.types.run")]] = (
-        load_run_aggregate_rows  # type:ignore
-    )
+        load_run_aggregate_rows
+    )  # type:ignore
     title: str = strawberry.field(description="Title of a CryoET dataset")
     description: str = strawberry.field(
         description="A short description of a CryoET dataset, similar to an abstract for a journal article or dataset.",
@@ -321,8 +350,7 @@ class Dataset(EntityInterface):
         default=None,
     )
     organism_taxid: Optional[int] = strawberry.field(
-        description="NCBI taxonomy identifier for the organism, e.g. 9606",
-        default=None,
+        description="NCBI taxonomy identifier for the organism, e.g. 9606", default=None,
     )
     tissue_name: Optional[str] = strawberry.field(
         description="Name of the tissue from which a biological sample used in a CryoET study is derived from.",
@@ -334,21 +362,18 @@ class Dataset(EntityInterface):
         default=None,
     )
     cell_type_id: Optional[str] = strawberry.field(
-        description="Cell Ontology identifier for the cell type",
-        default=None,
+        description="Cell Ontology identifier for the cell type", default=None,
     )
     cell_strain_name: Optional[str] = strawberry.field(description="Cell line or strain for the sample.", default=None)
     cell_strain_id: Optional[str] = strawberry.field(
-        description="Link to more information about the cell strain",
-        default=None,
+        description="Link to more information about the cell strain", default=None,
     )
     sample_type: Optional[sample_type_enum] = strawberry.field(
         description="Type of samples used in a CryoET study. (cell, tissue, organism, intact organelle, in-vitro mixture, in-silico synthetic data, other)",
         default=None,
     )
     sample_preparation: Optional[str] = strawberry.field(
-        description="Describe how the sample was prepared.",
-        default=None,
+        description="Describe how the sample was prepared.", default=None,
     )
     grid_preparation: Optional[str] = strawberry.field(description="Describe Cryo-ET grid preparation.", default=None)
     other_setup: Optional[str] = strawberry.field(
@@ -357,13 +382,11 @@ class Dataset(EntityInterface):
     )
     key_photo_url: Optional[str] = strawberry.field(description="URL for the dataset preview image.", default=None)
     key_photo_thumbnail_url: Optional[str] = strawberry.field(
-        description="URL for the thumbnail of preview image.",
-        default=None,
+        description="URL for the thumbnail of preview image.", default=None,
     )
     cell_component_name: Optional[str] = strawberry.field(description="Name of the cellular component", default=None)
     cell_component_id: Optional[str] = strawberry.field(
-        description="If the dataset focuses on a specific part of a cell, the subset is included here",
-        default=None,
+        description="If the dataset focuses on a specific part of a cell, the subset is included here", default=None,
     )
     deposition_date: datetime.datetime = strawberry.field(
         description="Date when a dataset is initially received by the Data Portal.",
@@ -375,8 +398,7 @@ class Dataset(EntityInterface):
         description="Date when a released dataset is last modified.",
     )
     dataset_publications: Optional[str] = strawberry.field(
-        description="Comma-separated list of DOIs for publications associated with the dataset.",
-        default=None,
+        description="Comma-separated list of DOIs for publications associated with the dataset.", default=None,
     )
     related_database_entries: Optional[str] = strawberry.field(
         description="If a CryoET dataset is also deposited into another database, enter the database identifier here (e.g. EMPIAR-11445). Use a comma to separate multiple identifiers.",
@@ -454,10 +476,6 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class DatasetCountColumns(enum.Enum):
-    deposition = "deposition"
-    fundingSources = "funding_sources"
-    authors = "authors"
-    runs = "runs"
     title = "title"
     description = "description"
     organismName = "organism_name"
@@ -484,6 +502,24 @@ class DatasetCountColumns(enum.Enum):
     s3Prefix = "s3_prefix"
     httpsPrefix = "https_prefix"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class DatasetAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["DatasetCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[DatasetWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class DatasetAggregateWhereClause(TypedDict):
+    count: DatasetAggregateWhereClauseCount
 
 
 """
@@ -539,8 +575,7 @@ class DatasetCreateInput:
         default=None,
     )
     organism_taxid: Optional[int] = strawberry.field(
-        description="NCBI taxonomy identifier for the organism, e.g. 9606",
-        default=None,
+        description="NCBI taxonomy identifier for the organism, e.g. 9606", default=None,
     )
     tissue_name: Optional[str] = strawberry.field(
         description="Name of the tissue from which a biological sample used in a CryoET study is derived from.",
@@ -552,21 +587,18 @@ class DatasetCreateInput:
         default=None,
     )
     cell_type_id: Optional[str] = strawberry.field(
-        description="Cell Ontology identifier for the cell type",
-        default=None,
+        description="Cell Ontology identifier for the cell type", default=None,
     )
     cell_strain_name: Optional[str] = strawberry.field(description="Cell line or strain for the sample.", default=None)
     cell_strain_id: Optional[str] = strawberry.field(
-        description="Link to more information about the cell strain",
-        default=None,
+        description="Link to more information about the cell strain", default=None,
     )
     sample_type: Optional[sample_type_enum] = strawberry.field(
         description="Type of samples used in a CryoET study. (cell, tissue, organism, intact organelle, in-vitro mixture, in-silico synthetic data, other)",
         default=None,
     )
     sample_preparation: Optional[str] = strawberry.field(
-        description="Describe how the sample was prepared.",
-        default=None,
+        description="Describe how the sample was prepared.", default=None,
     )
     grid_preparation: Optional[str] = strawberry.field(description="Describe Cryo-ET grid preparation.", default=None)
     other_setup: Optional[str] = strawberry.field(
@@ -575,13 +607,11 @@ class DatasetCreateInput:
     )
     key_photo_url: Optional[str] = strawberry.field(description="URL for the dataset preview image.", default=None)
     key_photo_thumbnail_url: Optional[str] = strawberry.field(
-        description="URL for the thumbnail of preview image.",
-        default=None,
+        description="URL for the thumbnail of preview image.", default=None,
     )
     cell_component_name: Optional[str] = strawberry.field(description="Name of the cellular component", default=None)
     cell_component_id: Optional[str] = strawberry.field(
-        description="If the dataset focuses on a specific part of a cell, the subset is included here",
-        default=None,
+        description="If the dataset focuses on a specific part of a cell, the subset is included here", default=None,
     )
     deposition_date: datetime.datetime = strawberry.field(
         description="Date when a dataset is initially received by the Data Portal.",
@@ -593,8 +623,7 @@ class DatasetCreateInput:
         description="Date when a released dataset is last modified.",
     )
     dataset_publications: Optional[str] = strawberry.field(
-        description="Comma-separated list of DOIs for publications associated with the dataset.",
-        default=None,
+        description="Comma-separated list of DOIs for publications associated with the dataset.", default=None,
     )
     related_database_entries: Optional[str] = strawberry.field(
         description="If a CryoET dataset is also deposited into another database, enter the database identifier here (e.g. EMPIAR-11445). Use a comma to separate multiple identifiers.",
@@ -621,8 +650,7 @@ class DatasetUpdateInput:
         default=None,
     )
     organism_taxid: Optional[int] = strawberry.field(
-        description="NCBI taxonomy identifier for the organism, e.g. 9606",
-        default=None,
+        description="NCBI taxonomy identifier for the organism, e.g. 9606", default=None,
     )
     tissue_name: Optional[str] = strawberry.field(
         description="Name of the tissue from which a biological sample used in a CryoET study is derived from.",
@@ -634,21 +662,18 @@ class DatasetUpdateInput:
         default=None,
     )
     cell_type_id: Optional[str] = strawberry.field(
-        description="Cell Ontology identifier for the cell type",
-        default=None,
+        description="Cell Ontology identifier for the cell type", default=None,
     )
     cell_strain_name: Optional[str] = strawberry.field(description="Cell line or strain for the sample.", default=None)
     cell_strain_id: Optional[str] = strawberry.field(
-        description="Link to more information about the cell strain",
-        default=None,
+        description="Link to more information about the cell strain", default=None,
     )
     sample_type: Optional[sample_type_enum] = strawberry.field(
         description="Type of samples used in a CryoET study. (cell, tissue, organism, intact organelle, in-vitro mixture, in-silico synthetic data, other)",
         default=None,
     )
     sample_preparation: Optional[str] = strawberry.field(
-        description="Describe how the sample was prepared.",
-        default=None,
+        description="Describe how the sample was prepared.", default=None,
     )
     grid_preparation: Optional[str] = strawberry.field(description="Describe Cryo-ET grid preparation.", default=None)
     other_setup: Optional[str] = strawberry.field(
@@ -657,13 +682,11 @@ class DatasetUpdateInput:
     )
     key_photo_url: Optional[str] = strawberry.field(description="URL for the dataset preview image.", default=None)
     key_photo_thumbnail_url: Optional[str] = strawberry.field(
-        description="URL for the thumbnail of preview image.",
-        default=None,
+        description="URL for the thumbnail of preview image.", default=None,
     )
     cell_component_name: Optional[str] = strawberry.field(description="Name of the cellular component", default=None)
     cell_component_id: Optional[str] = strawberry.field(
-        description="If the dataset focuses on a specific part of a cell, the subset is included here",
-        default=None,
+        description="If the dataset focuses on a specific part of a cell, the subset is included here", default=None,
     )
     deposition_date: Optional[datetime.datetime] = strawberry.field(
         description="Date when a dataset is initially received by the Data Portal.",
@@ -675,8 +698,7 @@ class DatasetUpdateInput:
         description="Date when a released dataset is last modified.",
     )
     dataset_publications: Optional[str] = strawberry.field(
-        description="Comma-separated list of DOIs for publications associated with the dataset.",
-        default=None,
+        description="Comma-separated list of DOIs for publications associated with the dataset.", default=None,
     )
     related_database_entries: Optional[str] = strawberry.field(
         description="If a CryoET dataset is also deposited into another database, enter the database identifier here (e.g. EMPIAR-11445). Use a comma to separate multiple identifiers.",
@@ -714,9 +736,7 @@ async def resolve_datasets(
     offset = limit_offset["offset"] if limit_offset and "offset" in limit_offset else None
     if offset and not limit:
         raise PlatformicsError("Cannot use offset without limit")
-    return await get_db_rows(
-        db.Dataset, session, authz_client, principal, where, order_by, AuthzAction.VIEW, limit, offset
-    )  # type: ignore
+    return await get_db_rows(db.Dataset, session, authz_client, principal, where, order_by, AuthzAction.VIEW, limit, offset)  # type: ignore
 
 
 def format_dataset_aggregate_output(query_results: Sequence[RowMapping] | RowMapping) -> DatasetAggregate:
@@ -785,9 +805,7 @@ async def resolve_datasets_aggregate(
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")
 
-    rows = await get_aggregate_db_rows(
-        db.Dataset, session, authz_client, principal, where, aggregate_selections, [], groupby_selections
-    )  # type: ignore
+    rows = await get_aggregate_db_rows(db.Dataset, session, authz_client, principal, where, aggregate_selections, [], groupby_selections)  # type: ignore
     aggregate_output = format_dataset_aggregate_output(rows)
     return aggregate_output
 

--- a/apiv2/graphql_api/types/dataset_author.py
+++ b/apiv2/graphql_api/types/dataset_author.py
@@ -37,6 +37,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -434,10 +435,7 @@ async def resolve_dataset_authors_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/dataset_author.py
+++ b/apiv2/graphql_api/types/dataset_author.py
@@ -43,11 +43,12 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.dataset import Dataset, DatasetOrderByClause, DatasetWhereClause
+    from graphql_api.types.dataset import Dataset, DatasetAggregateWhereClause, DatasetOrderByClause, DatasetWhereClause
 
     pass
 else:
     DatasetWhereClause = "DatasetWhereClause"
+    DatasetAggregateWhereClause = "DatasetAggregateWhereClause"
     Dataset = "Dataset"
     DatasetOrderByClause = "DatasetOrderByClause"
     pass
@@ -218,7 +219,6 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class DatasetAuthorCountColumns(enum.Enum):
-    dataset = "dataset"
     id = "id"
     authorListOrder = "author_list_order"
     orcid = "orcid"
@@ -229,6 +229,24 @@ class DatasetAuthorCountColumns(enum.Enum):
     affiliationIdentifier = "affiliation_identifier"
     correspondingAuthorStatus = "corresponding_author_status"
     primaryAuthorStatus = "primary_author_status"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class DatasetAuthorAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["DatasetAuthorCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[DatasetAuthorWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class DatasetAuthorAggregateWhereClause(TypedDict):
+    count: DatasetAuthorAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/dataset_funding.py
+++ b/apiv2/graphql_api/types/dataset_funding.py
@@ -36,6 +36,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -353,10 +354,7 @@ async def resolve_dataset_funding_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/dataset_funding.py
+++ b/apiv2/graphql_api/types/dataset_funding.py
@@ -42,11 +42,12 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.dataset import Dataset, DatasetOrderByClause, DatasetWhereClause
+    from graphql_api.types.dataset import Dataset, DatasetAggregateWhereClause, DatasetOrderByClause, DatasetWhereClause
 
     pass
 else:
     DatasetWhereClause = "DatasetWhereClause"
+    DatasetAggregateWhereClause = "DatasetAggregateWhereClause"
     Dataset = "Dataset"
     DatasetOrderByClause = "DatasetOrderByClause"
     pass
@@ -178,10 +179,27 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class DatasetFundingCountColumns(enum.Enum):
-    dataset = "dataset"
     fundingAgencyName = "funding_agency_name"
     grantId = "grant_id"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class DatasetFundingAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["DatasetFundingCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[DatasetFundingWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class DatasetFundingAggregateWhereClause(TypedDict):
+    count: DatasetFundingAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/deposition.py
+++ b/apiv2/graphql_api/types/deposition.py
@@ -46,6 +46,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections, get_nested_selected_fields
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -165,7 +166,7 @@ async def load_deposition_author_aggregate_rows(
         Annotated["DepositionAuthorWhereClause", strawberry.lazy("graphql_api.types.deposition_author")] | None
     ) = None,
 ) -> Optional[Annotated["DepositionAuthorAggregate", strawberry.lazy("graphql_api.types.deposition_author")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Deposition)
     relationship = mapper.relationships["authors"]
@@ -195,7 +196,7 @@ async def load_alignment_aggregate_rows(
     info: Info,
     where: Annotated["AlignmentWhereClause", strawberry.lazy("graphql_api.types.alignment")] | None = None,
 ) -> Optional[Annotated["AlignmentAggregate", strawberry.lazy("graphql_api.types.alignment")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Deposition)
     relationship = mapper.relationships["alignments"]
@@ -227,7 +228,7 @@ async def load_annotation_aggregate_rows(
     info: Info,
     where: Annotated["AnnotationWhereClause", strawberry.lazy("graphql_api.types.annotation")] | None = None,
 ) -> Optional[Annotated["AnnotationAggregate", strawberry.lazy("graphql_api.types.annotation")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Deposition)
     relationship = mapper.relationships["annotations"]
@@ -257,7 +258,7 @@ async def load_dataset_aggregate_rows(
     info: Info,
     where: Annotated["DatasetWhereClause", strawberry.lazy("graphql_api.types.dataset")] | None = None,
 ) -> Optional[Annotated["DatasetAggregate", strawberry.lazy("graphql_api.types.dataset")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Deposition)
     relationship = mapper.relationships["datasets"]
@@ -287,7 +288,7 @@ async def load_frame_aggregate_rows(
     info: Info,
     where: Annotated["FrameWhereClause", strawberry.lazy("graphql_api.types.frame")] | None = None,
 ) -> Optional[Annotated["FrameAggregate", strawberry.lazy("graphql_api.types.frame")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Deposition)
     relationship = mapper.relationships["frames"]
@@ -319,7 +320,7 @@ async def load_tiltseries_aggregate_rows(
     info: Info,
     where: Annotated["TiltseriesWhereClause", strawberry.lazy("graphql_api.types.tiltseries")] | None = None,
 ) -> Optional[Annotated["TiltseriesAggregate", strawberry.lazy("graphql_api.types.tiltseries")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Deposition)
     relationship = mapper.relationships["tiltseries"]
@@ -349,7 +350,7 @@ async def load_tomogram_aggregate_rows(
     info: Info,
     where: Annotated["TomogramWhereClause", strawberry.lazy("graphql_api.types.tomogram")] | None = None,
 ) -> Optional[Annotated["TomogramAggregate", strawberry.lazy("graphql_api.types.tomogram")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Deposition)
     relationship = mapper.relationships["tomograms"]
@@ -383,7 +384,7 @@ async def load_deposition_type_aggregate_rows(
     info: Info,
     where: Annotated["DepositionTypeWhereClause", strawberry.lazy("graphql_api.types.deposition_type")] | None = None,
 ) -> Optional[Annotated["DepositionTypeAggregate", strawberry.lazy("graphql_api.types.deposition_type")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Deposition)
     relationship = mapper.relationships["deposition_types"]
@@ -806,10 +807,7 @@ async def resolve_depositions_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/deposition.py
+++ b/apiv2/graphql_api/types/deposition.py
@@ -52,43 +52,77 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.alignment import Alignment, AlignmentOrderByClause, AlignmentWhereClause
-    from graphql_api.types.annotation import Annotation, AnnotationOrderByClause, AnnotationWhereClause
-    from graphql_api.types.dataset import Dataset, DatasetOrderByClause, DatasetWhereClause
+    from graphql_api.types.alignment import (
+        Alignment,
+        AlignmentAggregateWhereClause,
+        AlignmentOrderByClause,
+        AlignmentWhereClause,
+    )
+    from graphql_api.types.annotation import (
+        Annotation,
+        AnnotationAggregateWhereClause,
+        AnnotationOrderByClause,
+        AnnotationWhereClause,
+    )
+    from graphql_api.types.dataset import Dataset, DatasetAggregateWhereClause, DatasetOrderByClause, DatasetWhereClause
     from graphql_api.types.deposition_author import (
         DepositionAuthor,
+        DepositionAuthorAggregateWhereClause,
         DepositionAuthorOrderByClause,
         DepositionAuthorWhereClause,
     )
-    from graphql_api.types.deposition_type import DepositionType, DepositionTypeOrderByClause, DepositionTypeWhereClause
-    from graphql_api.types.frame import Frame, FrameOrderByClause, FrameWhereClause
-    from graphql_api.types.tiltseries import Tiltseries, TiltseriesOrderByClause, TiltseriesWhereClause
-    from graphql_api.types.tomogram import Tomogram, TomogramOrderByClause, TomogramWhereClause
+    from graphql_api.types.deposition_type import (
+        DepositionType,
+        DepositionTypeAggregateWhereClause,
+        DepositionTypeOrderByClause,
+        DepositionTypeWhereClause,
+    )
+    from graphql_api.types.frame import Frame, FrameAggregateWhereClause, FrameOrderByClause, FrameWhereClause
+    from graphql_api.types.tiltseries import (
+        Tiltseries,
+        TiltseriesAggregateWhereClause,
+        TiltseriesOrderByClause,
+        TiltseriesWhereClause,
+    )
+    from graphql_api.types.tomogram import (
+        Tomogram,
+        TomogramAggregateWhereClause,
+        TomogramOrderByClause,
+        TomogramWhereClause,
+    )
 
     pass
 else:
     DepositionAuthorWhereClause = "DepositionAuthorWhereClause"
+    DepositionAuthorAggregateWhereClause = "DepositionAuthorAggregateWhereClause"
     DepositionAuthor = "DepositionAuthor"
     DepositionAuthorOrderByClause = "DepositionAuthorOrderByClause"
     AlignmentWhereClause = "AlignmentWhereClause"
+    AlignmentAggregateWhereClause = "AlignmentAggregateWhereClause"
     Alignment = "Alignment"
     AlignmentOrderByClause = "AlignmentOrderByClause"
     AnnotationWhereClause = "AnnotationWhereClause"
+    AnnotationAggregateWhereClause = "AnnotationAggregateWhereClause"
     Annotation = "Annotation"
     AnnotationOrderByClause = "AnnotationOrderByClause"
     DatasetWhereClause = "DatasetWhereClause"
+    DatasetAggregateWhereClause = "DatasetAggregateWhereClause"
     Dataset = "Dataset"
     DatasetOrderByClause = "DatasetOrderByClause"
     FrameWhereClause = "FrameWhereClause"
+    FrameAggregateWhereClause = "FrameAggregateWhereClause"
     Frame = "Frame"
     FrameOrderByClause = "FrameOrderByClause"
     TiltseriesWhereClause = "TiltseriesWhereClause"
+    TiltseriesAggregateWhereClause = "TiltseriesAggregateWhereClause"
     Tiltseries = "Tiltseries"
     TiltseriesOrderByClause = "TiltseriesOrderByClause"
     TomogramWhereClause = "TomogramWhereClause"
+    TomogramAggregateWhereClause = "TomogramAggregateWhereClause"
     Tomogram = "Tomogram"
     TomogramOrderByClause = "TomogramOrderByClause"
     DepositionTypeWhereClause = "DepositionTypeWhereClause"
+    DepositionTypeAggregateWhereClause = "DepositionTypeAggregateWhereClause"
     DepositionType = "DepositionType"
     DepositionTypeOrderByClause = "DepositionTypeOrderByClause"
     pass
@@ -387,16 +421,44 @@ class DepositionWhereClause(TypedDict):
         Optional[Annotated["DepositionAuthorWhereClause", strawberry.lazy("graphql_api.types.deposition_author")]]
         | None
     )
+    authors_aggregate: (
+        Optional[
+            Annotated["DepositionAuthorAggregateWhereClause", strawberry.lazy("graphql_api.types.deposition_author")]
+        ]
+        | None
+    )
     alignments: Optional[Annotated["AlignmentWhereClause", strawberry.lazy("graphql_api.types.alignment")]] | None
+    alignments_aggregate: (
+        Optional[Annotated["AlignmentAggregateWhereClause", strawberry.lazy("graphql_api.types.alignment")]] | None
+    )
     annotations: Optional[Annotated["AnnotationWhereClause", strawberry.lazy("graphql_api.types.annotation")]] | None
+    annotations_aggregate: (
+        Optional[Annotated["AnnotationAggregateWhereClause", strawberry.lazy("graphql_api.types.annotation")]] | None
+    )
     datasets: Optional[Annotated["DatasetWhereClause", strawberry.lazy("graphql_api.types.dataset")]] | None
+    datasets_aggregate: (
+        Optional[Annotated["DatasetAggregateWhereClause", strawberry.lazy("graphql_api.types.dataset")]] | None
+    )
     frames: Optional[Annotated["FrameWhereClause", strawberry.lazy("graphql_api.types.frame")]] | None
+    frames_aggregate: (
+        Optional[Annotated["FrameAggregateWhereClause", strawberry.lazy("graphql_api.types.frame")]] | None
+    )
     tiltseries: Optional[Annotated["TiltseriesWhereClause", strawberry.lazy("graphql_api.types.tiltseries")]] | None
+    tiltseries_aggregate: (
+        Optional[Annotated["TiltseriesAggregateWhereClause", strawberry.lazy("graphql_api.types.tiltseries")]] | None
+    )
     tomograms: Optional[Annotated["TomogramWhereClause", strawberry.lazy("graphql_api.types.tomogram")]] | None
+    tomograms_aggregate: (
+        Optional[Annotated["TomogramAggregateWhereClause", strawberry.lazy("graphql_api.types.tomogram")]] | None
+    )
     title: Optional[StrComparators] | None
     description: Optional[StrComparators] | None
     deposition_types: (
         Optional[Annotated["DepositionTypeWhereClause", strawberry.lazy("graphql_api.types.deposition_type")]] | None
+    )
+    deposition_types_aggregate: (
+        Optional[Annotated["DepositionTypeAggregateWhereClause", strawberry.lazy("graphql_api.types.deposition_type")]]
+        | None
     )
     deposition_publications: Optional[StrComparators] | None
     related_database_entries: Optional[StrComparators] | None
@@ -547,16 +609,8 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class DepositionCountColumns(enum.Enum):
-    authors = "authors"
-    alignments = "alignments"
-    annotations = "annotations"
-    datasets = "datasets"
-    frames = "frames"
-    tiltseries = "tiltseries"
-    tomograms = "tomograms"
     title = "title"
     description = "description"
-    depositionTypes = "deposition_types"
     depositionPublications = "deposition_publications"
     relatedDatabaseEntries = "related_database_entries"
     depositionDate = "deposition_date"
@@ -565,6 +619,24 @@ class DepositionCountColumns(enum.Enum):
     keyPhotoUrl = "key_photo_url"
     keyPhotoThumbnailUrl = "key_photo_thumbnail_url"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class DepositionAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["DepositionCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[DepositionWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class DepositionAggregateWhereClause(TypedDict):
+    count: DepositionAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/deposition_author.py
+++ b/apiv2/graphql_api/types/deposition_author.py
@@ -37,6 +37,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -440,10 +441,7 @@ async def resolve_deposition_authors_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/deposition_author.py
+++ b/apiv2/graphql_api/types/deposition_author.py
@@ -43,11 +43,17 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.deposition import Deposition, DepositionOrderByClause, DepositionWhereClause
+    from graphql_api.types.deposition import (
+        Deposition,
+        DepositionAggregateWhereClause,
+        DepositionOrderByClause,
+        DepositionWhereClause,
+    )
 
     pass
 else:
     DepositionWhereClause = "DepositionWhereClause"
+    DepositionAggregateWhereClause = "DepositionAggregateWhereClause"
     Deposition = "Deposition"
     DepositionOrderByClause = "DepositionOrderByClause"
     pass
@@ -219,7 +225,6 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class DepositionAuthorCountColumns(enum.Enum):
-    deposition = "deposition"
     id = "id"
     authorListOrder = "author_list_order"
     orcid = "orcid"
@@ -230,6 +235,24 @@ class DepositionAuthorCountColumns(enum.Enum):
     affiliationIdentifier = "affiliation_identifier"
     correspondingAuthorStatus = "corresponding_author_status"
     primaryAuthorStatus = "primary_author_status"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class DepositionAuthorAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["DepositionAuthorCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[DepositionAuthorWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class DepositionAuthorAggregateWhereClause(TypedDict):
+    count: DepositionAuthorAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/deposition_type.py
+++ b/apiv2/graphql_api/types/deposition_type.py
@@ -43,11 +43,17 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.deposition import Deposition, DepositionOrderByClause, DepositionWhereClause
+    from graphql_api.types.deposition import (
+        Deposition,
+        DepositionAggregateWhereClause,
+        DepositionOrderByClause,
+        DepositionWhereClause,
+    )
 
     pass
 else:
     DepositionWhereClause = "DepositionWhereClause"
+    DepositionAggregateWhereClause = "DepositionAggregateWhereClause"
     Deposition = "Deposition"
     DepositionOrderByClause = "DepositionOrderByClause"
     pass
@@ -177,9 +183,26 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class DepositionTypeCountColumns(enum.Enum):
-    deposition = "deposition"
     type = "type"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class DepositionTypeAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["DepositionTypeCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[DepositionTypeWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class DepositionTypeAggregateWhereClause(TypedDict):
+    count: DepositionTypeAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/deposition_type.py
+++ b/apiv2/graphql_api/types/deposition_type.py
@@ -37,6 +37,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -352,10 +353,7 @@ async def resolve_deposition_types_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/frame.py
+++ b/apiv2/graphql_api/types/frame.py
@@ -38,6 +38,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -415,10 +416,7 @@ async def resolve_frames_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/frame.py
+++ b/apiv2/graphql_api/types/frame.py
@@ -44,15 +44,22 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.deposition import Deposition, DepositionOrderByClause, DepositionWhereClause
-    from graphql_api.types.run import Run, RunOrderByClause, RunWhereClause
+    from graphql_api.types.deposition import (
+        Deposition,
+        DepositionAggregateWhereClause,
+        DepositionOrderByClause,
+        DepositionWhereClause,
+    )
+    from graphql_api.types.run import Run, RunAggregateWhereClause, RunOrderByClause, RunWhereClause
 
     pass
 else:
     DepositionWhereClause = "DepositionWhereClause"
+    DepositionAggregateWhereClause = "DepositionAggregateWhereClause"
     Deposition = "Deposition"
     DepositionOrderByClause = "DepositionOrderByClause"
     RunWhereClause = "RunWhereClause"
+    RunAggregateWhereClause = "RunAggregateWhereClause"
     Run = "Run"
     RunOrderByClause = "RunOrderByClause"
     pass
@@ -224,8 +231,6 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class FrameCountColumns(enum.Enum):
-    deposition = "deposition"
-    run = "run"
     rawAngle = "raw_angle"
     acquisitionOrder = "acquisition_order"
     dose = "dose"
@@ -233,6 +238,24 @@ class FrameCountColumns(enum.Enum):
     s3FramePath = "s3_frame_path"
     httpsFramePath = "https_frame_path"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class FrameAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["FrameCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[FrameWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class FrameAggregateWhereClause(TypedDict):
+    count: FrameAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/frame_acquisition_file.py
+++ b/apiv2/graphql_api/types/frame_acquisition_file.py
@@ -42,6 +42,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -349,10 +350,7 @@ async def resolve_frame_acquisition_files_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/frame_acquisition_file.py
+++ b/apiv2/graphql_api/types/frame_acquisition_file.py
@@ -48,11 +48,12 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.run import Run, RunOrderByClause, RunWhereClause
+    from graphql_api.types.run import Run, RunAggregateWhereClause, RunOrderByClause, RunWhereClause
 
     pass
 else:
     RunWhereClause = "RunWhereClause"
+    RunAggregateWhereClause = "RunAggregateWhereClause"
     Run = "Run"
     RunOrderByClause = "RunOrderByClause"
     pass
@@ -180,10 +181,27 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class FrameAcquisitionFileCountColumns(enum.Enum):
-    run = "run"
     s3MdocPath = "s3_mdoc_path"
     httpsMdocPath = "https_mdoc_path"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class FrameAcquisitionFileAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["FrameAcquisitionFileCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[FrameAcquisitionFileWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class FrameAcquisitionFileAggregateWhereClause(TypedDict):
+    count: FrameAcquisitionFileAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/gain_file.py
+++ b/apiv2/graphql_api/types/gain_file.py
@@ -36,6 +36,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -337,10 +338,7 @@ async def resolve_gain_files_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/gain_file.py
+++ b/apiv2/graphql_api/types/gain_file.py
@@ -42,11 +42,12 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.run import Run, RunOrderByClause, RunWhereClause
+    from graphql_api.types.run import Run, RunAggregateWhereClause, RunOrderByClause, RunWhereClause
 
     pass
 else:
     RunWhereClause = "RunWhereClause"
+    RunAggregateWhereClause = "RunAggregateWhereClause"
     Run = "Run"
     RunOrderByClause = "RunOrderByClause"
     pass
@@ -174,10 +175,27 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class GainFileCountColumns(enum.Enum):
-    run = "run"
     s3FilePath = "s3_file_path"
     httpsFilePath = "https_file_path"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class GainFileAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["GainFileCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[GainFileWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class GainFileAggregateWhereClause(TypedDict):
+    count: GainFileAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/per_section_alignment_parameters.py
+++ b/apiv2/graphql_api/types/per_section_alignment_parameters.py
@@ -48,11 +48,17 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.alignment import Alignment, AlignmentOrderByClause, AlignmentWhereClause
+    from graphql_api.types.alignment import (
+        Alignment,
+        AlignmentAggregateWhereClause,
+        AlignmentOrderByClause,
+        AlignmentWhereClause,
+    )
 
     pass
 else:
     AlignmentWhereClause = "AlignmentWhereClause"
+    AlignmentAggregateWhereClause = "AlignmentAggregateWhereClause"
     Alignment = "Alignment"
     AlignmentOrderByClause = "AlignmentOrderByClause"
     pass
@@ -207,7 +213,6 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class PerSectionAlignmentParametersCountColumns(enum.Enum):
-    alignment = "alignment"
     zIndex = "z_index"
     xOffset = "x_offset"
     yOffset = "y_offset"
@@ -215,6 +220,24 @@ class PerSectionAlignmentParametersCountColumns(enum.Enum):
     inPlaneRotation = "in_plane_rotation"
     tiltAngle = "tilt_angle"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class PerSectionAlignmentParametersAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["PerSectionAlignmentParametersCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[PerSectionAlignmentParametersWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class PerSectionAlignmentParametersAggregateWhereClause(TypedDict):
+    count: PerSectionAlignmentParametersAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/per_section_alignment_parameters.py
+++ b/apiv2/graphql_api/types/per_section_alignment_parameters.py
@@ -42,6 +42,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -405,10 +406,7 @@ async def resolve_per_section_alignment_parameters_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/run.py
+++ b/apiv2/graphql_api/types/run.py
@@ -454,7 +454,7 @@ class RunAggregateWhereClauseCount(TypedDict):
 
 @strawberry.input
 class RunAggregateWhereClause(TypedDict):
-    count: RunAggregateWhereClauseCount | None
+    count: RunAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/run.py
+++ b/apiv2/graphql_api/types/run.py
@@ -7,6 +7,7 @@ Make changes to the template codegen/templates/graphql_api/types/class_name.py.j
 
 # ruff: noqa: E501 Line too long
 
+
 import datetime
 import enum
 import typing
@@ -56,20 +57,47 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.alignment import Alignment, AlignmentOrderByClause, AlignmentWhereClause
-    from graphql_api.types.annotation import Annotation, AnnotationOrderByClause, AnnotationWhereClause
-    from graphql_api.types.dataset import Dataset, DatasetOrderByClause, DatasetWhereClause
-    from graphql_api.types.frame import Frame, FrameOrderByClause, FrameWhereClause
+    from graphql_api.types.alignment import (
+        Alignment,
+        AlignmentAggregateWhereClause,
+        AlignmentOrderByClause,
+        AlignmentWhereClause,
+    )
+    from graphql_api.types.annotation import (
+        Annotation,
+        AnnotationAggregateWhereClause,
+        AnnotationOrderByClause,
+        AnnotationWhereClause,
+    )
+    from graphql_api.types.dataset import Dataset, DatasetAggregateWhereClause, DatasetOrderByClause, DatasetWhereClause
+    from graphql_api.types.frame import Frame, FrameAggregateWhereClause, FrameOrderByClause, FrameWhereClause
     from graphql_api.types.frame_acquisition_file import (
         FrameAcquisitionFile,
+        FrameAcquisitionFileAggregateWhereClause,
         FrameAcquisitionFileOrderByClause,
         FrameAcquisitionFileWhereClause,
     )
-    from graphql_api.types.gain_file import GainFile, GainFileOrderByClause, GainFileWhereClause
-    from graphql_api.types.tiltseries import Tiltseries, TiltseriesOrderByClause, TiltseriesWhereClause
-    from graphql_api.types.tomogram import Tomogram, TomogramOrderByClause, TomogramWhereClause
+    from graphql_api.types.gain_file import (
+        GainFile,
+        GainFileAggregateWhereClause,
+        GainFileOrderByClause,
+        GainFileWhereClause,
+    )
+    from graphql_api.types.tiltseries import (
+        Tiltseries,
+        TiltseriesAggregateWhereClause,
+        TiltseriesOrderByClause,
+        TiltseriesWhereClause,
+    )
+    from graphql_api.types.tomogram import (
+        Tomogram,
+        TomogramAggregateWhereClause,
+        TomogramOrderByClause,
+        TomogramWhereClause,
+    )
     from graphql_api.types.tomogram_voxel_spacing import (
         TomogramVoxelSpacing,
+        TomogramVoxelSpacingAggregateWhereClause,
         TomogramVoxelSpacingOrderByClause,
         TomogramVoxelSpacingWhereClause,
     )
@@ -77,30 +105,39 @@ if TYPE_CHECKING:
     pass
 else:
     AlignmentWhereClause = "AlignmentWhereClause"
+    AlignmentAggregateWhereClause = "AlignmentAggregateWhereClause"
     Alignment = "Alignment"
     AlignmentOrderByClause = "AlignmentOrderByClause"
     AnnotationWhereClause = "AnnotationWhereClause"
+    AnnotationAggregateWhereClause = "AnnotationAggregateWhereClause"
     Annotation = "Annotation"
     AnnotationOrderByClause = "AnnotationOrderByClause"
     DatasetWhereClause = "DatasetWhereClause"
+    DatasetAggregateWhereClause = "DatasetAggregateWhereClause"
     Dataset = "Dataset"
     DatasetOrderByClause = "DatasetOrderByClause"
     FrameWhereClause = "FrameWhereClause"
+    FrameAggregateWhereClause = "FrameAggregateWhereClause"
     Frame = "Frame"
     FrameOrderByClause = "FrameOrderByClause"
     GainFileWhereClause = "GainFileWhereClause"
+    GainFileAggregateWhereClause = "GainFileAggregateWhereClause"
     GainFile = "GainFile"
     GainFileOrderByClause = "GainFileOrderByClause"
     FrameAcquisitionFileWhereClause = "FrameAcquisitionFileWhereClause"
+    FrameAcquisitionFileAggregateWhereClause = "FrameAcquisitionFileAggregateWhereClause"
     FrameAcquisitionFile = "FrameAcquisitionFile"
     FrameAcquisitionFileOrderByClause = "FrameAcquisitionFileOrderByClause"
     TiltseriesWhereClause = "TiltseriesWhereClause"
+    TiltseriesAggregateWhereClause = "TiltseriesAggregateWhereClause"
     Tiltseries = "Tiltseries"
     TiltseriesOrderByClause = "TiltseriesOrderByClause"
     TomogramVoxelSpacingWhereClause = "TomogramVoxelSpacingWhereClause"
+    TomogramVoxelSpacingAggregateWhereClause = "TomogramVoxelSpacingAggregateWhereClause"
     TomogramVoxelSpacing = "TomogramVoxelSpacing"
     TomogramVoxelSpacingOrderByClause = "TomogramVoxelSpacingOrderByClause"
     TomogramWhereClause = "TomogramWhereClause"
+    TomogramAggregateWhereClause = "TomogramAggregateWhereClause"
     Tomogram = "Tomogram"
     TomogramOrderByClause = "TomogramOrderByClause"
     pass
@@ -417,44 +454,63 @@ Supported WHERE clause attributes
 @strawberry.input
 class RunWhereClause(TypedDict):
     alignments: Optional[Annotated["AlignmentWhereClause", strawberry.lazy("graphql_api.types.alignment")]] | None
+    alignments_aggregate: (
+        Optional[Annotated["AlignmentAggregateWhereClause", strawberry.lazy("graphql_api.types.alignment")]] | None
+    )
     annotations: Optional[Annotated["AnnotationWhereClause", strawberry.lazy("graphql_api.types.annotation")]] | None
+    annotations_aggregate: (
+        Optional[Annotated["AnnotationAggregateWhereClause", strawberry.lazy("graphql_api.types.annotation")]] | None
+    )
     dataset: Optional[Annotated["DatasetWhereClause", strawberry.lazy("graphql_api.types.dataset")]] | None
     dataset_id: Optional[IntComparators] | None
     frames: Optional[Annotated["FrameWhereClause", strawberry.lazy("graphql_api.types.frame")]] | None
+    frames_aggregate: (
+        Optional[Annotated["FrameAggregateWhereClause", strawberry.lazy("graphql_api.types.frame")]] | None
+    )
     gain_files: Optional[Annotated["GainFileWhereClause", strawberry.lazy("graphql_api.types.gain_file")]] | None
+    gain_files_aggregate: (
+        Optional[Annotated["GainFileAggregateWhereClause", strawberry.lazy("graphql_api.types.gain_file")]] | None
+    )
     frame_acquisition_files: (
         Optional[
             Annotated["FrameAcquisitionFileWhereClause", strawberry.lazy("graphql_api.types.frame_acquisition_file")]
         ]
         | None
     )
+    frame_acquisition_files_aggregate: (
+        Optional[
+            Annotated[
+                "FrameAcquisitionFileAggregateWhereClause", strawberry.lazy("graphql_api.types.frame_acquisition_file"),
+            ]
+        ]
+        | None
+    )
     tiltseries: Optional[Annotated["TiltseriesWhereClause", strawberry.lazy("graphql_api.types.tiltseries")]] | None
+    tiltseries_aggregate: (
+        Optional[Annotated["TiltseriesAggregateWhereClause", strawberry.lazy("graphql_api.types.tiltseries")]] | None
+    )
     tomogram_voxel_spacings: (
         Optional[
             Annotated["TomogramVoxelSpacingWhereClause", strawberry.lazy("graphql_api.types.tomogram_voxel_spacing")]
         ]
         | None
     )
+    tomogram_voxel_spacings_aggregate: (
+        Optional[
+            Annotated[
+                "TomogramVoxelSpacingAggregateWhereClause", strawberry.lazy("graphql_api.types.tomogram_voxel_spacing"),
+            ]
+        ]
+        | None
+    )
     tomograms: Optional[Annotated["TomogramWhereClause", strawberry.lazy("graphql_api.types.tomogram")]] | None
+    tomograms_aggregate: (
+        Optional[Annotated["TomogramAggregateWhereClause", strawberry.lazy("graphql_api.types.tomogram")]] | None
+    )
     name: Optional[StrComparators] | None
     s3_prefix: Optional[StrComparators] | None
     https_prefix: Optional[StrComparators] | None
     id: Optional[IntComparators] | None
-
-
-@strawberry.input
-class RunAggregateWhereClauseCount(TypedDict):
-    # TODO FIXME - this includes related cols for some reason??!?
-    # Should it only include local cols???
-    arguments: Optional["RunCountColumns"] | None
-    distinct: Optional[bool] | None
-    filter: Optional[RunWhereClause] | None
-    predicate: Optional[IntComparators] | None
-
-
-@strawberry.input
-class RunAggregateWhereClause(TypedDict):
-    count: RunAggregateWhereClauseCount
 
 
 """
@@ -478,26 +534,32 @@ Define Run type
 
 @strawberry.type(description=None)
 class Run(EntityInterface):
-    alignments: Sequence[Annotated["Alignment", strawberry.lazy("graphql_api.types.alignment")]] = load_alignment_rows  # type:ignore
+    alignments: Sequence[Annotated["Alignment", strawberry.lazy("graphql_api.types.alignment")]] = (
+        load_alignment_rows
+    )  # type:ignore
     alignments_aggregate: Optional[Annotated["AlignmentAggregate", strawberry.lazy("graphql_api.types.alignment")]] = (
-        load_alignment_aggregate_rows  # type:ignore
-    )
+        load_alignment_aggregate_rows
+    )  # type:ignore
     annotations: Sequence[Annotated["Annotation", strawberry.lazy("graphql_api.types.annotation")]] = (
-        load_annotation_rows  # type:ignore
-    )
+        load_annotation_rows
+    )  # type:ignore
     annotations_aggregate: Optional[
         Annotated["AnnotationAggregate", strawberry.lazy("graphql_api.types.annotation")]
     ] = load_annotation_aggregate_rows  # type:ignore
-    dataset: Optional[Annotated["Dataset", strawberry.lazy("graphql_api.types.dataset")]] = load_dataset_rows  # type:ignore
+    dataset: Optional[Annotated["Dataset", strawberry.lazy("graphql_api.types.dataset")]] = (
+        load_dataset_rows
+    )  # type:ignore
     dataset_id: int
     frames: Sequence[Annotated["Frame", strawberry.lazy("graphql_api.types.frame")]] = load_frame_rows  # type:ignore
     frames_aggregate: Optional[Annotated["FrameAggregate", strawberry.lazy("graphql_api.types.frame")]] = (
-        load_frame_aggregate_rows  # type:ignore
-    )
-    gain_files: Sequence[Annotated["GainFile", strawberry.lazy("graphql_api.types.gain_file")]] = load_gain_file_rows  # type:ignore
+        load_frame_aggregate_rows
+    )  # type:ignore
+    gain_files: Sequence[Annotated["GainFile", strawberry.lazy("graphql_api.types.gain_file")]] = (
+        load_gain_file_rows
+    )  # type:ignore
     gain_files_aggregate: Optional[Annotated["GainFileAggregate", strawberry.lazy("graphql_api.types.gain_file")]] = (
-        load_gain_file_aggregate_rows  # type:ignore
-    )
+        load_gain_file_aggregate_rows
+    )  # type:ignore
     frame_acquisition_files: Sequence[
         Annotated["FrameAcquisitionFile", strawberry.lazy("graphql_api.types.frame_acquisition_file")]
     ] = load_frame_acquisition_file_rows  # type:ignore
@@ -505,8 +567,8 @@ class Run(EntityInterface):
         Annotated["FrameAcquisitionFileAggregate", strawberry.lazy("graphql_api.types.frame_acquisition_file")]
     ] = load_frame_acquisition_file_aggregate_rows  # type:ignore
     tiltseries: Sequence[Annotated["Tiltseries", strawberry.lazy("graphql_api.types.tiltseries")]] = (
-        load_tiltseries_rows  # type:ignore
-    )
+        load_tiltseries_rows
+    )  # type:ignore
     tiltseries_aggregate: Optional[
         Annotated["TiltseriesAggregate", strawberry.lazy("graphql_api.types.tiltseries")]
     ] = load_tiltseries_aggregate_rows  # type:ignore
@@ -516,10 +578,12 @@ class Run(EntityInterface):
     tomogram_voxel_spacings_aggregate: Optional[
         Annotated["TomogramVoxelSpacingAggregate", strawberry.lazy("graphql_api.types.tomogram_voxel_spacing")]
     ] = load_tomogram_voxel_spacing_aggregate_rows  # type:ignore
-    tomograms: Sequence[Annotated["Tomogram", strawberry.lazy("graphql_api.types.tomogram")]] = load_tomogram_rows  # type:ignore
+    tomograms: Sequence[Annotated["Tomogram", strawberry.lazy("graphql_api.types.tomogram")]] = (
+        load_tomogram_rows
+    )  # type:ignore
     tomograms_aggregate: Optional[Annotated["TomogramAggregate", strawberry.lazy("graphql_api.types.tomogram")]] = (
-        load_tomogram_aggregate_rows  # type:ignore
-    )
+        load_tomogram_aggregate_rows
+    )  # type:ignore
     name: str = strawberry.field(description="Short name for this experiment run")
     s3_prefix: str = strawberry.field(description="The S3 public bucket path where this run is contained")
     https_prefix: str = strawberry.field(description="The HTTPS directory path where this run is contained url")
@@ -567,19 +631,28 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class RunCountColumns(enum.Enum):
-    alignments = "alignments"
-    annotations = "annotations"
-    dataset = "dataset"
-    frames = "frames"
-    gainFiles = "gain_files"
-    frameAcquisitionFiles = "frame_acquisition_files"
-    tiltseries = "tiltseries"
-    tomogramVoxelSpacings = "tomogram_voxel_spacings"
-    tomograms = "tomograms"
     name = "name"
     s3Prefix = "s3_prefix"
     httpsPrefix = "https_prefix"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class RunAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["RunCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[RunWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class RunAggregateWhereClause(TypedDict):
+    count: RunAggregateWhereClauseCount
 
 
 """
@@ -733,9 +806,7 @@ async def resolve_runs_aggregate(
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")
 
-    rows = await get_aggregate_db_rows(
-        db.Run, session, authz_client, principal, where, aggregate_selections, [], groupby_selections
-    )  # type: ignore
+    rows = await get_aggregate_db_rows(db.Run, session, authz_client, principal, where, aggregate_selections, [], groupby_selections)  # type: ignore
     aggregate_output = format_run_aggregate_output(rows)
     return aggregate_output
 
@@ -760,13 +831,7 @@ async def create_run(
     # Check that dataset relationship is accessible.
     if validated.dataset_id:
         dataset = await get_db_rows(
-            db.Dataset,
-            session,
-            authz_client,
-            principal,
-            {"id": {"_eq": validated.dataset_id}},
-            [],
-            AuthzAction.VIEW,
+            db.Dataset, session, authz_client, principal, {"id": {"_eq": validated.dataset_id}}, [], AuthzAction.VIEW,
         )
         if not dataset:
             raise PlatformicsError("Unauthorized: dataset does not exist")
@@ -808,13 +873,7 @@ async def update_run(
     # Check that dataset relationship is accessible.
     if validated.dataset_id:
         dataset = await get_db_rows(
-            db.Dataset,
-            session,
-            authz_client,
-            principal,
-            {"id": {"_eq": validated.dataset_id}},
-            [],
-            AuthzAction.VIEW,
+            db.Dataset, session, authz_client, principal, {"id": {"_eq": validated.dataset_id}}, [], AuthzAction.VIEW,
         )
         if not dataset:
             raise PlatformicsError("Unauthorized: dataset does not exist")

--- a/apiv2/graphql_api/types/run.py
+++ b/apiv2/graphql_api/types/run.py
@@ -444,6 +444,8 @@ class RunWhereClause(TypedDict):
 
 @strawberry.input
 class RunAggregateWhereClauseCount(TypedDict):
+    # TODO FIXME - this includes related cols for some reason??!?
+    # Should it only include local cols???
     arguments: Optional["RunCountColumns"] | None
     distinct: Optional[bool] | None
     filter: Optional[RunWhereClause] | None
@@ -452,7 +454,7 @@ class RunAggregateWhereClauseCount(TypedDict):
 
 @strawberry.input
 class RunAggregateWhereClause(TypedDict):
-    count: Optional[RunAggregateWhereClauseCount] | None
+    count: RunAggregateWhereClauseCount | None
 
 
 """

--- a/apiv2/graphql_api/types/run.py
+++ b/apiv2/graphql_api/types/run.py
@@ -51,6 +51,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections, get_nested_selected_fields
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -172,7 +173,7 @@ async def load_alignment_aggregate_rows(
     info: Info,
     where: Annotated["AlignmentWhereClause", strawberry.lazy("graphql_api.types.alignment")] | None = None,
 ) -> Optional[Annotated["AlignmentAggregate", strawberry.lazy("graphql_api.types.alignment")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Run)
     relationship = mapper.relationships["alignments"]
@@ -204,7 +205,7 @@ async def load_annotation_aggregate_rows(
     info: Info,
     where: Annotated["AnnotationWhereClause", strawberry.lazy("graphql_api.types.annotation")] | None = None,
 ) -> Optional[Annotated["AnnotationAggregate", strawberry.lazy("graphql_api.types.annotation")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Run)
     relationship = mapper.relationships["annotations"]
@@ -247,7 +248,7 @@ async def load_frame_aggregate_rows(
     info: Info,
     where: Annotated["FrameWhereClause", strawberry.lazy("graphql_api.types.frame")] | None = None,
 ) -> Optional[Annotated["FrameAggregate", strawberry.lazy("graphql_api.types.frame")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Run)
     relationship = mapper.relationships["frames"]
@@ -277,7 +278,7 @@ async def load_gain_file_aggregate_rows(
     info: Info,
     where: Annotated["GainFileWhereClause", strawberry.lazy("graphql_api.types.gain_file")] | None = None,
 ) -> Optional[Annotated["GainFileAggregate", strawberry.lazy("graphql_api.types.gain_file")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Run)
     relationship = mapper.relationships["gain_files"]
@@ -317,7 +318,7 @@ async def load_frame_acquisition_file_aggregate_rows(
         Annotated["FrameAcquisitionFileWhereClause", strawberry.lazy("graphql_api.types.frame_acquisition_file")] | None
     ) = None,
 ) -> Optional[Annotated["FrameAcquisitionFileAggregate", strawberry.lazy("graphql_api.types.frame_acquisition_file")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Run)
     relationship = mapper.relationships["frame_acquisition_files"]
@@ -349,7 +350,7 @@ async def load_tiltseries_aggregate_rows(
     info: Info,
     where: Annotated["TiltseriesWhereClause", strawberry.lazy("graphql_api.types.tiltseries")] | None = None,
 ) -> Optional[Annotated["TiltseriesAggregate", strawberry.lazy("graphql_api.types.tiltseries")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Run)
     relationship = mapper.relationships["tiltseries"]
@@ -389,7 +390,7 @@ async def load_tomogram_voxel_spacing_aggregate_rows(
         Annotated["TomogramVoxelSpacingWhereClause", strawberry.lazy("graphql_api.types.tomogram_voxel_spacing")] | None
     ) = None,
 ) -> Optional[Annotated["TomogramVoxelSpacingAggregate", strawberry.lazy("graphql_api.types.tomogram_voxel_spacing")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Run)
     relationship = mapper.relationships["tomogram_voxel_spacings"]
@@ -419,7 +420,7 @@ async def load_tomogram_aggregate_rows(
     info: Info,
     where: Annotated["TomogramWhereClause", strawberry.lazy("graphql_api.types.tomogram")] | None = None,
 ) -> Optional[Annotated["TomogramAggregate", strawberry.lazy("graphql_api.types.tomogram")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Run)
     relationship = mapper.relationships["tomograms"]
@@ -798,10 +799,7 @@ async def resolve_runs_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/run.py
+++ b/apiv2/graphql_api/types/run.py
@@ -7,7 +7,6 @@ Make changes to the template codegen/templates/graphql_api/types/class_name.py.j
 
 # ruff: noqa: E501 Line too long
 
-
 import datetime
 import enum
 import typing
@@ -443,6 +442,19 @@ class RunWhereClause(TypedDict):
     id: Optional[IntComparators] | None
 
 
+@strawberry.input
+class RunAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["RunCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[RunWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class RunAggregateWhereClause(TypedDict):
+    count: Optional[RunAggregateWhereClauseCount] | None
+
+
 """
 Supported ORDER BY clause attributes
 """
@@ -464,32 +476,26 @@ Define Run type
 
 @strawberry.type(description=None)
 class Run(EntityInterface):
-    alignments: Sequence[Annotated["Alignment", strawberry.lazy("graphql_api.types.alignment")]] = (
-        load_alignment_rows
-    )  # type:ignore
+    alignments: Sequence[Annotated["Alignment", strawberry.lazy("graphql_api.types.alignment")]] = load_alignment_rows  # type:ignore
     alignments_aggregate: Optional[Annotated["AlignmentAggregate", strawberry.lazy("graphql_api.types.alignment")]] = (
-        load_alignment_aggregate_rows
-    )  # type:ignore
+        load_alignment_aggregate_rows  # type:ignore
+    )
     annotations: Sequence[Annotated["Annotation", strawberry.lazy("graphql_api.types.annotation")]] = (
-        load_annotation_rows
-    )  # type:ignore
+        load_annotation_rows  # type:ignore
+    )
     annotations_aggregate: Optional[
         Annotated["AnnotationAggregate", strawberry.lazy("graphql_api.types.annotation")]
     ] = load_annotation_aggregate_rows  # type:ignore
-    dataset: Optional[Annotated["Dataset", strawberry.lazy("graphql_api.types.dataset")]] = (
-        load_dataset_rows
-    )  # type:ignore
+    dataset: Optional[Annotated["Dataset", strawberry.lazy("graphql_api.types.dataset")]] = load_dataset_rows  # type:ignore
     dataset_id: int
     frames: Sequence[Annotated["Frame", strawberry.lazy("graphql_api.types.frame")]] = load_frame_rows  # type:ignore
     frames_aggregate: Optional[Annotated["FrameAggregate", strawberry.lazy("graphql_api.types.frame")]] = (
-        load_frame_aggregate_rows
-    )  # type:ignore
-    gain_files: Sequence[Annotated["GainFile", strawberry.lazy("graphql_api.types.gain_file")]] = (
-        load_gain_file_rows
-    )  # type:ignore
+        load_frame_aggregate_rows  # type:ignore
+    )
+    gain_files: Sequence[Annotated["GainFile", strawberry.lazy("graphql_api.types.gain_file")]] = load_gain_file_rows  # type:ignore
     gain_files_aggregate: Optional[Annotated["GainFileAggregate", strawberry.lazy("graphql_api.types.gain_file")]] = (
-        load_gain_file_aggregate_rows
-    )  # type:ignore
+        load_gain_file_aggregate_rows  # type:ignore
+    )
     frame_acquisition_files: Sequence[
         Annotated["FrameAcquisitionFile", strawberry.lazy("graphql_api.types.frame_acquisition_file")]
     ] = load_frame_acquisition_file_rows  # type:ignore
@@ -497,8 +503,8 @@ class Run(EntityInterface):
         Annotated["FrameAcquisitionFileAggregate", strawberry.lazy("graphql_api.types.frame_acquisition_file")]
     ] = load_frame_acquisition_file_aggregate_rows  # type:ignore
     tiltseries: Sequence[Annotated["Tiltseries", strawberry.lazy("graphql_api.types.tiltseries")]] = (
-        load_tiltseries_rows
-    )  # type:ignore
+        load_tiltseries_rows  # type:ignore
+    )
     tiltseries_aggregate: Optional[
         Annotated["TiltseriesAggregate", strawberry.lazy("graphql_api.types.tiltseries")]
     ] = load_tiltseries_aggregate_rows  # type:ignore
@@ -508,12 +514,10 @@ class Run(EntityInterface):
     tomogram_voxel_spacings_aggregate: Optional[
         Annotated["TomogramVoxelSpacingAggregate", strawberry.lazy("graphql_api.types.tomogram_voxel_spacing")]
     ] = load_tomogram_voxel_spacing_aggregate_rows  # type:ignore
-    tomograms: Sequence[Annotated["Tomogram", strawberry.lazy("graphql_api.types.tomogram")]] = (
-        load_tomogram_rows
-    )  # type:ignore
+    tomograms: Sequence[Annotated["Tomogram", strawberry.lazy("graphql_api.types.tomogram")]] = load_tomogram_rows  # type:ignore
     tomograms_aggregate: Optional[Annotated["TomogramAggregate", strawberry.lazy("graphql_api.types.tomogram")]] = (
-        load_tomogram_aggregate_rows
-    )  # type:ignore
+        load_tomogram_aggregate_rows  # type:ignore
+    )
     name: str = strawberry.field(description="Short name for this experiment run")
     s3_prefix: str = strawberry.field(description="The S3 public bucket path where this run is contained")
     https_prefix: str = strawberry.field(description="The HTTPS directory path where this run is contained url")
@@ -727,7 +731,9 @@ async def resolve_runs_aggregate(
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")
 
-    rows = await get_aggregate_db_rows(db.Run, session, authz_client, principal, where, aggregate_selections, [], groupby_selections)  # type: ignore
+    rows = await get_aggregate_db_rows(
+        db.Run, session, authz_client, principal, where, aggregate_selections, [], groupby_selections
+    )  # type: ignore
     aggregate_output = format_run_aggregate_output(rows)
     return aggregate_output
 
@@ -752,7 +758,13 @@ async def create_run(
     # Check that dataset relationship is accessible.
     if validated.dataset_id:
         dataset = await get_db_rows(
-            db.Dataset, session, authz_client, principal, {"id": {"_eq": validated.dataset_id}}, [], AuthzAction.VIEW,
+            db.Dataset,
+            session,
+            authz_client,
+            principal,
+            {"id": {"_eq": validated.dataset_id}},
+            [],
+            AuthzAction.VIEW,
         )
         if not dataset:
             raise PlatformicsError("Unauthorized: dataset does not exist")
@@ -794,7 +806,13 @@ async def update_run(
     # Check that dataset relationship is accessible.
     if validated.dataset_id:
         dataset = await get_db_rows(
-            db.Dataset, session, authz_client, principal, {"id": {"_eq": validated.dataset_id}}, [], AuthzAction.VIEW,
+            db.Dataset,
+            session,
+            authz_client,
+            principal,
+            {"id": {"_eq": validated.dataset_id}},
+            [],
+            AuthzAction.VIEW,
         )
         if not dataset:
             raise PlatformicsError("Unauthorized: dataset does not exist")

--- a/apiv2/graphql_api/types/tiltseries.py
+++ b/apiv2/graphql_api/types/tiltseries.py
@@ -42,6 +42,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections, get_nested_selected_fields
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -108,7 +109,7 @@ async def load_alignment_aggregate_rows(
     info: Info,
     where: Annotated["AlignmentWhereClause", strawberry.lazy("graphql_api.types.alignment")] | None = None,
 ) -> Optional[Annotated["AlignmentAggregate", strawberry.lazy("graphql_api.types.alignment")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Tiltseries)
     relationship = mapper.relationships["alignments"]
@@ -750,10 +751,7 @@ async def resolve_tiltseries_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/tiltseries.py
+++ b/apiv2/graphql_api/types/tiltseries.py
@@ -48,19 +48,32 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.alignment import Alignment, AlignmentOrderByClause, AlignmentWhereClause
-    from graphql_api.types.deposition import Deposition, DepositionOrderByClause, DepositionWhereClause
-    from graphql_api.types.run import Run, RunOrderByClause, RunWhereClause
+    from graphql_api.types.alignment import (
+        Alignment,
+        AlignmentAggregateWhereClause,
+        AlignmentOrderByClause,
+        AlignmentWhereClause,
+    )
+    from graphql_api.types.deposition import (
+        Deposition,
+        DepositionAggregateWhereClause,
+        DepositionOrderByClause,
+        DepositionWhereClause,
+    )
+    from graphql_api.types.run import Run, RunAggregateWhereClause, RunOrderByClause, RunWhereClause
 
     pass
 else:
     AlignmentWhereClause = "AlignmentWhereClause"
+    AlignmentAggregateWhereClause = "AlignmentAggregateWhereClause"
     Alignment = "Alignment"
     AlignmentOrderByClause = "AlignmentOrderByClause"
     RunWhereClause = "RunWhereClause"
+    RunAggregateWhereClause = "RunAggregateWhereClause"
     Run = "Run"
     RunOrderByClause = "RunOrderByClause"
     DepositionWhereClause = "DepositionWhereClause"
+    DepositionAggregateWhereClause = "DepositionAggregateWhereClause"
     Deposition = "Deposition"
     DepositionOrderByClause = "DepositionOrderByClause"
     pass
@@ -158,6 +171,9 @@ Supported WHERE clause attributes
 @strawberry.input
 class TiltseriesWhereClause(TypedDict):
     alignments: Optional[Annotated["AlignmentWhereClause", strawberry.lazy("graphql_api.types.alignment")]] | None
+    alignments_aggregate: (
+        Optional[Annotated["AlignmentAggregateWhereClause", strawberry.lazy("graphql_api.types.alignment")]] | None
+    )
     run: Optional[Annotated["RunWhereClause", strawberry.lazy("graphql_api.types.run")]] | None
     run_id: Optional[IntComparators] | None
     deposition: Optional[Annotated["DepositionWhereClause", strawberry.lazy("graphql_api.types.deposition")]] | None
@@ -413,9 +429,6 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class TiltseriesCountColumns(enum.Enum):
-    alignments = "alignments"
-    run = "run"
-    deposition = "deposition"
     s3OmezarrDir = "s3_omezarr_dir"
     s3MrcFile = "s3_mrc_file"
     httpsOmezarrDir = "https_omezarr_dir"
@@ -450,6 +463,24 @@ class TiltseriesCountColumns(enum.Enum):
     sizeY = "size_y"
     sizeZ = "size_z"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class TiltseriesAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["TiltseriesCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[TiltseriesWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class TiltseriesAggregateWhereClause(TypedDict):
+    count: TiltseriesAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/tomogram.py
+++ b/apiv2/graphql_api/types/tomogram.py
@@ -49,12 +49,28 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.alignment import Alignment, AlignmentOrderByClause, AlignmentWhereClause
-    from graphql_api.types.deposition import Deposition, DepositionOrderByClause, DepositionWhereClause
-    from graphql_api.types.run import Run, RunOrderByClause, RunWhereClause
-    from graphql_api.types.tomogram_author import TomogramAuthor, TomogramAuthorOrderByClause, TomogramAuthorWhereClause
+    from graphql_api.types.alignment import (
+        Alignment,
+        AlignmentAggregateWhereClause,
+        AlignmentOrderByClause,
+        AlignmentWhereClause,
+    )
+    from graphql_api.types.deposition import (
+        Deposition,
+        DepositionAggregateWhereClause,
+        DepositionOrderByClause,
+        DepositionWhereClause,
+    )
+    from graphql_api.types.run import Run, RunAggregateWhereClause, RunOrderByClause, RunWhereClause
+    from graphql_api.types.tomogram_author import (
+        TomogramAuthor,
+        TomogramAuthorAggregateWhereClause,
+        TomogramAuthorOrderByClause,
+        TomogramAuthorWhereClause,
+    )
     from graphql_api.types.tomogram_voxel_spacing import (
         TomogramVoxelSpacing,
+        TomogramVoxelSpacingAggregateWhereClause,
         TomogramVoxelSpacingOrderByClause,
         TomogramVoxelSpacingWhereClause,
     )
@@ -62,18 +78,23 @@ if TYPE_CHECKING:
     pass
 else:
     AlignmentWhereClause = "AlignmentWhereClause"
+    AlignmentAggregateWhereClause = "AlignmentAggregateWhereClause"
     Alignment = "Alignment"
     AlignmentOrderByClause = "AlignmentOrderByClause"
     TomogramAuthorWhereClause = "TomogramAuthorWhereClause"
+    TomogramAuthorAggregateWhereClause = "TomogramAuthorAggregateWhereClause"
     TomogramAuthor = "TomogramAuthor"
     TomogramAuthorOrderByClause = "TomogramAuthorOrderByClause"
     DepositionWhereClause = "DepositionWhereClause"
+    DepositionAggregateWhereClause = "DepositionAggregateWhereClause"
     Deposition = "Deposition"
     DepositionOrderByClause = "DepositionOrderByClause"
     RunWhereClause = "RunWhereClause"
+    RunAggregateWhereClause = "RunAggregateWhereClause"
     Run = "Run"
     RunOrderByClause = "RunOrderByClause"
     TomogramVoxelSpacingWhereClause = "TomogramVoxelSpacingWhereClause"
+    TomogramVoxelSpacingAggregateWhereClause = "TomogramVoxelSpacingAggregateWhereClause"
     TomogramVoxelSpacing = "TomogramVoxelSpacing"
     TomogramVoxelSpacingOrderByClause = "TomogramVoxelSpacingOrderByClause"
     pass
@@ -212,6 +233,10 @@ class TomogramWhereClause(TypedDict):
     alignment_id: Optional[IntComparators] | None
     authors: (
         Optional[Annotated["TomogramAuthorWhereClause", strawberry.lazy("graphql_api.types.tomogram_author")]] | None
+    )
+    authors_aggregate: (
+        Optional[Annotated["TomogramAuthorAggregateWhereClause", strawberry.lazy("graphql_api.types.tomogram_author")]]
+        | None
     )
     deposition: Optional[Annotated["DepositionWhereClause", strawberry.lazy("graphql_api.types.deposition")]] | None
     deposition_id: Optional[IntComparators] | None
@@ -495,11 +520,6 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class TomogramCountColumns(enum.Enum):
-    alignment = "alignment"
-    authors = "authors"
-    deposition = "deposition"
-    run = "run"
-    tomogramVoxelSpacing = "tomogram_voxel_spacing"
     name = "name"
     sizeX = "size_x"
     sizeY = "size_y"
@@ -534,6 +554,24 @@ class TomogramCountColumns(enum.Enum):
     depositionDate = "deposition_date"
     releaseDate = "release_date"
     lastModifiedDate = "last_modified_date"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class TomogramAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["TomogramCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[TomogramWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class TomogramAggregateWhereClause(TypedDict):
+    count: TomogramAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/tomogram.py
+++ b/apiv2/graphql_api/types/tomogram.py
@@ -43,6 +43,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections, get_nested_selected_fields
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -146,7 +147,7 @@ async def load_tomogram_author_aggregate_rows(
     info: Info,
     where: Annotated["TomogramAuthorWhereClause", strawberry.lazy("graphql_api.types.tomogram_author")] | None = None,
 ) -> Optional[Annotated["TomogramAuthorAggregate", strawberry.lazy("graphql_api.types.tomogram_author")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.Tomogram)
     relationship = mapper.relationships["authors"]
@@ -881,10 +882,7 @@ async def resolve_tomograms_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/tomogram_author.py
+++ b/apiv2/graphql_api/types/tomogram_author.py
@@ -43,11 +43,17 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.tomogram import Tomogram, TomogramOrderByClause, TomogramWhereClause
+    from graphql_api.types.tomogram import (
+        Tomogram,
+        TomogramAggregateWhereClause,
+        TomogramOrderByClause,
+        TomogramWhereClause,
+    )
 
     pass
 else:
     TomogramWhereClause = "TomogramWhereClause"
+    TomogramAggregateWhereClause = "TomogramAggregateWhereClause"
     Tomogram = "Tomogram"
     TomogramOrderByClause = "TomogramOrderByClause"
     pass
@@ -217,7 +223,6 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class TomogramAuthorCountColumns(enum.Enum):
-    tomogram = "tomogram"
     id = "id"
     authorListOrder = "author_list_order"
     orcid = "orcid"
@@ -228,6 +233,24 @@ class TomogramAuthorCountColumns(enum.Enum):
     affiliationIdentifier = "affiliation_identifier"
     correspondingAuthorStatus = "corresponding_author_status"
     primaryAuthorStatus = "primary_author_status"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class TomogramAuthorAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["TomogramAuthorCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[TomogramAuthorWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class TomogramAuthorAggregateWhereClause(TypedDict):
+    count: TomogramAuthorAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/tomogram_author.py
+++ b/apiv2/graphql_api/types/tomogram_author.py
@@ -37,6 +37,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -442,10 +443,7 @@ async def resolve_tomogram_authors_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/graphql_api/types/tomogram_voxel_spacing.py
+++ b/apiv2/graphql_api/types/tomogram_voxel_spacing.py
@@ -52,19 +52,32 @@ E = typing.TypeVar("E")
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
-    from graphql_api.types.annotation_file import AnnotationFile, AnnotationFileOrderByClause, AnnotationFileWhereClause
-    from graphql_api.types.run import Run, RunOrderByClause, RunWhereClause
-    from graphql_api.types.tomogram import Tomogram, TomogramOrderByClause, TomogramWhereClause
+    from graphql_api.types.annotation_file import (
+        AnnotationFile,
+        AnnotationFileAggregateWhereClause,
+        AnnotationFileOrderByClause,
+        AnnotationFileWhereClause,
+    )
+    from graphql_api.types.run import Run, RunAggregateWhereClause, RunOrderByClause, RunWhereClause
+    from graphql_api.types.tomogram import (
+        Tomogram,
+        TomogramAggregateWhereClause,
+        TomogramOrderByClause,
+        TomogramWhereClause,
+    )
 
     pass
 else:
     AnnotationFileWhereClause = "AnnotationFileWhereClause"
+    AnnotationFileAggregateWhereClause = "AnnotationFileAggregateWhereClause"
     AnnotationFile = "AnnotationFile"
     AnnotationFileOrderByClause = "AnnotationFileOrderByClause"
     RunWhereClause = "RunWhereClause"
+    RunAggregateWhereClause = "RunAggregateWhereClause"
     Run = "Run"
     RunOrderByClause = "RunOrderByClause"
     TomogramWhereClause = "TomogramWhereClause"
+    TomogramAggregateWhereClause = "TomogramAggregateWhereClause"
     Tomogram = "Tomogram"
     TomogramOrderByClause = "TomogramOrderByClause"
     pass
@@ -183,9 +196,16 @@ class TomogramVoxelSpacingWhereClause(TypedDict):
     annotation_files: (
         Optional[Annotated["AnnotationFileWhereClause", strawberry.lazy("graphql_api.types.annotation_file")]] | None
     )
+    annotation_files_aggregate: (
+        Optional[Annotated["AnnotationFileAggregateWhereClause", strawberry.lazy("graphql_api.types.annotation_file")]]
+        | None
+    )
     run: Optional[Annotated["RunWhereClause", strawberry.lazy("graphql_api.types.run")]] | None
     run_id: Optional[IntComparators] | None
     tomograms: Optional[Annotated["TomogramWhereClause", strawberry.lazy("graphql_api.types.tomogram")]] | None
+    tomograms_aggregate: (
+        Optional[Annotated["TomogramAggregateWhereClause", strawberry.lazy("graphql_api.types.tomogram")]] | None
+    )
     voxel_spacing: Optional[FloatComparators] | None
     s3_prefix: Optional[StrComparators] | None
     https_prefix: Optional[StrComparators] | None
@@ -281,13 +301,28 @@ Define enum of all columns to support count and count(distinct) aggregations
 
 @strawberry.enum
 class TomogramVoxelSpacingCountColumns(enum.Enum):
-    annotationFiles = "annotation_files"
-    run = "run"
-    tomograms = "tomograms"
     voxelSpacing = "voxel_spacing"
     s3Prefix = "s3_prefix"
     httpsPrefix = "https_prefix"
     id = "id"
+
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+
+
+@strawberry.input
+class TomogramVoxelSpacingAggregateWhereClauseCount(TypedDict):
+    arguments: Optional["TomogramVoxelSpacingCountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[TomogramVoxelSpacingWhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class TomogramVoxelSpacingAggregateWhereClause(TypedDict):
+    count: TomogramVoxelSpacingAggregateWhereClauseCount
 
 
 """

--- a/apiv2/graphql_api/types/tomogram_voxel_spacing.py
+++ b/apiv2/graphql_api/types/tomogram_voxel_spacing.py
@@ -46,6 +46,7 @@ from platformics.graphql_api.core.query_input_types import (
 )
 from platformics.graphql_api.core.relay_interface import EntityInterface
 from platformics.graphql_api.core.strawberry_extensions import DependencyExtension
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections, get_nested_selected_fields
 from platformics.security.authorization import AuthzAction, AuthzClient, Principal
 
 E = typing.TypeVar("E")
@@ -116,7 +117,7 @@ async def load_annotation_file_aggregate_rows(
     info: Info,
     where: Annotated["AnnotationFileWhereClause", strawberry.lazy("graphql_api.types.annotation_file")] | None = None,
 ) -> Optional[Annotated["AnnotationFileAggregate", strawberry.lazy("graphql_api.types.annotation_file")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.TomogramVoxelSpacing)
     relationship = mapper.relationships["annotation_files"]
@@ -159,7 +160,7 @@ async def load_tomogram_aggregate_rows(
     info: Info,
     where: Annotated["TomogramWhereClause", strawberry.lazy("graphql_api.types.tomogram")] | None = None,
 ) -> Optional[Annotated["TomogramAggregate", strawberry.lazy("graphql_api.types.tomogram")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.TomogramVoxelSpacing)
     relationship = mapper.relationships["tomograms"]
@@ -484,10 +485,7 @@ async def resolve_tomogram_voxel_spacings_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if selection.name != "groupBy"]
-    groupby_selections = [selection for selection in selections if selection.name == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/platformics/graphql_api/core/query_builder.py
+++ b/apiv2/platformics/graphql_api/core/query_builder.py
@@ -12,8 +12,8 @@ from sqlalchemy.engine.row import RowMapping
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import Select
-from typing_extensions import TypedDict
 from strawberry.types.nodes import SelectedField
+from typing_extensions import TypedDict
 
 from platformics.database.models.base import Base
 from platformics.graphql_api.core.errors import PlatformicsError
@@ -99,8 +99,8 @@ def convert_where_clauses_to_sql(
     for col, v in where_clause.items():
         if col in mapper.relationships:  # type: ignore
             where_joins[col]["where"] = v
-        elif col.rstrip("_aggregate") in mapper.relationships:
-            col_name = col.rstrip("_aggregate")
+        elif col.removesuffix("_aggregate") in mapper.relationships:
+            col_name = col.removesuffix("_aggregate")
             aggregate_joins[col_name] = v
         else:
             local_where_clauses[col] = v

--- a/apiv2/platformics/graphql_api/core/strawberry_helpers.py
+++ b/apiv2/platformics/graphql_api/core/strawberry_helpers.py
@@ -1,0 +1,35 @@
+from strawberry.types.nodes import SelectedField
+from platformics.graphql_api.core.errors import PlatformicsError
+from typing import Tuple
+
+def filter_meta_fields(selections: list[SelectedField]) -> list[SelectedField]:
+    return [item for item in selections if not item.name.startswith("__")]
+
+def get_field_by_name(selections: list[SelectedField], item_name: str) -> SelectedField:
+    for item in selections:
+        if item.name == item_name:
+            return item
+
+def exclude_fields_by_name(selections: list[SelectedField], item_name: str) -> list[SelectedField]:
+    return [item for item in selections if item.name != item_name]
+
+def get_nested_selected_fields(selected_fields: list[SelectedField]) -> list[SelectedField]:
+    selected_fields = selected_fields[0].selections
+    selections = []
+    for outer_field in filter_meta_fields(selected_fields):
+        selections.extend(filter_meta_fields(outer_field.selections))
+    return selections
+
+
+def get_aggregate_selections(selected_fields: list[SelectedField]) -> Tuple[list[SelectedField], list[SelectedField]]:
+    schema_fields = get_nested_selected_fields(selected_fields)
+    aggregate_selections = exclude_fields_by_name(schema_fields, "groupBy")
+    groupby = get_field_by_name(schema_fields, "groupBy")
+    groupby_selections = []
+    if groupby:
+        groupby_selections.extend(filter_meta_fields(groupby.selections))
+
+    if not aggregate_selections:
+        raise PlatformicsError("No aggregate functions selected")
+
+    return aggregate_selections, groupby_selections

--- a/apiv2/platformics/graphql_api/core/strawberry_helpers.py
+++ b/apiv2/platformics/graphql_api/core/strawberry_helpers.py
@@ -1,17 +1,23 @@
-from strawberry.types.nodes import SelectedField
-from platformics.graphql_api.core.errors import PlatformicsError
 from typing import Tuple
+
+from strawberry.types.nodes import SelectedField
+
+from platformics.graphql_api.core.errors import PlatformicsError
+
 
 def filter_meta_fields(selections: list[SelectedField]) -> list[SelectedField]:
     return [item for item in selections if not item.name.startswith("__")]
+
 
 def get_field_by_name(selections: list[SelectedField], item_name: str) -> SelectedField:
     for item in selections:
         if item.name == item_name:
             return item
 
+
 def exclude_fields_by_name(selections: list[SelectedField], item_name: str) -> list[SelectedField]:
     return [item for item in selections if item.name != item_name]
+
 
 def get_nested_selected_fields(selected_fields: list[SelectedField]) -> list[SelectedField]:
     selected_fields = selected_fields[0].selections

--- a/apiv2/template_overrides/graphql_api/types/class_name.py.j2
+++ b/apiv2/template_overrides/graphql_api/types/class_name.py.j2
@@ -144,7 +144,7 @@ T = typing.TypeVar("T")
 if TYPE_CHECKING:
     {%- for related_field in related_fields %}
         {%- if related_field.related_class.name not in ignored_fields %}
-    from graphql_api.types.{{related_field.related_class.snake_name}} import ({{related_field.related_class.name}}OrderByClause, {{related_field.related_class.name}}WhereClause, {{related_field.related_class.name}})
+    from graphql_api.types.{{related_field.related_class.snake_name}} import ({{related_field.related_class.name}}OrderByClause, {{related_field.related_class.name}}AggregateWhereClause, {{related_field.related_class.name}}WhereClause, {{related_field.related_class.name}})
         {%- endif %}
     {%- endfor %}
     pass
@@ -152,6 +152,7 @@ else:
     {%- for related_field in related_fields %}
         {%- if related_field.related_class.name not in ignored_fields %}
     {{related_field.related_class.name}}WhereClause = "{{related_field.related_class.name}}WhereClause"
+    {{related_field.related_class.name}}AggregateWhereClause = "{{related_field.related_class.name}}AggregateWhereClause"
     {{related_field.related_class.name}} = "{{related_field.related_class.name}}"
     {{related_field.related_class.name}}OrderByClause = "{{related_field.related_class.name}}OrderByClause"
         {%- endif %}
@@ -283,6 +284,9 @@ class {{ cls.name }}WhereClause(TypedDict):
         {%- if attr.inverse and not attr.multivalued %}
     {{ attr.name }}_id : Optional[{{ getComparators(attr.related_class.identifier) }}] | None
         {%- endif %}
+        {%- if attr.is_virtual_relationship %}
+    {{ attr.name }}_aggregate : Optional[Annotated["{{ attr.type }}AggregateWhereClause", strawberry.lazy("graphql_api.types.{{ attr.related_class.snake_name }}")]] | None
+        {%- endif %}
     {%- endfor %}
 
 """
@@ -378,8 +382,25 @@ Define enum of all columns to support count and count(distinct) aggregations
 @strawberry.enum
 class {{ cls.name }}CountColumns(enum.Enum):
     {%- for attr in cls.visible_fields %}
+        {%- if not attr.is_entity %}
     {{ attr.camel_name }} = "{{ attr.name }}"
+        {%- endif %}
     {%- endfor %}
+
+"""
+Support *filtering* on aggregates and related aggregates
+"""
+@strawberry.input
+class {{ cls.name }}AggregateWhereClauseCount(TypedDict):
+    arguments: Optional["{{ cls.name }}CountColumns"] | None
+    distinct: Optional[bool] | None
+    filter: Optional[{{ cls.name }}WhereClause] | None
+    predicate: Optional[IntComparators] | None
+
+
+@strawberry.input
+class {{ cls.name }}AggregateWhereClause(TypedDict):
+    count: {{ cls.name }}AggregateWhereClauseCount
 
 """
 All supported aggregation functions

--- a/apiv2/template_overrides/graphql_api/types/class_name.py.j2
+++ b/apiv2/template_overrides/graphql_api/types/class_name.py.j2
@@ -94,6 +94,7 @@ import typing
 from typing import TYPE_CHECKING, Annotated, Any, Optional, Sequence, Callable, List
 
 import platformics.database.models as base_db
+from platformics.graphql_api.core.strawberry_helpers import get_aggregate_selections, get_nested_selected_fields
 import database.models as db
 import strawberry
 import datetime
@@ -211,7 +212,7 @@ async def load_{{ related_field.related_class.snake_name }}_aggregate_rows(
     info: Info,
     where: Annotated["{{ related_field.type }}WhereClause", strawberry.lazy("graphql_api.types.{{ related_field.related_class.snake_name }}")] | None = None,
 ) -> Optional[Annotated["{{ related_field.related_class.name }}Aggregate", strawberry.lazy("graphql_api.types.{{ related_field.related_class.snake_name }}")]]:
-    selections = info.selected_fields[0].selections[0].selections
+    selections = get_nested_selected_fields(info.selected_fields)
     dataloader = info.context["sqlalchemy_loader"]
     mapper = inspect(db.{{ cls.name }})
     relationship = mapper.relationships["{{ related_field.name }}"]
@@ -531,10 +532,7 @@ async def resolve_{{ cls.plural_snake_name }}_aggregate(
     """
     # Get the selected aggregate functions and columns to operate on, and groupby options if any were provided.
     # TODO: not sure why selected_fields is a list
-    selections = info.selected_fields[0].selections[0].selections
-    aggregate_selections = [selection for selection in selections if getattr(selection, "name") != "groupBy"]
-    groupby_selections = [selection for selection in selections if getattr(selection, "name") == "groupBy"]
-    groupby_selections = groupby_selections[0].selections if groupby_selections else []
+    aggregate_selections, groupby_selections = get_aggregate_selections(info.selected_fields)
 
     if not aggregate_selections:
         raise PlatformicsError("No aggregate functions selected")

--- a/apiv2/tests/helpers.py
+++ b/apiv2/tests/helpers.py
@@ -1,0 +1,35 @@
+import operator
+
+
+# Helper for checking deep equality of python dict/list objects
+# Source: https://gist.github.com/samuraisam/901117/521ed1ff8937cb43d7fcdbc1a6f6d0ed2c723bae
+def deep_eq(_v1, _v2):
+    def _deep_dict_eq(d1, d2):
+        k1 = sorted(d1.keys())
+        k2 = sorted(d2.keys())
+        if k1 != k2:  # keys should be exactly equal
+            return False
+        return sum(deep_eq(d1[k], d2[k]) for k in k1) == len(k1)
+
+    def _deep_iter_eq(l1, l2):
+        if len(l1) != len(l2):
+            return False
+        return sum(deep_eq(v1, v2) for v1, v2 in zip(l1, l2, strict=False)) == len(l1)
+
+    op = operator.eq
+    c1, c2 = (_v1, _v2)
+
+    # guard against strings because they are also iterable
+    # and will consistently cause a RuntimeError (maximum recursion limit reached)
+    if not isinstance(_v1, str):
+        if isinstance(_v1, dict):
+            op = _deep_dict_eq
+        else:
+            try:
+                c1, c2 = (list(iter(_v1)), list(iter(_v2)))
+            except TypeError:
+                c1, c2 = _v1, _v2
+            else:
+                op = _deep_iter_eq
+
+    return op(c1, c2)

--- a/apiv2/tests/test_aggregate_filters.py
+++ b/apiv2/tests/test_aggregate_filters.py
@@ -9,6 +9,7 @@ import pytest
 from platformics.database.connect import SyncDB
 from platformics.test_infra.factories.base import SessionStorage
 from test_infra.factories.dataset import DatasetFactory
+from test_infra.factories.deposition import DepositionFactory
 from test_infra.factories.run import RunFactory
 
 date_now = datetime.datetime.now()

--- a/apiv2/tests/test_aggregate_filters.py
+++ b/apiv2/tests/test_aggregate_filters.py
@@ -1,0 +1,86 @@
+"""
+Test basic queries and mutations
+"""
+
+import datetime
+
+import pytest
+
+from platformics.database.connect import SyncDB
+from platformics.test_infra.factories.base import SessionStorage
+from test_infra.factories.annotation import AnnotationFactory
+from test_infra.factories.deposition import DepositionFactory
+from test_infra.factories.dataset import DatasetFactory
+from test_infra.factories.annotation_shape import AnnotationShapeFactory
+from test_infra.factories.dataset import DatasetFactory, DepositionFactory
+from test_infra.factories.run import RunFactory
+
+date_now = datetime.datetime.now()
+
+
+@pytest.mark.asyncio
+async def test_simple_aggregate(
+    sync_db: SyncDB,
+    gql_client,
+) -> None:
+    """
+    Test that we can filter datasets by the number of runs they have
+    """
+
+    # Create mock data
+    with sync_db.session() as session:
+        SessionStorage.set_session(session)
+        d1 = DatasetFactory.create(id=12345)
+        d2 = DatasetFactory.create(id=23456)
+        d3 = DatasetFactory.create(id=34567)
+        d4 = DatasetFactory.create(id=45678)
+        RunFactory.create_batch(3, dataset=d1, name="__first__")
+        RunFactory.create_batch(6, dataset=d2, name="__second__")
+        RunFactory.create_batch(9, dataset=d3, name="__third__")
+
+    # Fetch all datasets that have at least one run
+    query = """
+        query MyQuery {
+            datasets(
+                where: {runsAggregate: {count: {predicate: {_gt: 0}}}}
+            ) {
+                id
+            }
+        }
+    """
+    output = await gql_client.query(query)
+    dataset_ids = {item["id"] for item in output["data"]["datasets"]}
+    assert dataset_ids == {12345, 23456, 34567}
+
+    # Fetch all datasets that have between 4 and 8 runs
+    query = """
+        query MyQuery {
+            datasets(
+                where: {runsAggregate: {count: {predicate: {_gt: 3, _lt: 9}}}}
+            ) {
+                id
+            }
+        }
+    """
+    output = await gql_client.query(query)
+    dataset_ids = {item["id"] for item in output["data"]["datasets"]}
+    assert dataset_ids == {23456}
+
+    # Fetch datasets that <= 1 unique run name starting with "RUN"
+    query = """
+        query MyQuery {
+            datasets(
+              where: {runsAggregate: {count: {
+                predicate: {_eq: 1},
+                distinct: true,
+                arguments: name,
+                filter: {name: {_like: "%second%"}}}
+              }}
+            ) {
+              id
+            }
+        }
+    """
+    output = await gql_client.query(query)
+    dataset_ids = {item["id"] for item in output["data"]["datasets"]}
+    assert dataset_ids == {23456}

--- a/apiv2/tests/test_aggregate_filters.py
+++ b/apiv2/tests/test_aggregate_filters.py
@@ -8,11 +8,7 @@ import pytest
 
 from platformics.database.connect import SyncDB
 from platformics.test_infra.factories.base import SessionStorage
-from test_infra.factories.annotation import AnnotationFactory
-from test_infra.factories.deposition import DepositionFactory
 from test_infra.factories.dataset import DatasetFactory
-from test_infra.factories.annotation_shape import AnnotationShapeFactory
-from test_infra.factories.dataset import DatasetFactory, DepositionFactory
 from test_infra.factories.run import RunFactory
 
 date_now = datetime.datetime.now()

--- a/apiv2/tests/test_gql_meta_support.py
+++ b/apiv2/tests/test_gql_meta_support.py
@@ -5,7 +5,7 @@ Test basic queries and mutations
 import datetime
 
 import pytest
-from conftest import deep_eq
+from tests.helpers import deep_eq
 
 from platformics.database.connect import SyncDB
 from platformics.test_infra.factories.base import SessionStorage

--- a/apiv2/tests/test_gql_meta_support.py
+++ b/apiv2/tests/test_gql_meta_support.py
@@ -8,9 +8,7 @@ import pytest
 
 from platformics.database.connect import SyncDB
 from platformics.test_infra.factories.base import SessionStorage
-from test_infra.factories.dataset import DatasetFactory
 from test_infra.factories.deposition import DepositionFactory
-from test_infra.factories.run import RunFactory
 
 date_now = datetime.datetime.now()
 

--- a/apiv2/tests/test_gql_meta_support.py
+++ b/apiv2/tests/test_gql_meta_support.py
@@ -5,21 +5,23 @@ Test basic queries and mutations
 import datetime
 
 import pytest
+from conftest import deep_eq
 
 from platformics.database.connect import SyncDB
 from platformics.test_infra.factories.base import SessionStorage
+from test_infra.factories.dataset import DatasetFactory
 from test_infra.factories.deposition import DepositionFactory
 
 date_now = datetime.datetime.now()
 
 
 @pytest.mark.asyncio
-async def test_meta_fields_aggregate(
+async def test_top_meta_fields_aggregate(
     sync_db: SyncDB,
     gql_client,
 ) -> None:
     """
-    Test that we can filter datasets by the number of runs they have
+    Test that we can include gql meta fields at each level of an aggregate query
     """
 
     # Create mock data
@@ -55,3 +57,130 @@ async def test_meta_fields_aggregate(
         assert item["count"] == 1
         assert item["groupBy"]["__typename"] == "DepositionGroupByOptions"
         assert item["groupBy"]["id"] in dep_ids
+
+
+@pytest.mark.asyncio
+async def test_nested_meta_fields_aggregate(
+    sync_db: SyncDB,
+    gql_client,
+) -> None:
+    """
+    Test that we can include gql meta fields at each level of a nested aggregate query
+    """
+
+    # Create mock data
+    with sync_db.session() as session:
+        SessionStorage.set_session(session)
+        d1 = DepositionFactory.create(id=12345)
+        DatasetFactory.create(deposition=d1, id=222)
+
+    # Fetch all datasets that have at least one run
+    query = """
+        query MyQuery {
+          depositions {
+            __typename
+            id
+            datasetsAggregate {
+              __typename
+              aggregate {
+                __typename
+                count(columns: id, distinct: true)
+                sum {
+                  __typename
+                  id
+                }
+                groupBy {
+                  __typename
+                  id
+                }
+              }
+            }
+          }
+        }
+    """
+    output = await gql_client.query(query)
+    assert len(output["data"]["depositions"]) == 1
+    aggregate = output["data"]["depositions"][0]
+    assert aggregate["__typename"] == "Deposition"
+    assert aggregate["id"] == 12345
+
+    agg_info = aggregate["datasetsAggregate"]
+    assert agg_info["__typename"] == "DatasetAggregate"
+    assert len(agg_info["aggregate"]) == 1
+
+    agg_data = agg_info["aggregate"][0]
+    assert agg_data["__typename"] == "DatasetAggregateFunctions"
+    assert agg_data["count"] == 1
+    assert agg_data["sum"]["__typename"] == "DatasetNumericalColumns"
+    assert agg_data["sum"]["id"] == 222
+    assert agg_data["groupBy"]["__typename"] == "DatasetGroupByOptions"
+    assert agg_data["groupBy"]["id"] == 222
+
+
+@pytest.mark.asyncio
+async def test_nested_meta_fields_resolver(
+    sync_db: SyncDB,
+    gql_client,
+) -> None:
+    """
+    Test that we can include gql meta fields at each level of a nested NON-aggregate query
+    """
+
+    # Create mock data
+    with sync_db.session() as session:
+        SessionStorage.set_session(session)
+        d1 = DepositionFactory.create(id=12345)
+        DatasetFactory.create(deposition=d1, id=222)
+
+    # Fetch all datasets that have at least one run
+    query = """
+        query MyQuery {
+          depositions {
+            __typename
+            id
+            datasets {
+              __typename
+              edges {
+                __typename
+                node {
+                  __typename
+                  id
+                  deposition {
+                    __typename
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+    output = await gql_client.query(query)
+
+    expected = {
+        "data": {
+            "depositions": [
+                {
+                    "__typename": "Deposition",
+                    "id": 12345,
+                    "datasets": {
+                        "__typename": "DatasetConnection",
+                        "edges": [
+                            {
+                                "__typename": "DatasetEdge",
+                                "node": {
+                                    "__typename": "Dataset",
+                                    "id": 222,
+                                    "deposition": {
+                                        "__typename": "Deposition",
+                                        "id": 12345,
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    }
+    assert deep_eq(output, expected)

--- a/apiv2/tests/test_gql_meta_support.py
+++ b/apiv2/tests/test_gql_meta_support.py
@@ -1,0 +1,59 @@
+"""
+Test basic queries and mutations
+"""
+
+import datetime
+
+import pytest
+
+from platformics.database.connect import SyncDB
+from platformics.test_infra.factories.base import SessionStorage
+from test_infra.factories.dataset import DatasetFactory
+from test_infra.factories.deposition import DepositionFactory
+from test_infra.factories.run import RunFactory
+
+date_now = datetime.datetime.now()
+
+
+@pytest.mark.asyncio
+async def test_meta_fields_aggregate(
+    sync_db: SyncDB,
+    gql_client,
+) -> None:
+    """
+    Test that we can filter datasets by the number of runs they have
+    """
+
+    # Create mock data
+    with sync_db.session() as session:
+        SessionStorage.set_session(session)
+        DepositionFactory.create(id=12345)
+        DepositionFactory.create(id=23456)
+        DepositionFactory.create(id=34567)
+
+    # Fetch all datasets that have at least one run
+    query = """
+        query MyQuery {
+          depositionsAggregate {
+            __typename
+            aggregate {
+              __typename
+              count(columns: id)
+              groupBy {
+                __typename
+                id
+              }
+            }
+          }
+        }
+    """
+    output = await gql_client.query(query)
+    assert output["data"]["depositionsAggregate"]["__typename"] == "DepositionAggregate"
+    aggregates = output["data"]["depositionsAggregate"]["aggregate"]
+    assert len(aggregates) == 3
+    dep_ids = {12345, 23456, 34567}
+    for item in aggregates:
+        assert item["__typename"] == "DepositionAggregateFunctions"
+        assert item["count"] == 1
+        assert item["groupBy"]["__typename"] == "DepositionGroupByOptions"
+        assert item["groupBy"]["id"] in dep_ids


### PR DESCRIPTION
Adds support for including `__typename` and other graphql-reserved keywords in GraphQL queries. Our API was making naive/incorrect assumptions about query field ordering and also assuming that only application-specific fields would be present in queries. This updates our application code to filter out any GraphQL reserved fields (such as `__typename`) before interpreting queries. 

Some GraphQL clients (like Apollo) include `__typename` fields in every level of a GraphQL query to help with type interpretation. We've had to disable this functionality in our frontend to work around the issue in our API. We should be able to turn it back on now.

![Screenshot 2025-01-08 at 11 07 17 AM](https://github.com/user-attachments/assets/876e7586-29ab-41be-ac2f-ec1d4b34ac84)
