### PR TITLE
fix: Fix for spurious test failures.

### DIFF
--- a/apiv2/platformics/codegen/templates/test_infra/factories/class_name.py.j2
+++ b/apiv2/platformics/codegen/templates/test_infra/factories/class_name.py.j2
@@ -100,7 +100,12 @@ class {{ cls.name }}Factory(CommonFactory):
                 {%- elif field.type == "Array2dFloat" %}
     {{ field.name }} = factory.LazyAttribute(lambda o: [ [random.uniform(1, 100) for _ in range(5)] ] * random.randint(2, 5) )
                 {%- elif field.type == "integer" %}
+                    {% if field.identifier %}
+    # Auto increment integer identifiers starting with 1
+    {{ field.name }} = factory.Sequence(lambda n: n + 1)
+                    {% else %}
     {{ field.name }} = fuzzy.FuzzyInteger(1, 1000)
+                    {% endif %}
                 {%- elif field.type == "float" %}
     {{ field.name }} = fuzzy.FuzzyFloat(1, 100)
                 {%- elif field.type == cls.name %}{#

--- a/apiv2/test_infra/factories/alignment.py
+++ b/apiv2/test_infra/factories/alignment.py
@@ -54,4 +54,6 @@ class AlignmentFactory(CommonFactory):
     s3_alignment_metadata = fuzzy.FuzzyText()
     https_alignment_metadata = fuzzy.FuzzyText()
     is_portal_standard = factory.Faker("boolean")
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/annotation.py
+++ b/apiv2/test_infra/factories/annotation.py
@@ -45,7 +45,9 @@ class AnnotationFactory(CommonFactory):
     object_name = fuzzy.FuzzyText()
     object_description = fuzzy.FuzzyText()
     object_state = fuzzy.FuzzyText()
+
     object_count = fuzzy.FuzzyInteger(1, 1000)
+
     confidence_precision = fuzzy.FuzzyFloat(1, 100)
     confidence_recall = fuzzy.FuzzyFloat(1, 100)
     ground_truth_used = fuzzy.FuzzyText()
@@ -55,4 +57,6 @@ class AnnotationFactory(CommonFactory):
     deposition_date = factory.Faker("date")
     release_date = factory.Faker("date")
     last_modified_date = factory.Faker("date")
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/annotation_author.py
+++ b/apiv2/test_infra/factories/annotation_author.py
@@ -32,8 +32,12 @@ class AnnotationAuthorFactory(CommonFactory):
     annotation = factory.SubFactory(
         AnnotationFactory,
     )
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)
+
     author_list_order = fuzzy.FuzzyInteger(1, 1000)
+
     orcid = fuzzy.FuzzyText()
     name = fuzzy.FuzzyText()
     email = fuzzy.FuzzyText()

--- a/apiv2/test_infra/factories/annotation_file.py
+++ b/apiv2/test_infra/factories/annotation_file.py
@@ -45,4 +45,6 @@ class AnnotationFileFactory(CommonFactory):
     https_path = fuzzy.FuzzyText()
     is_visualization_default = factory.Faker("boolean")
     source = fuzzy.FuzzyChoice(["dataset_author", "community", "portal_standard"])
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/annotation_method_link.py
+++ b/apiv2/test_infra/factories/annotation_method_link.py
@@ -35,4 +35,6 @@ class AnnotationMethodLinkFactory(CommonFactory):
     link_type = fuzzy.FuzzyChoice(["documentation", "models_weights", "other", "source_code", "website"])
     name = fuzzy.FuzzyText()
     link = fuzzy.FuzzyText()
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/annotation_shape.py
+++ b/apiv2/test_infra/factories/annotation_shape.py
@@ -33,4 +33,6 @@ class AnnotationShapeFactory(CommonFactory):
         AnnotationFactory,
     )
     shape_type = fuzzy.FuzzyChoice(["SegmentationMask", "OrientedPoint", "Point", "InstanceSegmentation", "Mesh"])
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/dataset.py
+++ b/apiv2/test_infra/factories/dataset.py
@@ -35,7 +35,9 @@ class DatasetFactory(CommonFactory):
     title = fuzzy.FuzzyText()
     description = fuzzy.FuzzyText()
     organism_name = fuzzy.FuzzyText()
+
     organism_taxid = fuzzy.FuzzyInteger(1, 1000)
+
     tissue_name = fuzzy.FuzzyText()
     tissue_id = fuzzy.FuzzyText()
     cell_name = fuzzy.FuzzyText()
