### PR TITLE
chore: Updating long execution name generation

### DIFF
--- a/ingestion_tools/scripts/enqueue_runs.py
+++ b/ingestion_tools/scripts/enqueue_runs.py
@@ -443,11 +443,13 @@ def queue(
 
                     dataset_id = dataset.name
                     deposition_id = deposition.name
-                    execution_name = f"{int(time.time())}-dep{deposition_id}-ds{dataset_id}-run{run.name}"
+                    prefix = f"{int(time.time())}-dep{deposition_id}-ds{dataset_id}"
+                    execution_name = f"{prefix}-run{run.name}"
 
                     # execution name greater than 80 chars causes boto ValidationException
                     if len(execution_name) > 80:
-                        execution_name = execution_name[-80:]
+                        run_size = 80 - len(prefix)
+                        execution_name = f"{prefix}-run{run.name[-run_size:]}"
 
                     wdl_args = {
                         "config_file": config_file,

--- a/ingestion_tools/scripts/tests/db_import/test_db_tomo_import.py
+++ b/ingestion_tools/scripts/tests/db_import/test_db_tomo_import.py
@@ -63,7 +63,7 @@ def expected_tomograms_by_run(http_prefix: str) -> dict[str, dict[float, list[di
         "voxel_spacing": 12.3,
         "fiducial_alignment_status": "FIDUCIAL",
         "reconstruction_method": "WBP",
-        "reconstruction_software": "IMOD",
+        "reconstruction_software": "AreTomo 1.0",
         "processing": "raw",
         "processing_software": "tomo3D",
         "tomogram_version": "1",


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to ~
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
> Ais deposition ingestion and one issue I'm running into is that I can't enqueue certain jobs because the [name truncation here](https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/32bde071d117e3ba27abeb7d28d31c181d158e76/ingestion_tools/scripts/enqueue_runs.py#L449-L450) leads to jobs having the same name when I want to re-run them, i.e. I get a botocore.errorfactory.ExecutionAlreadyExists exception. Also, this exception is occuring silently because enqueue_runs doesn't check the result of the concurrent futures.

Addresses the issue mentioned above. 

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
