### PR TITLE
fix: Don't replace spaces with underscores for reconstruction software.

### DIFF
--- a/apiv2/db_import/importers/tomogram.py
+++ b/apiv2/db_import/importers/tomogram.py
@@ -62,7 +62,7 @@ class TomogramItem(ItemDBImporter):
                 self.input_data.get("fiducial_alignment_status", False),
             ),
             "reconstruction_method": self.normalize_to_unknown_str(self.input_data.get("reconstruction_method")),
-            "reconstruction_software": self.normalize_to_unknown_str(self.input_data.get("reconstruction_software")),
+            "reconstruction_software": self.input_data.get("reconstruction_software") or "Unknown",
             "s3_omezarr_dir": self.get_s3_url(self.input_data["omezarr_dir"]),
             "https_omezarr_dir": self.get_https_url(self.input_data["omezarr_dir"]),
             "s3_mrc_file": self.get_s3_url(self.input_data["mrc_file"]),

--- a/apiv2/db_import/tests/test_db_tomo_import.py
+++ b/apiv2/db_import/tests/test_db_tomo_import.py
@@ -67,7 +67,7 @@ def expected_tomograms_by_run(http_prefix: str) -> dict[str, dict[float, list[di
         "voxel_spacing": 12.3,
         "fiducial_alignment_status": "FIDUCIAL",
         "reconstruction_method": "WBP",
-        "reconstruction_software": "IMOD",
+        "reconstruction_software": "AreTomo 1.0",
         "processing": "raw",
         "processing_software": "tomo3D",
         "tomogram_version": 1.0,

--- a/test_infra/test_files/30001/RUN1/Reconstructions/VoxelSpacing12.300/Tomograms/100/tomogram_metadata.json
+++ b/test_infra/test_files/30001/RUN1/Reconstructions/VoxelSpacing12.300/Tomograms/100/tomogram_metadata.json
@@ -1,7 +1,7 @@
 {
   "voxel_spacing": 12.300,
   "reconstruction_method": "WBP",
-  "reconstruction_software": "IMOD",
+  "reconstruction_software": "AreTomo 1.0",
   "fiducial_alignment_status": "FIDUCIAL",
   "ctf_corrected": true,
   "processing": "raw",


### PR DESCRIPTION
We were erroneously replacing spaces with underscores for the reconstruction software field when importing metadata to the db. This fixes the issue and updates the tests to reflect the change.

<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