@@ -59,4 +61,6 @@ class DatasetFactory(CommonFactory):
     related_database_entries = fuzzy.FuzzyText()
     s3_prefix = fuzzy.FuzzyText()
     https_prefix = fuzzy.FuzzyText()
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/dataset_author.py
+++ b/apiv2/test_infra/factories/dataset_author.py
@@ -32,8 +32,12 @@ class DatasetAuthorFactory(CommonFactory):
     dataset = factory.SubFactory(
         DatasetFactory,
     )
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)
+
     author_list_order = fuzzy.FuzzyInteger(1, 1000)
+
     orcid = fuzzy.FuzzyText()
     name = fuzzy.FuzzyText()
     email = fuzzy.FuzzyText()

--- a/apiv2/test_infra/factories/dataset_funding.py
+++ b/apiv2/test_infra/factories/dataset_funding.py
@@ -34,4 +34,6 @@ class DatasetFundingFactory(CommonFactory):
     )
     funding_agency_name = fuzzy.FuzzyText()
     grant_id = fuzzy.FuzzyText()
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/deposition.py
+++ b/apiv2/test_infra/factories/deposition.py
@@ -37,4 +37,6 @@ class DepositionFactory(CommonFactory):
     last_modified_date = factory.Faker("date")
     key_photo_url = fuzzy.FuzzyText()
     key_photo_thumbnail_url = fuzzy.FuzzyText()
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/deposition_author.py
+++ b/apiv2/test_infra/factories/deposition_author.py
@@ -32,8 +32,12 @@ class DepositionAuthorFactory(CommonFactory):
     deposition = factory.SubFactory(
         DepositionFactory,
     )
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)
+
     author_list_order = fuzzy.FuzzyInteger(1, 1000)
+
     orcid = fuzzy.FuzzyText()
     name = fuzzy.FuzzyText()
     email = fuzzy.FuzzyText()

--- a/apiv2/test_infra/factories/deposition_type.py
+++ b/apiv2/test_infra/factories/deposition_type.py
@@ -33,4 +33,6 @@ class DepositionTypeFactory(CommonFactory):
         DepositionFactory,
     )
     type = fuzzy.FuzzyChoice(["annotation", "dataset", "tomogram"])
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/frame.py
+++ b/apiv2/test_infra/factories/frame.py
@@ -37,9 +37,13 @@ class FrameFactory(CommonFactory):
         RunFactory,
     )
     raw_angle = fuzzy.FuzzyFloat(1, 100)
+
     acquisition_order = fuzzy.FuzzyInteger(1, 1000)
+
     dose = fuzzy.FuzzyFloat(1, 100)
     is_gain_corrected = factory.Faker("boolean")
     s3_frame_path = fuzzy.FuzzyText()
     https_frame_path = fuzzy.FuzzyText()
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/frame_acquisition_file.py
+++ b/apiv2/test_infra/factories/frame_acquisition_file.py
@@ -34,4 +34,6 @@ class FrameAcquisitionFileFactory(CommonFactory):
     )
     s3_mdoc_path = fuzzy.FuzzyText()
     https_mdoc_path = fuzzy.FuzzyText()
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/gain_file.py
+++ b/apiv2/test_infra/factories/gain_file.py
@@ -34,4 +34,6 @@ class GainFileFactory(CommonFactory):
     )
     s3_file_path = fuzzy.FuzzyText()
     https_file_path = fuzzy.FuzzyText()
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/per_section_alignment_parameters.py
+++ b/apiv2/test_infra/factories/per_section_alignment_parameters.py
@@ -34,7 +34,9 @@ class PerSectionAlignmentParametersFactory(CommonFactory):
     alignment = factory.SubFactory(
         AlignmentFactory,
     )
+
     z_index = fuzzy.FuzzyInteger(1, 1000)
+
     x_offset = fuzzy.FuzzyFloat(1, 100)
     y_offset = fuzzy.FuzzyFloat(1, 100)
     volume_x_rotation = fuzzy.FuzzyFloat(1, 100)
@@ -42,4 +44,6 @@ class PerSectionAlignmentParametersFactory(CommonFactory):
         lambda o: [[random.uniform(1, 100) for _ in range(5)]] * random.randint(2, 5),
     )
     tilt_angle = fuzzy.FuzzyFloat(1, 100)
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/run.py
+++ b/apiv2/test_infra/factories/run.py
@@ -35,4 +35,6 @@ class RunFactory(CommonFactory):
     name = fuzzy.FuzzyText()
     s3_prefix = fuzzy.FuzzyText()
     https_prefix = fuzzy.FuzzyText()
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/tiltseries.py
+++ b/apiv2/test_infra/factories/tiltseries.py
@@ -42,7 +42,9 @@ class TiltseriesFactory(CommonFactory):
     https_mrc_file = fuzzy.FuzzyText()
     s3_angle_list = fuzzy.FuzzyText()
     https_angle_list = fuzzy.FuzzyText()
+
     acceleration_voltage = fuzzy.FuzzyInteger(1, 1000)
