### PR TITLE
fix: Execution name length determination for enqueue

### DIFF
--- a/ingestion_tools/scripts/enqueue_runs.py
+++ b/ingestion_tools/scripts/enqueue_runs.py
@@ -448,7 +448,7 @@ def queue(
 
                     # execution name greater than 80 chars causes boto ValidationException
                     if len(execution_name) > 80:
-                        run_size = 80 - len(prefix)
+                        run_size = 76 - len(prefix)
                         execution_name = f"{prefix}-run{run.name[-run_size:]}"
 
                     wdl_args = {


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to N/A
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
The fixed determination of execution name length still had a minor issue. We need to consider the `"-run"` part that is not contained in the prefix, and thus use 76 as maximum run name length instead of 80. 

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
