### PR TITLE
Feat add oriented mesh production 

### DIFF
--- a/ingestion_tools/scripts/common/config.py
+++ b/ingestion_tools/scripts/common/config.py
@@ -4,6 +4,7 @@ import os
 import os.path
 import re
 from copy import deepcopy
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -29,6 +30,7 @@ class RunOverride:
 
 class DepositionImportConfig:
     https_prefix = os.getenv("DOMAIN_NAME", "https://files.cryoetdataportal.cziscience.com")
+    oriented_mesh_prefix = "OrientedMeshes"
     # Core metadata
     source_prefix: str
 
@@ -259,3 +261,6 @@ class DepositionImportConfig:
                 return os.path.relpath(path, self.output_prefix)
             return path
         return None
+
+    def get_mesh_folder(self, obj: BaseImporter) -> Path:
+        return Path(self.input_path) / self.get_run_name(obj) / self.oriented_mesh_prefix

--- a/ingestion_tools/scripts/common/config.py
+++ b/ingestion_tools/scripts/common/config.py
@@ -262,5 +262,5 @@ class DepositionImportConfig:
             return path
         return None
 
-    def get_mesh_folder(self, obj: BaseImporter) -> Path:
+    def get_oriented_mesh_folder(self, obj: BaseImporter) -> Path:
         return Path(self.input_path) / self.get_run_name(obj) / self.oriented_mesh_prefix

--- a/ingestion_tools/scripts/common/finders.py
+++ b/ingestion_tools/scripts/common/finders.py
@@ -111,7 +111,7 @@ class BaseLiteralValueFinder(BaseFinder):
     def find(self, config: DepositionImportConfig, glob_vars: dict[str, Any]) -> dict[str, str | None]:
         if isinstance(self.literal_value, dict):
             return self.literal_value
-        return {item: None for item in self.literal_value}
+        return dict.fromkeys(self.literal_value)
 
 
 class DestinationFilteredMetadataFinder(BaseFinder):

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -507,6 +507,12 @@ class OrientedPointAnnotation(AbstractPointAnnotation):
             "filter_value": self.filter_value,
         }
 
+    @property
+    def mesh_folder(self) -> str | None:
+        if not hasattr(self, "_mesh_folder"):
+            self._mesh_folder = next(iter(self.config.glob_files(self, "**/OrientedMeshes")), None)
+        return self._mesh_folder
+
 
 class InstanceSegmentationAnnotation(OrientedPointAnnotation):
     shape = "InstanceSegmentation"

--- a/ingestion_tools/scripts/importers/visualization_precompute.py
+++ b/ingestion_tools/scripts/importers/visualization_precompute.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from common import colors
 from common.config import DepositionImportConfig
@@ -9,6 +9,7 @@ from importers.annotation import (
     AbstractPointAnnotation,
     BaseAnnotationSource,
     InstanceSegmentationAnnotation,
+    OrientedPointAnnotation,
     VolumeAnnotationSource,
 )
 from importers.base_importer import BaseImporter
@@ -126,13 +127,13 @@ class OrientedPointAnnotationPrecompute(PointAnnotationPrecompute):
         )
 
         # Convert the mesh to a precomputed format oriented mesh if a mesh file exists
-        mesh_folder = next(iter(self.config.glob_files(self.annotation, "**/OrientedMeshes")), None)
+        obj_name = metadata["annotation_object"]["name"]
+        mesh_folder = cast(OrientedPointAnnotation, self.annotation).mesh_folder
         if not mesh_folder:
-            print("No mesh folder found")
+            print(f"No mesh folder found, skipping mesh generation for {obj_name}")
             return
 
         mesh_folder = Path(mesh_folder)
-        obj_name = metadata["annotation_object"]["name"]
         mesh_filename = obj_name.lower().translate(str.maketrans({"-": "_", " ": "_"}))
         mesh_file = mesh_folder / f"{mesh_filename}.glb"
         local_mesh_file = fs.localreadable(f"{mesh_file}")

--- a/ingestion_tools/scripts/importers/visualization_precompute.py
+++ b/ingestion_tools/scripts/importers/visualization_precompute.py
@@ -106,6 +106,56 @@ class OrientedPointAnnotationPrecompute(PointAnnotationPrecompute):
     def neuroglancer_precompute_args(self, output_prefix: str, metadata: dict[str, Any]) -> dict[str, Any]:
         return {"is_oriented": True}
 