+
     spherical_aberration_constant = fuzzy.FuzzyFloat(1, 100)
     microscope_manufacturer = fuzzy.FuzzyChoice(["FEI", "TFS", "JEOL", "SIMULATED"])
     microscope_model = fuzzy.FuzzyText()
@@ -62,11 +64,19 @@ class TiltseriesFactory(CommonFactory):
     data_acquisition_software = fuzzy.FuzzyText()
     related_empiar_entry = fuzzy.FuzzyText()
     binning_from_frames = fuzzy.FuzzyFloat(1, 100)
+
     tilt_series_quality = fuzzy.FuzzyInteger(1, 1000)
+
     is_aligned = factory.Faker("boolean")
     pixel_spacing = fuzzy.FuzzyFloat(1, 100)
+
     aligned_tiltseries_binning = fuzzy.FuzzyInteger(1, 1000)
+
     size_x = fuzzy.FuzzyInteger(1, 1000)
+
     size_y = fuzzy.FuzzyInteger(1, 1000)
+
     size_z = fuzzy.FuzzyInteger(1, 1000)
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)

--- a/apiv2/test_infra/factories/tomogram.py
+++ b/apiv2/test_infra/factories/tomogram.py
@@ -45,9 +45,13 @@ class TomogramFactory(CommonFactory):
         TomogramVoxelSpacingFactory,
     )
     name = fuzzy.FuzzyText()
+
     size_x = fuzzy.FuzzyInteger(1, 1000)
+
     size_y = fuzzy.FuzzyInteger(1, 1000)
+
     size_z = fuzzy.FuzzyInteger(1, 1000)
+
     voxel_spacing = fuzzy.FuzzyFloat(1, 100)
     fiducial_alignment_status = fuzzy.FuzzyChoice(["FIDUCIAL", "NON_FIDUCIAL"])
     reconstruction_method = fuzzy.FuzzyChoice(["SART", "Fourier Space", "SIRT", "WBP", "Unknown"])
@@ -66,15 +70,22 @@ class TomogramFactory(CommonFactory):
     scale1_dimensions = fuzzy.FuzzyText()
     scale2_dimensions = fuzzy.FuzzyText()
     ctf_corrected = factory.Faker("boolean")
+
     offset_x = fuzzy.FuzzyInteger(1, 1000)
+
     offset_y = fuzzy.FuzzyInteger(1, 1000)
+
     offset_z = fuzzy.FuzzyInteger(1, 1000)
+
     key_photo_url = fuzzy.FuzzyText()
     key_photo_thumbnail_url = fuzzy.FuzzyText()
     neuroglancer_config = fuzzy.FuzzyText()
     publications = fuzzy.FuzzyText()
     related_database_entries = fuzzy.FuzzyText()
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)
+
     deposition_date = factory.Faker("date")
     release_date = factory.Faker("date")
     last_modified_date = factory.Faker("date")

--- a/apiv2/test_infra/factories/tomogram_author.py
+++ b/apiv2/test_infra/factories/tomogram_author.py
@@ -32,8 +32,12 @@ class TomogramAuthorFactory(CommonFactory):
     tomogram = factory.SubFactory(
         TomogramFactory,
     )
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)
+
     author_list_order = fuzzy.FuzzyInteger(1, 1000)
+
     orcid = fuzzy.FuzzyText()
     name = fuzzy.FuzzyText()
     email = fuzzy.FuzzyText()

--- a/apiv2/test_infra/factories/tomogram_voxel_spacing.py
+++ b/apiv2/test_infra/factories/tomogram_voxel_spacing.py
@@ -35,4 +35,6 @@ class TomogramVoxelSpacingFactory(CommonFactory):
     voxel_spacing = fuzzy.FuzzyFloat(1, 100)
     s3_prefix = fuzzy.FuzzyText()
     https_prefix = fuzzy.FuzzyText()
-    id = fuzzy.FuzzyInteger(1, 1000)
+
+    # Auto increment integer identifiers starting with 1
+    id = factory.Sequence(lambda n: n + 1)


### PR DESCRIPTION
We've been seeing intermittent apiv2 test failures in our pull requests.

We use a test fixture library called `factory_boy` to generate semi-randomized database rows in our tests. This tool works great, when it's configured properly! However we were generating object ID's like so:

```
id = fuzzy.FuzzyInteger(1, 1000)
```
This tells the test fixture to use a random number between 1 and 1000 for each object ID. Our tests were failing sporadically because sometimes when we told the fixture to make a batch of N rows, some of those rows would get generated with the same identifier, and get collapsed into a single row!

This PR updates the fixture configuration to use factory_boy's [Sequences](https://factoryboy.readthedocs.io/en/stable/#sequences) functionality to generate sequential ID's instead of random ID's, and should hopefully 🤞 make our tests more reliable.