### PR TITLE
fix: Include threshold when checking mask annotation validity

### DIFF
--- a/ingestion_tools/scripts/common/image.py
+++ b/ingestion_tools/scripts/common/image.py
@@ -514,6 +514,7 @@ def check_mask_for_label(
     fs: FileSystemApi,
     tomo_filename: str,
     label: int,
+    threshold: float | None = None,
 ) -> bool:
-    mc = MaskConverter(fs, tomo_filename, label)
+    mc = MaskConverter(fs, tomo_filename, label, threshold=threshold)
     return mc.has_label()

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -352,7 +352,7 @@ class SemanticSegmentationMaskAnnotation(VolumeAnnotationSource):
     def is_valid(self) -> bool:
         try:
             input_file = self.path
-            return check_mask_for_label(self.config.fs, input_file, self.mask_label)
+            return check_mask_for_label(self.config.fs, input_file, self.mask_label, threshold=self.threshold)
         except Exception:
             return False
 


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to N/A
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
When checking if a SegmentationMask annotation is valid the threshold (if it exists) needs to be passed to the MaskConverter. When a threshold is applied, the mask is checked for any value > threshold instead of simply checking for the presence of the mask label. This PR fixes that by adding the threshold as an optional argument to the validity check.

Required for correctly ingesting the Ais deposition. (#363)
<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