+    def neuroglancer_precompute(self, output_prefix: str, voxel_spacing: float) -> None:
+        # Build the oriented points
+        super().neuroglancer_precompute(output_prefix, voxel_spacing)
+
+        fs = self.config.fs
+        annotation_path = self.annotation.get_output_path()
+
+        metadata = self.annotation.metadata
+
+        # Importing this at runtime instead of compile time since zfpy (a dependency of this
+        # module) cannot be imported successfully on darwin/ARM machines.
+        import cryoet_data_portal_neuroglancer.io as io
+        from cryoet_data_portal_neuroglancer.precompute.instance_mesh import (
+            encode_oriented_mesh,
+        )
+        from cryoet_data_portal_neuroglancer.precompute.mesh import (
+            generate_mesh_from_lods,
+        )
+
+        # Convert the mesh to a precomputed format oriented mesh if a mesh file exists
+        mesh_folder = self.config.get_mesh_folder(self.annotation)
+        obj_name = metadata["annotation_object"]["name"]
+        mesh_filename = obj_name.lower().translate(str.maketrans({"-": "_", " ": "_"}))
+        mesh_file = mesh_folder / f"{mesh_filename}.glb"
+        if mesh_file.exists():
+            print("Loading", mesh_filename, "from", mesh_file)
+            # Generates the precomputed version of the mesh in memory
+            scene = io.load_glb_file(mesh_file)
+            oriented_mesh_at_each_lod = encode_oriented_mesh(
+                scene,
+                self.annotation.get_output_data(annotation_path),
+                max_lod=2,
+                max_faces_for_first_lod=10e6,
+                decimation_aggressiveness=5.5,
+            )
+
+            # Dump the precomputed version on the output folder
+            precompute_path = self._get_neuroglancer_precompute_path(annotation_path, output_prefix)
+            tmp_path = fs.localwritable(precompute_path)
+            oriented_mesh_path = tmp_path.replace("_orientedpoint", "_orientedmesh")
+            print(f"Generating oriented mesh for oriented point in {oriented_mesh_path}")
+            generate_mesh_from_lods(
+                oriented_mesh_at_each_lod,
+                Path(oriented_mesh_path),
+                min_mesh_chunk_dim=2,
+            )
+            fs.push(oriented_mesh_path)
+        else:
+            print(f"No mesh found for '{obj_name}' [looked for '{mesh_filename}' GLB file]")
+
 
 class InstanceSegmentationAnnotationPrecompute(PointAnnotationPrecompute):
     annotation: InstanceSegmentationAnnotation
@@ -142,7 +192,7 @@ class SegmentationMaskAnnotationPrecompute(BaseAnnotationPrecompute):
         # module) cannot be imported successfully on darwin/ARM machines.
         from cryoet_data_portal_neuroglancer.precompute import segmentation_mask
 
-        resolution_in_nm = voxel_spacing * 0.1 # original in angstrom
+        resolution_in_nm = voxel_spacing * 0.1  # original in angstrom
         segmentation_mask.encode_segmentation(
             zarr_file_path,
             Path(tmp_path),

--- a/ingestion_tools/scripts/importers/visualization_precompute.py
+++ b/ingestion_tools/scripts/importers/visualization_precompute.py
@@ -126,12 +126,18 @@ class OrientedPointAnnotationPrecompute(PointAnnotationPrecompute):
         )
 
         # Convert the mesh to a precomputed format oriented mesh if a mesh file exists
-        mesh_folder = self.config.get_mesh_folder(self.annotation)
+        mesh_folder = next(iter(self.config.glob_files(self.annotation, "**/OrientedMeshes")), None)
+        if not mesh_folder:
+            print("No mesh folder found")
+            return
+
+        mesh_folder = Path(mesh_folder)
         obj_name = metadata["annotation_object"]["name"]
         mesh_filename = obj_name.lower().translate(str.maketrans({"-": "_", " ": "_"}))
         mesh_file = mesh_folder / f"{mesh_filename}.glb"
-        if mesh_file.exists():
-            print("Loading", mesh_filename, "from", mesh_file)
+        local_mesh_file = fs.localreadable(f"{mesh_file}")
+        if fs.exists(local_mesh_file):
+            print("Found mesh for", mesh_filename, "in", mesh_file)
             # Generates the precomputed version of the mesh in memory
             scene = io.load_glb_file(mesh_file)
             oriented_mesh_at_each_lod = encode_oriented_mesh(


### PR DESCRIPTION
## Description

## Description

Adds the production of oriented mesh layers if meshes related to oriented point are found in the input bucket. 

![screen](https://github.com/user-attachments/assets/305ba596-dd28-4c07-96be-443b4549ec1e)

The input bucket needs to have the meshes in the `OrientedMeshes` directory (at the moment), located at the root of the input run, e.g:
```
input_bucket/CZII/202410_simulated_2/TS_0/
├── mdocs
│   └── TS_0_vali.mdoc
├── OrientedMeshes
│   ├── beta_amylase.glb
│   ├── beta_galactosidase.glb
│   ├── ferritin_complex.glb
│   ├── ribosome.glb
│   ├── thyroglobulin.glb
│   └── virus_like_capsid.glb
├── Picks
│   ├── apo-ferritin.star
│   ├── beta-amylase.star
│   ├── beta-galactoside.star
│   ├── ribosome.star
│   ├── thyroglobulin.star
│   └── virus-like-particle.star
├── Segmentations
│   └── ground_truth.mrc
├── TiltSeries
│   ├── tilt_series.mrc
│   ├── TS_0_st.rawtlt
│   ├── TS_0_st.tlt
│   └── TS_0_st.xf
└── VoxelSpacing10.000
    └── wbp.mrc

7 directories, 19 files
```