### PR TITLE
fix: convert angstrom resolution to nm resolution in precompute seg

### DIFF
--- a/ingestion_tools/scripts/importers/visualization_precompute.py
+++ b/ingestion_tools/scripts/importers/visualization_precompute.py
@@ -142,10 +142,11 @@ class SegmentationMaskAnnotationPrecompute(BaseAnnotationPrecompute):
         # module) cannot be imported successfully on darwin/ARM machines.
         from cryoet_data_portal_neuroglancer.precompute import segmentation_mask
 
+        resolution_in_nm = voxel_spacing * 0.1 # original in angstrom
         segmentation_mask.encode_segmentation(
             zarr_file_path,
             Path(tmp_path),
-            resolution=(voxel_spacing,) * 3,
+            resolution=(resolution_in_nm,) * 3,
             delete_existing=True,
             include_mesh=True,
         )


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to n/a
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
The cryoet-data-portal-neuroglancer function `encode_segmentation` being called here to convert a segmentation to the neuroglancer precomputed format expects the resolution to be in nanometers, but the provided voxel resolution seems to be in angstrom.

This won't have any noticeable effect on the production version of the portal, because the JSON state generator called in `_to_segmentation_mask_layer` is overriding this value with the correct resolution via a co-ordinate transform.

Providing the correct resolution to the conversion function would be nice to change just for consistency.