### PR TITLE
fix: Do not attempt to import dataset keyphoto when dataset is not being imported

### DIFF
--- a/ingestion_tools/scripts/importers/dataset_key_photo.py
+++ b/ingestion_tools/scripts/importers/dataset_key_photo.py
@@ -18,6 +18,9 @@ class DatasetKeyPhotoImporter(BaseKeyPhotoImporter):
     has_metadata = False
     dir_path = "{dataset_name}/Images"
 
+    def is_import_allowed(self) -> bool:
+        return self.get_dataset().is_import_allowed()
+
     def get_image_src_path(self) -> str:
         image_src = self.path if self.file_exists(self.path) else self.get_first_valid_tomo_key_photo(self.name)
         if not image_src:


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to N/A
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
When importing an annotation deposition using a `destination_glob` for datasets, the import of `dataset_keyphotos` should also be disallowed. This is achieved here by overriding the `DatasetKeyPhotoImporter`'s `is_import_allowed` method with the result of the parent's method. 

Needed to avoid errors when running import for the Ais deposition (#363)
<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
