### PR TITLE
fix: doi publication validation bug

### DIFF
--- a/schema/ingestion_config/v1.0.0/ingestion_config_models_extended.py
+++ b/schema/ingestion_config/v1.0.0/ingestion_config_models_extended.py
@@ -437,7 +437,7 @@ class ExtendedValidationDepositionKeyPhotoSource(DepositionKeyPhotoSource):
 @alru_cache
 async def lookup_doi(doi: str) -> Tuple[str, bool]:
     doi = doi.replace("doi:", "")
-    url = f"https://api.crossref.org/works/{doi}/agency"
+    url = f"https://api.crossref.org/works/{doi}"
     logger.debug("Checking DOI %s at %s", doi, url)
     async with aiohttp.ClientSession() as session, session.head(url) as response:
         return doi, response.status == 200


### PR DESCRIPTION
When making network requests to api.crossref.org to validation publication DOIs, we currently try to make a `HEAD` request to a URL along the lines of `https://api.crossref.org/works/{doi}/agency`. However, an 405 error (Method Not Allowed) status now appears, likely because there should only be `GET` requests getting sent to this endpoint. As a fix, we just make a `HEAD` request to `https://api.crossref.org/works/{doi}`, which properly validates the DOI and does not give this 405 error. 

For reference: 
https://api.crossref.org/swagger-ui/index.html#:~:text=Headers%20only%3A%20you,org/members/98%22