### PR TITLE
fix: Retrieve volume_dimension alignment metadata correctly when rescaling segmentation masks during ingestion.

### DIFF
--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -248,7 +248,9 @@ class VolumeAnnotationSource(BaseAnnotationSource):
     def get_output_dim(self) -> tuple[int, int, int]:
         """Returns the dimensions of the output volume at the Annotation's VoxelSpacing."""
         alignment = list(AlignmentImporter.finder(self.config, **self.parents))[0]
-        dims = alignment.get_extra_metadata()["volume_dimension"]
+        dims = alignment.metadata.get("volume_dimension", None)
+        if not dims:
+            dims = alignment.get_extra_metadata()["volume_dimension"]
         voxel_spacing = self.parents["voxel_spacing"].as_float()
 
         dims = (


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to N/A
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
When ingesting SegmentationMasks that require rescaling, the volume dimensions are retrieved from the alignment metadata. This PR fixes where the metadata are read from (i.e. the `AlignmentImporter.metadata` rather than the output of `AlignmentImporter.get_extra_metadata`). 

This is a fix enabling ingestion of the Ais deposition from #363

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
