### PR TITLE
fix: fix response handling for grouping by related fields 

### DIFF
--- a/apiv2/graphql_api/helpers/alignment.py
+++ b/apiv2/graphql_api/helpers/alignment.py
@@ -101,7 +101,7 @@ def build_alignment_groupby_output(
                     keys,
                     value,
                 )
-        case "per_section_alignment_parameters":
+        case "per_section_alignments":
             if getattr(group_object, key):
                 value = per_section_alignment_parameters_helper.build_per_section_alignment_parameters_groupby_output(
                     getattr(group_object, key),

--- a/apiv2/graphql_api/helpers/annotation.py
+++ b/apiv2/graphql_api/helpers/annotation.py
@@ -113,7 +113,7 @@ def build_annotation_groupby_output(
                     keys,
                     value,
                 )
-        case "annotation_method_links":
+        case "method_links":
             if getattr(group_object, key):
                 value = annotation_method_link_helper.build_annotation_method_link_groupby_output(
                     getattr(group_object, key),
@@ -126,7 +126,7 @@ def build_annotation_groupby_output(
                     keys,
                     value,
                 )
-        case "annotation_authors":
+        case "authors":
             if getattr(group_object, key):
                 value = annotation_author_helper.build_annotation_author_groupby_output(
                     getattr(group_object, key),

--- a/apiv2/graphql_api/helpers/dataset.py
+++ b/apiv2/graphql_api/helpers/dataset.py
@@ -100,7 +100,7 @@ def build_dataset_groupby_output(
                     keys,
                     value,
                 )
-        case "dataset_funding":
+        case "funding_sources":
             if getattr(group_object, key):
                 value = dataset_funding_helper.build_dataset_funding_groupby_output(
                     getattr(group_object, key),
@@ -113,7 +113,7 @@ def build_dataset_groupby_output(
                     keys,
                     value,
                 )
-        case "dataset_authors":
+        case "authors":
             if getattr(group_object, key):
                 value = dataset_author_helper.build_dataset_author_groupby_output(
                     getattr(group_object, key),

--- a/apiv2/graphql_api/helpers/deposition.py
+++ b/apiv2/graphql_api/helpers/deposition.py
@@ -88,7 +88,7 @@ def build_deposition_groupby_output(
 
     key = keys.pop(0)
     match key:
-        case "deposition_authors":
+        case "authors":
             if getattr(group_object, key):
                 value = deposition_author_helper.build_deposition_author_groupby_output(
                     getattr(group_object, key),

--- a/apiv2/graphql_api/helpers/tomogram.py
+++ b/apiv2/graphql_api/helpers/tomogram.py
@@ -112,7 +112,7 @@ def build_tomogram_groupby_output(
                     keys,
                     value,
                 )
-        case "tomogram_authors":
+        case "authors":
             if getattr(group_object, key):
                 value = tomogram_author_helper.build_tomogram_author_groupby_output(
                     getattr(group_object, key),

--- a/apiv2/platformics/codegen/templates/graphql_api/helpers/class_name.py.j2
+++ b/apiv2/platformics/codegen/templates/graphql_api/helpers/class_name.py.j2
@@ -94,11 +94,7 @@ def build_{{ cls.snake_name }}_groupby_output(
 {%- for attr in cls.visible_fields %}
     {%- if attr.type != "File" %}
         {%- if attr.inverse %}
-        {%- if attr.multivalued or attr.is_virtual_relationship %}
-        case "{{ attr.related_class.plural_snake_name }}":
-        {%- else %}
-        case "{{ attr.related_class.snake_name }}":
-        {%- endif %}
+        case "{{ attr.name }}":
             if getattr(group_object, key):
                 value = {{ attr.related_class.snake_name }}_helper.build_{{ attr.related_class.snake_name }}_groupby_output(
                     getattr(group_object, key),


### PR DESCRIPTION
We had a bad assumption in our `group_by` query handling where we were expecting each relationship (like the relationship between datasets and dataset authors) to have the same name as the related class (in our example, we expect the field on datasets to be `dataset.dataset_authors`), which is definitely not the case! We can support *multiple* relationships between two types, so long as each relationship has its own name.

This fix updates codegen to use the name of the *relationship name* to unpack our SQL data into GraphQL response types instead of the *related table name*, and adds a test for this case.