### PR TITLE
feat: Addition of global image labels to ingest config schema and metadata file schema. 

### DIFF
--- a/ingestion_tools/dataset_configs/10301.yaml
+++ b/ingestion_tools/dataset_configs/10301.yaml
@@ -309,6 +309,12 @@ gains:
   - sources:
       - source_glob:
           list_glob: '{run_name}/*.gain'
+identified_objects:
+  - metadata:
+      filter_value: '{run_name}'
+    sources:
+      - source_glob:
+          list_glob: 'identified_objects.csv'
 rawtilts:
   - sources:
       - source_glob:

--- a/ingestion_tools/dataset_configs/10441.yaml
+++ b/ingestion_tools/dataset_configs/10441.yaml
@@ -268,6 +268,12 @@ dataset_keyphotos:
           value:
             snapshot: null
             thumbnail: null
+identified_objects:
+ - metadata:
+     filter_value: '{run_name}'
+   sources:
+     - source_glob:
+         list_glob: '{run_name}/objects.csv'
 rawtilts:
   - sources:
       - source_glob:

--- a/ingestion_tools/dataset_configs/10441.yaml
+++ b/ingestion_tools/dataset_configs/10441.yaml
@@ -268,12 +268,6 @@ dataset_keyphotos:
           value:
             snapshot: null
             thumbnail: null
-identified_objects:
- - metadata:
-     filter_value: '{run_name}'
-   sources:
-     - source_glob:
-         list_glob: '{run_name}/objects.csv'
 rawtilts:
   - sources:
       - source_glob:

--- a/schema/Makefile
+++ b/schema/Makefile
@@ -57,7 +57,7 @@ clean-all: clean
 	rm -rf ingestion_config/latest
 
 .PHONY: build
-build: build-ingestion-config
+build: build-ingestion-config build-metadata-files
 
 # To build-ingestion-config for the non-default version, run `make build-ingestion-config INGESTION_CONFIG_VERSION=v2.0.0 CORE_VERSION=v2.0.0`
 .PHONY: build-ingestion-config

--- a/schema/core/v2.0.0/codegen/metadata_materialized.yaml
+++ b/schema/core/v2.0.0/codegen/metadata_materialized.yaml
@@ -3315,6 +3315,7 @@ classes:
         domain_of:
         - AnnotationOrientedPointFile
         - AnnotationPointFile
+        - IdentifiedObjectList
         range: string
         inlined: true
         inlined_as_list: true
@@ -3447,6 +3448,7 @@ classes:
         domain_of:
         - AnnotationOrientedPointFile
         - AnnotationPointFile
+        - IdentifiedObjectList
         range: string
         inlined: true
         inlined_as_list: true
@@ -3607,6 +3609,7 @@ classes:
         domain_of:
         - AnnotationOrientedPointFile
         - AnnotationPointFile
+        - IdentifiedObjectList
         range: string
         inlined: true
         inlined_as_list: true
@@ -4117,6 +4120,93 @@ classes:
         - Alignment
         range: boolean
         required: false
+        inlined: true
+        inlined_as_list: true
+  IdentifiedObject:
+    name: IdentifiedObject
+    description: Metadata describing an identified object.
+    from_schema: metadata
+    attributes:
+      object_id:
+        name: object_id
+        description: A placeholder for any type of data.
+        from_schema: metadata
+        exact_mappings:
+        - cdp-common:identified_object_id
+        alias: object_id
+        owner: IdentifiedObject
+        domain_of:
+        - IdentifiedObject
+        range: Any
+        required: true
+        inlined: true
+        inlined_as_list: true
+        pattern: (^GO:[0-9]{7}$)|(^UniProtKB:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$)
+        any_of:
+        - range: GO_ID
+        - range: UNIPROT_ID
+      object_name:
+        name: object_name
+        description: Name of the object that was identified (e.g. ribosome, nuclear
+          pore complex, actin filament, membrane)
+        from_schema: metadata
+        exact_mappings:
+        - cdp-common:identified_object_name
+        alias: object_name
+        owner: IdentifiedObject
+        domain_of:
+        - IdentifiedObject
+        range: string
+        required: true
+        inlined: true
+        inlined_as_list: true
+      object_description:
+        name: object_description
+        description: A textual description of the identified object, can be a longer
+          description to include additional information not covered by the identified
+          object name and state.
+        from_schema: metadata
+        exact_mappings:
+        - cdp-common:identified_object_description
+        alias: object_description
+        owner: IdentifiedObject
+        domain_of:
+        - IdentifiedObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+      object_state:
+        name: object_state
+        description: Molecule state identified (e.g. open, closed)
+        from_schema: metadata
+        exact_mappings:
+        - cdp-common:identified_object_state
+        alias: object_state
+        owner: IdentifiedObject
+        domain_of:
+        - IdentifiedObject
+        range: string
+        inlined: true
+        inlined_as_list: true
+  IdentifiedObjectList:
+    name: IdentifiedObjectList
+    description: Metadata for a list of identified objects.
+    from_schema: metadata
+    attributes:
+      filter_value:
+        name: filter_value
+        description: Filter value for the identified object, used to filter the list
+          of identified objects by run name.
+        from_schema: metadata
+        exact_mappings:
+        - cdp-common:identified_object_filter_value
+        alias: filter_value
+        owner: IdentifiedObjectList
+        domain_of:
+        - AnnotationOrientedPointFile
+        - AnnotationPointFile
+        - IdentifiedObjectList
+        range: string
         inlined: true
         inlined_as_list: true
   Annotation:

--- a/schema/core/v2.0.0/codegen/metadata_models.py
+++ b/schema/core/v2.0.0/codegen/metadata_models.py
@@ -3120,6 +3120,7 @@ class AnnotationOrientedPointFile(AnnotationSourceFile):
                 "domain_of": [
                     "AnnotationOrientedPointFile",
                     "AnnotationPointFile",
+                    "IdentifiedObjectList",
                     "AnnotationInstanceSegmentationFile",
                 ],
                 "exact_mappings": ["cdp-common:annotation_source_file_filter_value"],
@@ -3277,6 +3278,7 @@ class AnnotationInstanceSegmentationFile(AnnotationOrientedPointFile):
                 "domain_of": [
                     "AnnotationOrientedPointFile",
                     "AnnotationPointFile",
+                    "IdentifiedObjectList",
                     "AnnotationInstanceSegmentationFile",
                 ],
                 "exact_mappings": ["cdp-common:annotation_source_file_filter_value"],
@@ -3458,6 +3460,7 @@ class AnnotationPointFile(AnnotationSourceFile):
                 "domain_of": [
                     "AnnotationOrientedPointFile",
                     "AnnotationPointFile",
+                    "IdentifiedObjectList",
                     "AnnotationInstanceSegmentationFile",
                 ],
                 "exact_mappings": ["cdp-common:annotation_source_file_filter_value"],
@@ -4099,6 +4102,99 @@ class AnnotationTriangularMeshGroupFile(AnnotationSourceFile):
                 ],
                 "exact_mappings": ["cdp-common:annotation_source_file_is_portal_standard"],
                 "ifabsent": "False",
+            }
+        },
+    )
+
+
+class IdentifiedObject(ConfiguredBaseModel):
+    """
+    Metadata describing an identified object.
+    """
+
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
+
+    object_id: str = Field(
+        ...,
+        description="""A placeholder for any type of data.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "object_id",
+                "any_of": [{"range": "GO_ID"}, {"range": "UNIPROT_ID"}],
+                "domain_of": ["IdentifiedObject"],
+                "exact_mappings": ["cdp-common:identified_object_id"],
+            }
+        },
+    )
+    object_name: str = Field(
+        ...,
+        description="""Name of the object that was identified (e.g. ribosome, nuclear pore complex, actin filament, membrane)""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "object_name",
+                "domain_of": ["IdentifiedObject"],
+                "exact_mappings": ["cdp-common:identified_object_name"],
+            }
+        },
+    )
+    object_description: Optional[str] = Field(
+        None,
+        description="""A textual description of the identified object, can be a longer description to include additional information not covered by the identified object name and state.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "object_description",
+                "domain_of": ["IdentifiedObject"],
+                "exact_mappings": ["cdp-common:identified_object_description"],
+            }
+        },
+    )
+    object_state: Optional[str] = Field(
+        None,
+        description="""Molecule state identified (e.g. open, closed)""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "object_state",
+                "domain_of": ["IdentifiedObject"],
+                "exact_mappings": ["cdp-common:identified_object_state"],
+            }
+        },
+    )
+
+    @field_validator("object_id")
+    def pattern_object_id(cls, v):
+        pattern = re.compile(
+            r"(^GO:[0-9]{7}$)|(^UniProtKB:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$)"
+        )
+        if isinstance(v, list):
+            for element in v:
+                if not pattern.match(element):
+                    raise ValueError(f"Invalid object_id format: {element}")
+        elif isinstance(v, str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid object_id format: {v}")
+        return v
+
+
+class IdentifiedObjectList(ConfiguredBaseModel):
+    """
+    Metadata for a list of identified objects.
+    """
+
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "metadata"})
+
+    filter_value: Optional[str] = Field(
+        None,
+        description="""Filter value for the identified object, used to filter the list of identified objects by run name.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "filter_value",
+                "domain_of": [
+                    "AnnotationOrientedPointFile",
+                    "AnnotationPointFile",
+                    "IdentifiedObjectList",
+                    "AnnotationInstanceSegmentationFile",
+                ],
+                "exact_mappings": ["cdp-common:identified_object_filter_value"],
             }
         },
     )
@@ -5250,6 +5346,8 @@ AnnotationSegmentationMaskFile.model_rebuild()
 AnnotationSemanticSegmentationMaskFile.model_rebuild()
 AnnotationTriangularMeshFile.model_rebuild()
 AnnotationTriangularMeshGroupFile.model_rebuild()
+IdentifiedObject.model_rebuild()
+IdentifiedObjectList.model_rebuild()
 Annotation.model_rebuild()
 AlignmentSize.model_rebuild()
 AlignmentOffset.model_rebuild()

--- a/schema/core/v2.0.0/common.yaml
+++ b/schema/core/v2.0.0/common.yaml
@@ -801,6 +801,30 @@ slots:
     description: The name that identifies to a single annotation mesh among multiple meshes.
 
   # ============================================================================
+  # Identified Objects fields
+  # ============================================================================
+  identified_object_description:
+    range: string
+    description: A textual description of the identified object, can be a longer description to include additional
+      information not covered by the identified object name and state.
+  identified_object_id:
+    any_of:
+      - range: GO_ID
+      - range: UNIPROT_ID
+    required: true
+    description: Gene Ontology Cellular Component identifier or UniProtKB accession for the identified object.
+  identified_object_name:
+    range: string
+    required: true
+    description: Name of the object that was identified (e.g. ribosome, nuclear pore complex, actin filament, membrane)
+  identified_object_state:
+    range: string
+    description: Molecule state identified (e.g. open, closed)
+  identified_object_filter_value:
+    range: string
+    description: Filter value for the identified object, used to filter the list of identified objects by run name.
+
+  # ============================================================================
   # Per Section Parameters fields
   # ============================================================================
   per_section_z_index:

--- a/schema/core/v2.0.0/metadata.yaml
+++ b/schema/core/v2.0.0/metadata.yaml
@@ -799,6 +799,34 @@ classes:
   # ============================================================================
 
   # ============================================================================
+  # Identified object metadata
+  # ============================================================================
+  IdentifiedObject:
+    description: Metadata describing an identified object.
+    attributes:
+      object_id:
+        exact_mappings:
+          - cdp-common:identified_object_id
+      object_name:
+        exact_mappings:
+          - cdp-common:identified_object_name
+      object_description:
+        exact_mappings:
+          - cdp-common:identified_object_description
+      object_state:
+        exact_mappings:
+          - cdp-common:identified_object_state
+
+  IdentifiedObjectList:
+    description: Metadata for a list of identified objects.
+    attributes:
+      filter_value:
+        exact_mappings:
+          - cdp-common:identified_object_filter_value
+  # ============================================================================
+
+
+  # ============================================================================
   # annotation_metadata.json
   # ============================================================================
   Annotation:

--- a/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.py
+++ b/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.py
@@ -477,6 +477,20 @@ class AnnotationFileShapeTypeEnum(str, Enum):
     InstanceSegmentation = "InstanceSegmentation"
 
 
+class AnnotationFileFormatEnum(str, Enum):
+    """
+    Describes the format of the annotation file
+    """
+    # MRC format
+    mrc = "mrc"
+    # OMEZARR format
+    zarr = "zarr"
+    # NDJSON format
+    ndjson = "ndjson"
+    # GLB format
+    glb = "glb"
+
+
 class AnnotationMethodLinkTypeEnum(str, Enum):
     """
     Describes the type of link associated to the annotation method.
@@ -633,11 +647,11 @@ class PicturePath(ConfiguredBaseModel):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
 
     snapshot: Optional[str] = Field(None, description="""Path to the dataset preview image relative to the dataset directory root.""", json_schema_extra = { "linkml_meta": {'alias': 'snapshot',
-         'domain_of': ['PicturePath'],
+         'domain_of': ['PicturePath', 'MetadataPicturePath'],
          'exact_mappings': ['cdp-common:snapshot'],
          'recommended': True} })
     thumbnail: Optional[str] = Field(None, description="""Path to the thumbnail of preview image relative to the dataset directory root.""", json_schema_extra = { "linkml_meta": {'alias': 'thumbnail',
-         'domain_of': ['PicturePath'],
+         'domain_of': ['PicturePath', 'MetadataPicturePath'],
          'exact_mappings': ['cdp-common:thumbnail'],
          'recommended': True} })
 
@@ -664,6 +678,22 @@ class PicturePath(ConfiguredBaseModel):
             if not pattern.match(v):
                 raise ValueError(f"Invalid thumbnail format: {v}")
         return v
+
+
+class MetadataPicturePath(ConfiguredBaseModel):
+    """
+    A set of paths to representative images of a piece of data for metadata files.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
+
+    snapshot: Optional[str] = Field(None, description="""Relative path (non-URL/URI) to the dataset preview image relative to the dataset directory root.""", json_schema_extra = { "linkml_meta": {'alias': 'snapshot',
+         'domain_of': ['PicturePath', 'MetadataPicturePath'],
+         'exact_mappings': ['cdp-common:metadata_snapshot'],
+         'recommended': True} })
+    thumbnail: Optional[str] = Field(None, description="""Relative path (non-URL/URI) to the thumbnail of preview image relative to the dataset directory root.""", json_schema_extra = { "linkml_meta": {'alias': 'thumbnail',
+         'domain_of': ['PicturePath', 'MetadataPicturePath'],
+         'exact_mappings': ['cdp-common:metadata_thumbnail'],
+         'recommended': True} })
 
 
 class FundingDetails(ConfiguredBaseModel):
@@ -739,7 +769,18 @@ class PicturedEntity(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
 
-    key_photos: PicturePath = Field(..., description="""A set of paths to representative images of a piece of data.""", json_schema_extra = { "linkml_meta": {'alias': 'key_photos', 'domain_of': ['PicturedEntity']} })
+    key_photos: PicturePath = Field(..., description="""A set of paths to representative images of a piece of data.""", json_schema_extra = { "linkml_meta": {'alias': 'key_photos',
+         'domain_of': ['PicturedEntity', 'PicturedMetadataEntity']} })
+
+
+class PicturedMetadataEntity(ConfiguredBaseModel):
+    """
+    An entity with associated preview images for metadata files.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
+
+    key_photos: MetadataPicturePath = Field(..., description="""A set of paths to representative images of a piece of data for metadata files.""", json_schema_extra = { "linkml_meta": {'alias': 'key_photos',
+         'domain_of': ['PicturedEntity', 'PicturedMetadataEntity']} })
 
 
 class OrganismDetails(ConfiguredBaseModel):
@@ -1233,6 +1274,76 @@ class TiltRange(ConfiguredBaseModel):
         return v
 
 
+class PerSectionParameter(ConfiguredBaseModel):
+    """
+    Parameters for a section of a tilt series.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
+
+    z_index: int = Field(..., description="""z-index of the frame in the tiltseries""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'z_index',
+         'domain_of': ['PerSectionParameter', 'PerSectionAlignmentParameters'],
+         'exact_mappings': ['cdp-common:per_section_z_index']} })
+    frame_acquisition_order: int = Field(..., description="""The 0-based index of this movie stack in the order of acquisition.""", json_schema_extra = { "linkml_meta": {'alias': 'frame_acquisition_order',
+         'domain_of': ['PerSectionParameter'],
+         'exact_mappings': ['cdp-common:frames_acquisition_order']} })
+    raw_angle: Optional[float] = Field(None, description="""Nominal angle of the tilt series section.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'alias': 'raw_angle',
+         'domain_of': ['PerSectionParameter'],
+         'exact_mappings': ['cdp-common:per_section_nominal_tilt_angle'],
+         'unit': {'descriptive_name': 'degrees', 'symbol': '°'}} })
+    astigmatic_angle: Optional[float] = Field(None, description="""Angle of astigmatism.""", ge=-180, le=180, json_schema_extra = { "linkml_meta": {'alias': 'astigmatic_angle',
+         'domain_of': ['PerSectionParameter'],
+         'exact_mappings': ['cdp-common:per_section_astigmatic_angle'],
+         'unit': {'descriptive_name': 'degrees', 'symbol': '°'}} })
+    minor_defocus: Optional[float] = Field(None, description="""Minor axis defocus amount, underfocus is positive.""", json_schema_extra = { "linkml_meta": {'alias': 'minor_defocus',
+         'domain_of': ['PerSectionParameter'],
+         'exact_mappings': ['cdp-common:per_section_minor_defocus'],
+         'unit': {'descriptive_name': 'angstrom', 'symbol': 'Å'}} })
+    major_defocus: Optional[float] = Field(None, description="""Major axis defocus amount, underfocus is positive.""", json_schema_extra = { "linkml_meta": {'alias': 'major_defocus',
+         'domain_of': ['PerSectionParameter'],
+         'exact_mappings': ['cdp-common:per_section_major_defocus'],
+         'unit': {'descriptive_name': 'angstrom', 'symbol': 'Å'}} })
+    max_resolution: Optional[float] = Field(None, description="""Maximum resolution of the CTF fit for this section.""", json_schema_extra = { "linkml_meta": {'alias': 'max_resolution',
+         'domain_of': ['PerSectionParameter'],
+         'exact_mappings': ['cdp-common:per_section_max_resolution'],
+         'unit': {'descriptive_name': 'angstrom', 'symbol': 'Å'}} })
+    phase_shift: Optional[float] = Field(None, description="""Phase shift measured for this section.""", json_schema_extra = { "linkml_meta": {'alias': 'phase_shift',
+         'domain_of': ['PerSectionParameter'],
+         'exact_mappings': ['cdp-common:per_section_phase_shift'],
+         'unit': {'descriptive_name': 'radians', 'symbol': 'rad'}} })
+    cross_correlation: Optional[float] = Field(None, description="""CTF fit cross correlation value for this section.""", json_schema_extra = { "linkml_meta": {'alias': 'cross_correlation',
+         'domain_of': ['PerSectionParameter'],
+         'exact_mappings': ['cdp-common:per_section_cross_correlation']} })
+
+
+class TiltSeriesSize(ConfiguredBaseModel):
+    """
+    The size of a tiltseries in sctions/pixels in each dimension.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
+
+    x: int = Field(..., description="""Number of pixels in the 2D data fast axis""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'x',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
+                       'TomogramOffset',
+                       'AlignmentSize',
+                       'AlignmentOffset'],
+         'unit': {'descriptive_name': 'pixels', 'symbol': 'px'}} })
+    y: int = Field(..., description="""Number of pixels in the 2D data medium axis""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'y',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
+                       'TomogramOffset',
+                       'AlignmentSize',
+                       'AlignmentOffset'],
+         'unit': {'descriptive_name': 'pixels', 'symbol': 'px'}} })
+    z: int = Field(..., description="""Number of sections in the 2D stack.""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'z',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
+                       'TomogramOffset',
+                       'AlignmentSize',
+                       'AlignmentOffset'],
+         'unit': {'descriptive_name': 'sections'}} })
+
+
 class TiltSeries(ConfiguredBaseModel):
     """
     Metadata describing a tilt series.
@@ -1466,19 +1577,22 @@ class TomogramSize(ConfiguredBaseModel):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
 
     x: int = Field(..., description="""Number of pixels in the 3D data fast axis""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'x',
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
          'unit': {'descriptive_name': 'pixels', 'symbol': 'px'}} })
     y: int = Field(..., description="""Number of pixels in the 3D data medium axis""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'y',
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
          'unit': {'descriptive_name': 'pixels', 'symbol': 'px'}} })
     z: int = Field(..., description="""Number of pixels in the 3D data slow axis.  This is the image projection direction at zero stage tilt""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'z',
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
@@ -1492,19 +1606,22 @@ class TomogramOffset(ConfiguredBaseModel):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
 
     x: int = Field(..., description="""x offset data relative to the canonical tomogram in pixels""", json_schema_extra = { "linkml_meta": {'alias': 'x',
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
          'unit': {'descriptive_name': 'pixels', 'symbol': 'px'}} })
     y: int = Field(..., description="""y offset data relative to the canonical tomogram in pixels""", json_schema_extra = { "linkml_meta": {'alias': 'y',
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
          'unit': {'descriptive_name': 'pixels', 'symbol': 'px'}} })
     z: int = Field(..., description="""z offset data relative to the canonical tomogram in pixels""", json_schema_extra = { "linkml_meta": {'alias': 'z',
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
@@ -1572,7 +1689,7 @@ class Tomogram(AuthoredEntity):
                    'exact_number_dimensions': 2},
          'domain_of': ['Tomogram', 'Alignment']} })
     size: Optional[TomogramSize] = Field(None, description="""The size of a tomogram in voxels in each dimension.""", json_schema_extra = { "linkml_meta": {'alias': 'size', 'domain_of': ['Tomogram']} })
-    offset: TomogramOffset = Field(..., description="""The offset of a tomogram in voxels in each dimension relative to the canonical tomogram.""", json_schema_extra = { "linkml_meta": {'alias': 'offset', 'domain_of': ['Tomogram', 'Alignment']} })
+    offset: TomogramOffset = Field(..., description="""The offset of a tomogram in voxels in each dimension relative to the canonical tomogram.""", json_schema_extra = { "linkml_meta": {'alias': 'offset', 'domain_of': ['Tomogram']} })
     is_visualization_default: bool = Field(True, description="""Whether the tomogram is the default for visualization.""", json_schema_extra = { "linkml_meta": {'alias': 'is_visualization_default',
          'domain_of': ['Tomogram',
                        'AnnotationSourceFile',
@@ -1820,6 +1937,7 @@ class AnnotationOrientedPointFile(AnnotationSourceFile):
     filter_value: Optional[str] = Field(None, description="""The filter value for an oriented point / instance segmentation annotation file.""", json_schema_extra = { "linkml_meta": {'alias': 'filter_value',
          'domain_of': ['AnnotationOrientedPointFile',
                        'AnnotationPointFile',
+                       'IdentifiedObjectList',
                        'AnnotationInstanceSegmentationFile'],
          'exact_mappings': ['cdp-common:annotation_source_file_filter_value']} })
     order: Optional[str] = Field("xyz", description="""The order of axes for an oriented point / instance segmentation annotation file.""", json_schema_extra = { "linkml_meta": {'alias': 'order',
@@ -1898,6 +2016,7 @@ class AnnotationInstanceSegmentationFile(AnnotationOrientedPointFile):
     filter_value: Optional[str] = Field(None, description="""The filter value for an oriented point / instance segmentation annotation file.""", json_schema_extra = { "linkml_meta": {'alias': 'filter_value',
          'domain_of': ['AnnotationOrientedPointFile',
                        'AnnotationPointFile',
+                       'IdentifiedObjectList',
                        'AnnotationInstanceSegmentationFile'],
          'exact_mappings': ['cdp-common:annotation_source_file_filter_value']} })
     order: Optional[str] = Field("xyz", description="""The order of axes for an oriented point / instance segmentation annotation file.""", json_schema_extra = { "linkml_meta": {'alias': 'order',
@@ -1984,6 +2103,7 @@ class AnnotationPointFile(AnnotationSourceFile):
     filter_value: Optional[str] = Field(None, description="""The filter value for an oriented point / instance segmentation annotation file.""", json_schema_extra = { "linkml_meta": {'alias': 'filter_value',
          'domain_of': ['AnnotationOrientedPointFile',
                        'AnnotationPointFile',
+                       'IdentifiedObjectList',
                        'AnnotationInstanceSegmentationFile'],
          'exact_mappings': ['cdp-common:annotation_source_file_filter_value']} })
     file_format: str = Field(..., description="""File format for this file""", json_schema_extra = { "linkml_meta": {'alias': 'file_format',
@@ -2322,6 +2442,53 @@ class AnnotationTriangularMeshGroupFile(AnnotationSourceFile):
          'ifabsent': 'False'} })
 
 
+class IdentifiedObject(ConfiguredBaseModel):
+    """
+    Metadata describing an identified object.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
+
+    object_id: str = Field(..., description="""A placeholder for any type of data.""", json_schema_extra = { "linkml_meta": {'alias': 'object_id',
+         'any_of': [{'range': 'GO_ID'}, {'range': 'UNIPROT_ID'}],
+         'domain_of': ['IdentifiedObject'],
+         'exact_mappings': ['cdp-common:identified_object_id']} })
+    object_name: str = Field(..., description="""Name of the object that was identified (e.g. ribosome, nuclear pore complex, actin filament, membrane)""", json_schema_extra = { "linkml_meta": {'alias': 'object_name',
+         'domain_of': ['IdentifiedObject'],
+         'exact_mappings': ['cdp-common:identified_object_name']} })
+    object_description: Optional[str] = Field(None, description="""A textual description of the identified object, can be a longer description to include additional information not covered by the identified object name and state.""", json_schema_extra = { "linkml_meta": {'alias': 'object_description',
+         'domain_of': ['IdentifiedObject'],
+         'exact_mappings': ['cdp-common:identified_object_description']} })
+    object_state: Optional[str] = Field(None, description="""Molecule state identified (e.g. open, closed)""", json_schema_extra = { "linkml_meta": {'alias': 'object_state',
+         'domain_of': ['IdentifiedObject'],
+         'exact_mappings': ['cdp-common:identified_object_state']} })
+
+    @field_validator('object_id')
+    def pattern_object_id(cls, v):
+        pattern=re.compile(r"(^GO:[0-9]{7}$)|(^UniProtKB:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$)")
+        if isinstance(v,list):
+            for element in v:
+                if not pattern.match(element):
+                    raise ValueError(f"Invalid object_id format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid object_id format: {v}")
+        return v
+
+
+class IdentifiedObjectList(ConfiguredBaseModel):
+    """
+    Metadata for a list of identified objects.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
+
+    filter_value: Optional[str] = Field(None, description="""Filter value for the identified object, used to filter the list of identified objects by run name.""", json_schema_extra = { "linkml_meta": {'alias': 'filter_value',
+         'domain_of': ['AnnotationOrientedPointFile',
+                       'AnnotationPointFile',
+                       'IdentifiedObjectList',
+                       'AnnotationInstanceSegmentationFile'],
+         'exact_mappings': ['cdp-common:identified_object_filter_value']} })
+
+
 class Annotation(AuthoredEntity, DateStampedEntity):
     """
     Metadata describing an annotation.
@@ -2407,21 +2574,24 @@ class AlignmentSize(ConfiguredBaseModel):
 
     x: Union[float, str] = Field(..., description="""A placeholder for any type of data.""", json_schema_extra = { "linkml_meta": {'alias': 'x',
          'any_of': [{'range': 'float'}, {'range': 'FloatFormattedString'}],
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
          'unit': {'descriptive_name': 'Angstrom', 'symbol': 'Å'}} })
     y: Union[float, str] = Field(..., description="""A placeholder for any type of data.""", json_schema_extra = { "linkml_meta": {'alias': 'y',
          'any_of': [{'range': 'float'}, {'range': 'FloatFormattedString'}],
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
          'unit': {'descriptive_name': 'Angstrom', 'symbol': 'Å'}} })
     z: Union[float, str] = Field(..., description="""A placeholder for any type of data.""", json_schema_extra = { "linkml_meta": {'alias': 'z',
          'any_of': [{'range': 'float'}, {'range': 'FloatFormattedString'}],
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
@@ -2472,7 +2642,8 @@ class AlignmentOffset(ConfiguredBaseModel):
 
     x: Union[float, str] = Field(0.0, description="""A placeholder for any type of data.""", json_schema_extra = { "linkml_meta": {'alias': 'x',
          'any_of': [{'range': 'float'}, {'range': 'FloatFormattedString'}],
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
@@ -2480,7 +2651,8 @@ class AlignmentOffset(ConfiguredBaseModel):
          'unit': {'descriptive_name': 'Angstrom', 'symbol': 'Å'}} })
     y: Union[float, str] = Field(0.0, description="""A placeholder for any type of data.""", json_schema_extra = { "linkml_meta": {'alias': 'y',
          'any_of': [{'range': 'float'}, {'range': 'FloatFormattedString'}],
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
@@ -2488,7 +2660,8 @@ class AlignmentOffset(ConfiguredBaseModel):
          'unit': {'descriptive_name': 'Angstrom', 'symbol': 'Å'}} })
     z: Union[float, str] = Field(0.0, description="""A placeholder for any type of data.""", json_schema_extra = { "linkml_meta": {'alias': 'z',
          'any_of': [{'range': 'float'}, {'range': 'FloatFormattedString'}],
-         'domain_of': ['TomogramSize',
+         'domain_of': ['TiltSeriesSize',
+                       'TomogramSize',
                        'TomogramOffset',
                        'AlignmentSize',
                        'AlignmentOffset'],
@@ -2532,12 +2705,47 @@ class AlignmentOffset(ConfiguredBaseModel):
         return v
 
 
+class PerSectionAlignmentParameters(ConfiguredBaseModel):
+    """
+    Alignment parameters for one section of a tilt series.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
+
+    z_index: int = Field(..., description="""z-index of the frame in the tiltseries""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'z_index',
+         'domain_of': ['PerSectionParameter', 'PerSectionAlignmentParameters'],
+         'exact_mappings': ['cdp-common:per_section_z_index']} })
+    tilt_angle: Optional[float] = Field(None, description="""Tilt angle of the projection in degrees""", json_schema_extra = { "linkml_meta": {'alias': 'tilt_angle',
+         'domain_of': ['PerSectionAlignmentParameters'],
+         'exact_mappings': ['cdp-common:per_section_alignment_tilt_angle'],
+         'unit': {'descriptive_name': 'degrees', 'symbol': '°'}} })
+    volume_x_rotation: Optional[float] = Field(None, description="""Additional X rotation of the reconstruction volume in degrees""", json_schema_extra = { "linkml_meta": {'alias': 'volume_x_rotation',
+         'domain_of': ['PerSectionAlignmentParameters'],
+         'exact_mappings': ['cdp-common:alignment_volume_x_rotation'],
+         'unit': {'descriptive_name': 'degrees', 'symbol': '°'}} })
+    in_plane_rotation: Optional[conlist(min_length=2, max_length=2, item_type=conlist(min_length=2, max_length=2, item_type=float))] = Field(None, description="""In-plane rotation of the projection as a rotation matrix.""", json_schema_extra = { "linkml_meta": {'alias': 'in_plane_rotation',
+         'array': {'dimensions': [{'exact_cardinality': 2}, {'exact_cardinality': 2}],
+                   'exact_number_dimensions': 2},
+         'domain_of': ['PerSectionAlignmentParameters']} })
+    x_offset: Optional[float] = Field(None, description="""In-plane X-shift of the projection in angstrom""", json_schema_extra = { "linkml_meta": {'alias': 'x_offset',
+         'domain_of': ['PerSectionAlignmentParameters'],
+         'exact_mappings': ['cdp-common:per_section_alignment_x_offset'],
+         'unit': {'descriptive_name': 'Angstrom', 'symbol': 'Å'}} })
+    y_offset: Optional[float] = Field(None, description="""In-plane Y-shift of the projection in angstrom""", json_schema_extra = { "linkml_meta": {'alias': 'y_offset',
+         'domain_of': ['PerSectionAlignmentParameters'],
+         'exact_mappings': ['cdp-common:per_section_alignment_y_offset'],
+         'unit': {'descriptive_name': 'Angstrom', 'symbol': 'Å'}} })
+    beam_tilt: Optional[float] = Field(None, description="""Beam tilt during projection in degrees""", json_schema_extra = { "linkml_meta": {'alias': 'beam_tilt',
+         'domain_of': ['PerSectionAlignmentParameters'],
+         'exact_mappings': ['cdp-common:per_section_alignment_beam_tilt'],
+         'unit': {'descriptive_name': 'degrees', 'symbol': '°'}} })
+
+
 class Alignment(ConfiguredBaseModel):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
 
     alignment_type: Optional[AlignmentTypeEnum] = Field(None, description="""The type of alignment.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_type', 'domain_of': ['Alignment']} })
-    offset: Optional[AlignmentOffset] = Field(None, description="""The offset of a alignment in voxels in each dimension relative to the canonical tomogram.""", json_schema_extra = { "linkml_meta": {'alias': 'offset', 'domain_of': ['Tomogram', 'Alignment']} })
-    volume_dimesion: Optional[AlignmentSize] = Field(None, description="""The size of an alignment in voxels in each dimension.""", json_schema_extra = { "linkml_meta": {'alias': 'volume_dimesion', 'domain_of': ['Alignment']} })
+    volume_offset: Optional[AlignmentOffset] = Field(None, description="""The offset of a alignment in voxels in each dimension relative to the canonical tomogram.""", json_schema_extra = { "linkml_meta": {'alias': 'volume_offset', 'domain_of': ['Alignment']} })
+    volume_dimension: Optional[AlignmentSize] = Field(None, description="""The size of an alignment in voxels in each dimension.""", json_schema_extra = { "linkml_meta": {'alias': 'volume_dimension', 'domain_of': ['Alignment']} })
     x_rotation_offset: Optional[Union[int, str]] = Field(0, description="""A placeholder for any type of data.""", json_schema_extra = { "linkml_meta": {'alias': 'x_rotation_offset',
          'any_of': [{'range': 'integer'}, {'range': 'IntegerFormattedString'}],
          'domain_of': ['Alignment'],
@@ -2891,6 +3099,7 @@ class Container(ConfiguredBaseModel):
     depositions: List[DepositionEntity] = Field(..., description="""A deposition entity.""", min_length=1, json_schema_extra = { "linkml_meta": {'alias': 'depositions', 'domain_of': ['Container']} })
     frames: Optional[List[FrameEntity]] = Field(None, description="""A frame entity.""", json_schema_extra = { "linkml_meta": {'alias': 'frames', 'domain_of': ['Container']} })
     gains: Optional[List[GainEntity]] = Field(None, description="""A gain entity.""", json_schema_extra = { "linkml_meta": {'alias': 'gains', 'domain_of': ['Container']} })
+    identified_objects: Optional[List[IdentifiedObjectEntity]] = Field(None, description="""An identified object entity.""", json_schema_extra = { "linkml_meta": {'alias': 'identified_objects', 'domain_of': ['Container']} })
     key_images: Optional[List[KeyImageEntity]] = Field(None, description="""A key image entity.""", json_schema_extra = { "linkml_meta": {'alias': 'key_images', 'domain_of': ['Container']} })
     rawtilts: Optional[List[RawTiltEntity]] = Field(None, description="""A raw tilt entity.""", json_schema_extra = { "linkml_meta": {'alias': 'rawtilts', 'domain_of': ['Container']} })
     runs: List[RunEntity] = Field(..., description="""A run entity.""", min_length=1, json_schema_extra = { "linkml_meta": {'alias': 'runs', 'domain_of': ['Container']} })
@@ -3311,6 +3520,7 @@ class AlignmentEntity(ConfiguredBaseModel):
                        'DatasetEntity',
                        'DepositionEntity',
                        'FrameEntity',
+                       'IdentifiedObjectEntity',
                        'TiltSeriesEntity',
                        'TomogramEntity']} })
     sources: Optional[List[AlignmentSource]] = Field(None, description="""An alignment source.""", json_schema_extra = { "linkml_meta": {'alias': 'sources',
@@ -3324,6 +3534,7 @@ class AlignmentEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -3583,6 +3794,7 @@ class AnnotationEntity(ConfiguredBaseModel):
                        'DatasetEntity',
                        'DepositionEntity',
                        'FrameEntity',
+                       'IdentifiedObjectEntity',
                        'TiltSeriesEntity',
                        'TomogramEntity']} })
     sources: List[AnnotationSource] = Field(..., description="""An annotation source.""", min_length=1, json_schema_extra = { "linkml_meta": {'alias': 'sources',
@@ -3596,6 +3808,7 @@ class AnnotationEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -3800,6 +4013,7 @@ class CollectionMetadataEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -4059,6 +4273,7 @@ class CtfEntity(ConfiguredBaseModel):
                        'DatasetEntity',
                        'DepositionEntity',
                        'FrameEntity',
+                       'IdentifiedObjectEntity',
                        'TiltSeriesEntity',
                        'TomogramEntity']} })
     sources: List[CtfSource] = Field(..., description="""A ctf source.""", min_length=1, json_schema_extra = { "linkml_meta": {'alias': 'sources',
@@ -4072,6 +4287,7 @@ class CtfEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -4331,6 +4547,7 @@ class DatasetEntity(ConfiguredBaseModel):
                        'DatasetEntity',
                        'DepositionEntity',
                        'FrameEntity',
+                       'IdentifiedObjectEntity',
                        'TiltSeriesEntity',
                        'TomogramEntity']} })
     sources: List[DatasetSource] = Field(..., description="""A dataset source.""", min_length=1, json_schema_extra = { "linkml_meta": {'alias': 'sources',
@@ -4344,6 +4561,7 @@ class DatasetEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -4582,6 +4800,7 @@ class DatasetKeyPhotoEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -4816,6 +5035,7 @@ class DepositionEntity(ConfiguredBaseModel):
                        'DatasetEntity',
                        'DepositionEntity',
                        'FrameEntity',
+                       'IdentifiedObjectEntity',
                        'TiltSeriesEntity',
                        'TomogramEntity']} })
     sources: List[DepositionSource] = Field(..., description="""A deposition source.""", min_length=1, json_schema_extra = { "linkml_meta": {'alias': 'sources',
@@ -4829,6 +5049,7 @@ class DepositionEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -4968,6 +5189,7 @@ class DepositionKeyPhotoEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -5206,6 +5428,7 @@ class FrameEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -5219,6 +5442,7 @@ class FrameEntity(ConfiguredBaseModel):
                        'DatasetEntity',
                        'DepositionEntity',
                        'FrameEntity',
+                       'IdentifiedObjectEntity',
                        'TiltSeriesEntity',
                        'TomogramEntity']} })
 
@@ -5478,6 +5702,7 @@ class GainEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -5724,6 +5949,42 @@ class GainParent(ConfiguredBaseModel):
                        'VoxelSpacingParent']} })
 
 
+class IdentifiedObjectEntity(ConfiguredBaseModel):
+    """
+    An identified object entity.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'cdp-ingestion-config'})
+
+    metadata: Optional[IdentifiedObjectList] = Field(None, description="""Metadata for a list of identified objects.""", json_schema_extra = { "linkml_meta": {'alias': 'metadata',
+         'domain_of': ['AlignmentEntity',
+                       'AnnotationEntity',
+                       'CtfEntity',
+                       'DatasetEntity',
+                       'DepositionEntity',
+                       'FrameEntity',
+                       'IdentifiedObjectEntity',
+                       'TiltSeriesEntity',
+                       'TomogramEntity']} })
+    sources: List[StandardSource] = Field(..., description="""A generalized source class with glob finders. Inherited by a majority of source classes.""", min_length=1, json_schema_extra = { "linkml_meta": {'alias': 'sources',
+         'domain_of': ['AlignmentEntity',
+                       'AnnotationEntity',
+                       'CollectionMetadataEntity',
+                       'CtfEntity',
+                       'DatasetEntity',
+                       'DatasetKeyPhotoEntity',
+                       'DepositionEntity',
+                       'DepositionKeyPhotoEntity',
+                       'FrameEntity',
+                       'GainEntity',
+                       'IdentifiedObjectEntity',
+                       'KeyImageEntity',
+                       'RawTiltEntity',
+                       'RunEntity',
+                       'TiltSeriesEntity',
+                       'TomogramEntity',
+                       'VoxelSpacingEntity']} })
+
+
 class KeyImageEntity(ConfiguredBaseModel):
     """
     A key image entity.
@@ -5741,6 +6002,7 @@ class KeyImageEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -6010,6 +6272,7 @@ class RawTiltEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -6273,6 +6536,7 @@ class RunEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -6534,6 +6798,7 @@ class TiltSeriesEntity(ConfiguredBaseModel):
                        'DatasetEntity',
                        'DepositionEntity',
                        'FrameEntity',
+                       'IdentifiedObjectEntity',
                        'TiltSeriesEntity',
                        'TomogramEntity']} })
     sources: List[TiltSeriesSource] = Field(..., description="""A tilt series source.""", min_length=1, json_schema_extra = { "linkml_meta": {'alias': 'sources',
@@ -6547,6 +6812,7 @@ class TiltSeriesEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -6808,6 +7074,7 @@ class TomogramEntity(ConfiguredBaseModel):
                        'DatasetEntity',
                        'DepositionEntity',
                        'FrameEntity',
+                       'IdentifiedObjectEntity',
                        'TiltSeriesEntity',
                        'TomogramEntity']} })
     sources: List[TomogramSource] = Field(..., description="""A tomogram source.""", min_length=1, json_schema_extra = { "linkml_meta": {'alias': 'sources',
@@ -6821,6 +7088,7 @@ class TomogramEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -7091,6 +7359,7 @@ class VoxelSpacingEntity(ConfiguredBaseModel):
                        'DepositionKeyPhotoEntity',
                        'FrameEntity',
                        'GainEntity',
+                       'IdentifiedObjectEntity',
                        'KeyImageEntity',
                        'RawTiltEntity',
                        'RunEntity',
@@ -7359,12 +7628,14 @@ class TomogramHeader(ConfiguredBaseModel):
 # Model rebuild
 # see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
 PicturePath.model_rebuild()
+MetadataPicturePath.model_rebuild()
 FundingDetails.model_rebuild()
 DateStampedEntity.model_rebuild()
 AuthoredEntity.model_rebuild()
 FundedEntity.model_rebuild()
 CrossReferencedEntity.model_rebuild()
 PicturedEntity.model_rebuild()
+PicturedMetadataEntity.model_rebuild()
 OrganismDetails.model_rebuild()
 TissueDetails.model_rebuild()
 CellType.model_rebuild()
@@ -7377,6 +7648,8 @@ CameraDetails.model_rebuild()
 MicroscopeDetails.model_rebuild()
 MicroscopeOpticalSetup.model_rebuild()
 TiltRange.model_rebuild()
+PerSectionParameter.model_rebuild()
+TiltSeriesSize.model_rebuild()
 TiltSeries.model_rebuild()
 TomogramSize.model_rebuild()
 TomogramOffset.model_rebuild()
@@ -7392,9 +7665,12 @@ AnnotationSegmentationMaskFile.model_rebuild()
 AnnotationSemanticSegmentationMaskFile.model_rebuild()
 AnnotationTriangularMeshFile.model_rebuild()
 AnnotationTriangularMeshGroupFile.model_rebuild()
+IdentifiedObject.model_rebuild()
+IdentifiedObjectList.model_rebuild()
 Annotation.model_rebuild()
 AlignmentSize.model_rebuild()
 AlignmentOffset.model_rebuild()
+PerSectionAlignmentParameters.model_rebuild()
 Alignment.model_rebuild()
 Frame.model_rebuild()
 Ctf.model_rebuild()
@@ -7454,6 +7730,7 @@ GainEntity.model_rebuild()
 GainSource.model_rebuild()
 GainParentFilters.model_rebuild()
 GainParent.model_rebuild()
+IdentifiedObjectEntity.model_rebuild()
 KeyImageEntity.model_rebuild()
 KeyImageSource.model_rebuild()
 KeyImageParentFilters.model_rebuild()

--- a/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.schema.json
+++ b/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.schema.json
@@ -43,17 +43,6 @@
                     "description": "The alignment method type.",
                     "pattern": "(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^undefined$)"
                 },
-                "offset": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/AlignmentOffset"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The offset of a alignment in voxels in each dimension relative to the canonical tomogram."
-                },
                 "tilt_offset": {
                     "description": "The tilt offset relative to the tomogram.",
                     "type": [
@@ -61,7 +50,7 @@
                         "null"
                     ]
                 },
-                "volume_dimesion": {
+                "volume_dimension": {
                     "anyOf": [
                         {
                             "$ref": "#/$defs/AlignmentSize"
@@ -71,6 +60,17 @@
                         }
                     ],
                     "description": "The size of an alignment in voxels in each dimension."
+                },
+                "volume_offset": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AlignmentOffset"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The offset of a alignment in voxels in each dimension relative to the canonical tomogram."
                 },
                 "x_rotation_offset": {
                     "anyOf": [
@@ -575,6 +575,17 @@
             ],
             "title": "AnnotationEntity",
             "type": "object"
+        },
+        "AnnotationFileFormatEnum": {
+            "description": "Describes the format of the annotation file",
+            "enum": [
+                "mrc",
+                "zarr",
+                "ndjson",
+                "glb"
+            ],
+            "title": "AnnotationFileFormatEnum",
+            "type": "string"
         },
         "AnnotationFileShapeTypeEnum": {
             "description": "Describes the shape of the annotation",
@@ -1834,6 +1845,16 @@
                     "description": "A gain entity.",
                     "items": {
                         "$ref": "#/$defs/GainEntity"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "identified_objects": {
+                    "description": "An identified object entity.",
+                    "items": {
+                        "$ref": "#/$defs/IdentifiedObjectEntity"
                     },
                     "type": [
                         "array",
@@ -3527,6 +3548,96 @@
             "title": "GainSource",
             "type": "object"
         },
+        "IdentifiedObject": {
+            "additionalProperties": false,
+            "description": "Metadata describing an identified object.",
+            "properties": {
+                "object_description": {
+                    "description": "A textual description of the identified object, can be a longer description to include additional information not covered by the identified object name and state.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "object_id": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "pattern": "^GO:[0-9]{7}$",
+                            "type": "string"
+                        },
+                        {
+                            "pattern": "^UniProtKB:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$",
+                            "type": "string"
+                        }
+                    ],
+                    "description": "A placeholder for any type of data.",
+                    "pattern": "(^GO:[0-9]{7}$)|(^UniProtKB:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$)"
+                },
+                "object_name": {
+                    "description": "Name of the object that was identified (e.g. ribosome, nuclear pore complex, actin filament, membrane)",
+                    "type": "string"
+                },
+                "object_state": {
+                    "description": "Molecule state identified (e.g. open, closed)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "object_id",
+                "object_name"
+            ],
+            "title": "IdentifiedObject",
+            "type": "object"
+        },
+        "IdentifiedObjectEntity": {
+            "additionalProperties": false,
+            "description": "An identified object entity.",
+            "properties": {
+                "metadata": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/IdentifiedObjectList"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Metadata for a list of identified objects."
+                },
+                "sources": {
+                    "description": "A generalized source class with glob finders. Inherited by a majority of source classes.",
+                    "items": {
+                        "$ref": "#/$defs/StandardSource"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "sources"
+            ],
+            "title": "IdentifiedObjectEntity",
+            "type": "object"
+        },
+        "IdentifiedObjectList": {
+            "additionalProperties": false,
+            "description": "Metadata for a list of identified objects.",
+            "properties": {
+                "filter_value": {
+                    "description": "Filter value for the identified object, used to filter the list of identified objects by run name.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "IdentifiedObjectList",
+            "type": "object"
+        },
         "KeyImageEntity": {
             "additionalProperties": false,
             "description": "A key image entity.",
@@ -3722,6 +3833,28 @@
             "title": "KeyPhotoLiteral",
             "type": "object"
         },
+        "MetadataPicturePath": {
+            "additionalProperties": false,
+            "description": "A set of paths to representative images of a piece of data for metadata files.",
+            "properties": {
+                "snapshot": {
+                    "description": "Relative path (non-URL/URI) to the dataset preview image relative to the dataset directory root.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "thumbnail": {
+                    "description": "Relative path (non-URL/URI) to the thumbnail of preview image relative to the dataset directory root.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "MetadataPicturePath",
+            "type": "object"
+        },
         "MicroscopeDetails": {
             "additionalProperties": false,
             "description": "The microscope used to collect the tilt series.",
@@ -3812,6 +3945,148 @@
             "title": "OrganismDetails",
             "type": "object"
         },
+        "PerSectionAlignmentParameters": {
+            "additionalProperties": false,
+            "description": "Alignment parameters for one section of a tilt series.",
+            "properties": {
+                "beam_tilt": {
+                    "description": "Beam tilt during projection in degrees",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "in_plane_rotation": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "tilt_angle": {
+                    "description": "Tilt angle of the projection in degrees",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "volume_x_rotation": {
+                    "description": "Additional X rotation of the reconstruction volume in degrees",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "x_offset": {
+                    "description": "In-plane X-shift of the projection in angstrom",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "y_offset": {
+                    "description": "In-plane Y-shift of the projection in angstrom",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "z_index": {
+                    "description": "z-index of the frame in the tiltseries",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "z_index"
+            ],
+            "title": "PerSectionAlignmentParameters",
+            "type": "object"
+        },
+        "PerSectionParameter": {
+            "additionalProperties": false,
+            "description": "Parameters for a section of a tilt series.",
+            "properties": {
+                "astigmatic_angle": {
+                    "description": "Angle of astigmatism.",
+                    "maximum": 180,
+                    "minimum": -180,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "cross_correlation": {
+                    "description": "CTF fit cross correlation value for this section.",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "frame_acquisition_order": {
+                    "description": "The 0-based index of this movie stack in the order of acquisition.",
+                    "type": "integer"
+                },
+                "major_defocus": {
+                    "description": "Major axis defocus amount, underfocus is positive.",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "max_resolution": {
+                    "description": "Maximum resolution of the CTF fit for this section.",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "minor_defocus": {
+                    "description": "Minor axis defocus amount, underfocus is positive.",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "phase_shift": {
+                    "description": "Phase shift measured for this section.",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "raw_angle": {
+                    "description": "Nominal angle of the tilt series section.",
+                    "maximum": 90,
+                    "minimum": -90,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "z_index": {
+                    "description": "z-index of the frame in the tiltseries",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "z_index",
+                "frame_acquisition_order"
+            ],
+            "title": "PerSectionParameter",
+            "type": "object"
+        },
         "PicturePath": {
             "additionalProperties": false,
             "description": "A set of paths to representative images of a piece of data.",
@@ -3849,6 +4124,21 @@
                 "key_photos"
             ],
             "title": "PicturedEntity",
+            "type": "object"
+        },
+        "PicturedMetadataEntity": {
+            "additionalProperties": false,
+            "description": "An entity with associated preview images for metadata files.",
+            "properties": {
+                "key_photos": {
+                    "$ref": "#/$defs/MetadataPicturePath",
+                    "description": "A set of paths to representative images of a piece of data for metadata files."
+                }
+            },
+            "required": [
+                "key_photos"
+            ],
+            "title": "PicturedMetadataEntity",
             "type": "object"
         },
         "RawTiltEntity": {
@@ -4799,6 +5089,34 @@
             "title": "TiltSeriesParentFilters",
             "type": "object"
         },
+        "TiltSeriesSize": {
+            "additionalProperties": false,
+            "description": "The size of a tiltseries in sctions/pixels in each dimension.",
+            "properties": {
+                "x": {
+                    "description": "Number of pixels in the 2D data fast axis",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "y": {
+                    "description": "Number of pixels in the 2D data medium axis",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "z": {
+                    "description": "Number of sections in the 2D stack.",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "x",
+                "y",
+                "z"
+            ],
+            "title": "TiltSeriesSize",
+            "type": "object"
+        },
         "TiltSeriesSource": {
             "additionalProperties": false,
             "description": "A tilt series source.",
@@ -5681,6 +5999,16 @@
             "description": "A gain entity.",
             "items": {
                 "$ref": "#/$defs/GainEntity"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "identified_objects": {
+            "description": "An identified object entity.",
+            "items": {
+                "$ref": "#/$defs/IdentifiedObjectEntity"
             },
             "type": [
                 "array",

--- a/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models_materialized.yaml
+++ b/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models_materialized.yaml
@@ -446,6 +446,23 @@ enums:
       InstanceSegmentation:
         text: InstanceSegmentation
         description: A volume with labels for multiple instances
+  annotation_file_format_enum:
+    name: annotation_file_format_enum
+    description: Describes the format of the annotation file
+    from_schema: cdp-ingestion-config
+    permissible_values:
+      mrc:
+        text: mrc
+        description: MRC format
+      zarr:
+        text: zarr
+        description: OMEZARR format
+      ndjson:
+        text: ndjson
+        description: NDJSON format
+      glb:
+        text: glb
+        description: GLB format
   annotation_method_link_type_enum:
     name: annotation_method_link_type_enum
     description: Describes the type of link associated to the annotation method.
@@ -839,6 +856,18 @@ classes:
         domain_of:
         - Container
         range: GainEntity
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+      identified_objects:
+        name: identified_objects
+        description: An identified object entity.
+        from_schema: cdp-ingestion-config
+        alias: identified_objects
+        owner: Container
+        domain_of:
+        - Container
+        range: IdentifiedObjectEntity
         multivalued: true
         inlined: true
         inlined_as_list: true
@@ -1420,6 +1449,7 @@ classes:
         - DatasetEntity
         - DepositionEntity
         - FrameEntity
+        - IdentifiedObjectEntity
         - TiltSeriesEntity
         - TomogramEntity
         range: Alignment
@@ -1442,6 +1472,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -1719,6 +1750,7 @@ classes:
         - DatasetEntity
         - DepositionEntity
         - FrameEntity
+        - IdentifiedObjectEntity
         - TiltSeriesEntity
         - TomogramEntity
         range: Annotation
@@ -1742,6 +1774,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -2075,6 +2108,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -2355,6 +2389,7 @@ classes:
         - DatasetEntity
         - DepositionEntity
         - FrameEntity
+        - IdentifiedObjectEntity
         - TiltSeriesEntity
         - TomogramEntity
         range: Ctf
@@ -2377,6 +2412,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -2654,6 +2690,7 @@ classes:
         - DatasetEntity
         - DepositionEntity
         - FrameEntity
+        - IdentifiedObjectEntity
         - TiltSeriesEntity
         - TomogramEntity
         range: Dataset
@@ -2676,6 +2713,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -2912,6 +2950,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -3144,6 +3183,7 @@ classes:
         - DatasetEntity
         - DepositionEntity
         - FrameEntity
+        - IdentifiedObjectEntity
         - TiltSeriesEntity
         - TomogramEntity
         range: Deposition
@@ -3166,6 +3206,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -3283,6 +3324,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -3519,6 +3561,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -3542,6 +3585,7 @@ classes:
         - DatasetEntity
         - DepositionEntity
         - FrameEntity
+        - IdentifiedObjectEntity
         - TiltSeriesEntity
         - TomogramEntity
         range: Frame
@@ -3816,6 +3860,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -4075,6 +4120,62 @@ classes:
         multivalued: true
         inlined: true
         inlined_as_list: true
+  IdentifiedObjectEntity:
+    name: IdentifiedObjectEntity
+    description: An identified object entity.
+    from_schema: cdp-ingestion-config
+    attributes:
+      metadata:
+        name: metadata
+        description: Metadata for a list of identified objects.
+        from_schema: cdp-ingestion-config
+        alias: metadata
+        owner: IdentifiedObjectEntity
+        domain_of:
+        - AlignmentEntity
+        - AnnotationEntity
+        - CtfEntity
+        - DatasetEntity
+        - DepositionEntity
+        - FrameEntity
+        - IdentifiedObjectEntity
+        - TiltSeriesEntity
+        - TomogramEntity
+        range: IdentifiedObjectList
+        required: false
+        inlined: true
+        inlined_as_list: true
+      sources:
+        name: sources
+        description: A generalized source class with glob finders. Inherited by a
+          majority of source classes.
+        from_schema: cdp-ingestion-config
+        alias: sources
+        owner: IdentifiedObjectEntity
+        domain_of:
+        - AlignmentEntity
+        - AnnotationEntity
+        - CollectionMetadataEntity
+        - CtfEntity
+        - DatasetEntity
+        - DatasetKeyPhotoEntity
+        - DepositionEntity
+        - DepositionKeyPhotoEntity
+        - FrameEntity
+        - GainEntity
+        - IdentifiedObjectEntity
+        - KeyImageEntity
+        - RawTiltEntity
+        - RunEntity
+        - TiltSeriesEntity
+        - TomogramEntity
+        - VoxelSpacingEntity
+        range: StandardSource
+        required: true
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+        minimum_cardinality: 1
   KeyImageEntity:
     name: KeyImageEntity
     description: A key image entity.
@@ -4097,6 +4198,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -4409,6 +4511,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -4692,6 +4795,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -5019,6 +5123,7 @@ classes:
         - DatasetEntity
         - DepositionEntity
         - FrameEntity
+        - IdentifiedObjectEntity
         - TiltSeriesEntity
         - TomogramEntity
         range: TiltSeries
@@ -5041,6 +5146,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -5332,6 +5438,7 @@ classes:
         - DatasetEntity
         - DepositionEntity
         - FrameEntity
+        - IdentifiedObjectEntity
         - TiltSeriesEntity
         - TomogramEntity
         range: Tomogram
@@ -5354,6 +5461,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity
@@ -5665,6 +5773,7 @@ classes:
         - DepositionKeyPhotoEntity
         - FrameEntity
         - GainEntity
+        - IdentifiedObjectEntity
         - KeyImageEntity
         - RawTiltEntity
         - RunEntity

--- a/schema/ingestion_config/v1.0.0/ingestion_config_models.yaml
+++ b/schema/ingestion_config/v1.0.0/ingestion_config_models.yaml
@@ -91,6 +91,10 @@ classes:
         description: Gains for the dataset.
         multivalued: true
         range: GainEntity
+      identified_objects:
+        description: Identified objects for the runs in this dataset.
+        range: IdentifiedObjectEntity
+        multivalued: true
       key_images:
         description: Key images for the dataset.
         multivalued: true
@@ -588,6 +592,19 @@ classes:
       - dataset
       - deposition
       - run
+
+  IdentifiedObjectEntity:
+    description: An identified object entity.
+    attributes:
+      metadata:
+        description: The metadata for the identified object list.
+        range: IdentifiedObjectList
+        required: false
+      sources:
+        description: The sources for the identified object list.
+        multivalued: true
+        range: StandardSource
+        required: true
 
   KeyImageEntity:
     description: A key image entity.

--- a/schema/metadata_files/v2.0.0/codegen/metadata_files.py
+++ b/schema/metadata_files/v2.0.0/codegen/metadata_files.py
@@ -1,12 +1,29 @@
 from __future__ import annotations
-
-import re
-from datetime import date
+from datetime import (
+    datetime,
+    date
+)
+from decimal import Decimal
 from enum import Enum
-from typing import Any, ClassVar, Dict, List, Optional, Union
-
-from pydantic import BaseModel, ConfigDict, Field, RootModel, conlist, field_validator
-
+import re
+import sys
+from typing import (
+    Any,
+    ClassVar,
+    List,
+    Literal,
+    Dict,
+    Optional,
+    Union
+)
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator,
+    conlist
+)
 metamodel_version = "None"
 version = "2.0.0"
 
@@ -2009,6 +2026,7 @@ class AnnotationOrientedPointFile(AnnotationSourceFile):
     filter_value: Optional[str] = Field(None, description="""The filter value for an oriented point / instance segmentation annotation file.""", json_schema_extra = { "linkml_meta": {'alias': 'filter_value',
          'domain_of': ['AnnotationOrientedPointFile',
                        'AnnotationPointFile',
+                       'IdentifiedObjectList',
                        'AnnotationInstanceSegmentationFile'],
          'exact_mappings': ['cdp-common:annotation_source_file_filter_value']} })
     order: Optional[str] = Field("xyz", description="""The order of axes for an oriented point / instance segmentation annotation file.""", json_schema_extra = { "linkml_meta": {'alias': 'order',
@@ -2090,6 +2108,7 @@ class AnnotationInstanceSegmentationFile(AnnotationOrientedPointFile):
     filter_value: Optional[str] = Field(None, description="""The filter value for an oriented point / instance segmentation annotation file.""", json_schema_extra = { "linkml_meta": {'alias': 'filter_value',
          'domain_of': ['AnnotationOrientedPointFile',
                        'AnnotationPointFile',
+                       'IdentifiedObjectList',
                        'AnnotationInstanceSegmentationFile'],
          'exact_mappings': ['cdp-common:annotation_source_file_filter_value']} })
     order: Optional[str] = Field("xyz", description="""The order of axes for an oriented point / instance segmentation annotation file.""", json_schema_extra = { "linkml_meta": {'alias': 'order',
@@ -2179,6 +2198,7 @@ class AnnotationPointFile(AnnotationSourceFile):
     filter_value: Optional[str] = Field(None, description="""The filter value for an oriented point / instance segmentation annotation file.""", json_schema_extra = { "linkml_meta": {'alias': 'filter_value',
          'domain_of': ['AnnotationOrientedPointFile',
                        'AnnotationPointFile',
+                       'IdentifiedObjectList',
                        'AnnotationInstanceSegmentationFile'],
          'exact_mappings': ['cdp-common:annotation_source_file_filter_value']} })
     file_format: str = Field(..., description="""File format for this file""", json_schema_extra = { "linkml_meta": {'alias': 'file_format',
@@ -2530,6 +2550,53 @@ class AnnotationTriangularMeshGroupFile(AnnotationSourceFile):
                        'AlignmentMetadata'],
          'exact_mappings': ['cdp-common:annotation_source_file_is_portal_standard'],
          'ifabsent': 'False'} })
+
+
+class IdentifiedObject(ConfiguredBaseModel):
+    """
+    Metadata describing an identified object.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
+
+    object_id: str = Field(..., description="""A placeholder for any type of data.""", json_schema_extra = { "linkml_meta": {'alias': 'object_id',
+         'any_of': [{'range': 'GO_ID'}, {'range': 'UNIPROT_ID'}],
+         'domain_of': ['IdentifiedObject'],
+         'exact_mappings': ['cdp-common:identified_object_id']} })
+    object_name: str = Field(..., description="""Name of the object that was identified (e.g. ribosome, nuclear pore complex, actin filament, membrane)""", json_schema_extra = { "linkml_meta": {'alias': 'object_name',
+         'domain_of': ['IdentifiedObject'],
+         'exact_mappings': ['cdp-common:identified_object_name']} })
+    object_description: Optional[str] = Field(None, description="""A textual description of the identified object, can be a longer description to include additional information not covered by the identified object name and state.""", json_schema_extra = { "linkml_meta": {'alias': 'object_description',
+         'domain_of': ['IdentifiedObject'],
+         'exact_mappings': ['cdp-common:identified_object_description']} })
+    object_state: Optional[str] = Field(None, description="""Molecule state identified (e.g. open, closed)""", json_schema_extra = { "linkml_meta": {'alias': 'object_state',
+         'domain_of': ['IdentifiedObject'],
+         'exact_mappings': ['cdp-common:identified_object_state']} })
+
+    @field_validator('object_id')
+    def pattern_object_id(cls, v):
+        pattern=re.compile(r"(^GO:[0-9]{7}$)|(^UniProtKB:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$)")
+        if isinstance(v,list):
+            for element in v:
+                if not pattern.match(element):
+                    raise ValueError(f"Invalid object_id format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid object_id format: {v}")
+        return v
+
+
+class IdentifiedObjectList(ConfiguredBaseModel):
+    """
+    Metadata for a list of identified objects.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'metadata'})
+
+    filter_value: Optional[str] = Field(None, description="""Filter value for the identified object, used to filter the list of identified objects by run name.""", json_schema_extra = { "linkml_meta": {'alias': 'filter_value',
+         'domain_of': ['AnnotationOrientedPointFile',
+                       'AnnotationPointFile',
+                       'IdentifiedObjectList',
+                       'AnnotationInstanceSegmentationFile'],
+         'exact_mappings': ['cdp-common:identified_object_filter_value']} })
 
 
 class Annotation(AuthoredEntity, DateStampedEntity):
@@ -3776,6 +3843,7 @@ class RunMetadata(ConfiguredBaseModel):
     run_name: Optional[str] = Field(None, description="""Name of the run this metadata file is a part of.""", json_schema_extra = { "linkml_meta": {'alias': 'run_name',
          'domain_of': ['RunMetadata', 'TiltSeriesMetadata', 'TomogramMetadata'],
          'exact_mappings': ['cdp-common:metadata_run_name']} })
+    identified_objects: Optional[List[IdentifiedObject]] = Field(None, description="""Metadata describing an identified object.""", json_schema_extra = { "linkml_meta": {'alias': 'identified_objects', 'domain_of': ['RunMetadata']} })
 
 
 class TiltSeriesMetadata(DefaultMetadata, TiltSeries):
@@ -4280,6 +4348,8 @@ AnnotationSegmentationMaskFile.model_rebuild()
 AnnotationSemanticSegmentationMaskFile.model_rebuild()
 AnnotationTriangularMeshFile.model_rebuild()
 AnnotationTriangularMeshGroupFile.model_rebuild()
+IdentifiedObject.model_rebuild()
+IdentifiedObjectList.model_rebuild()
 Annotation.model_rebuild()
 AlignmentSize.model_rebuild()
 AlignmentOffset.model_rebuild()

--- a/schema/metadata_files/v2.0.0/codegen/metadata_files.schema.json
+++ b/schema/metadata_files/v2.0.0/codegen/metadata_files.schema.json
@@ -2336,6 +2336,66 @@
             "title": "FundingDetails",
             "type": "object"
         },
+        "IdentifiedObject": {
+            "additionalProperties": false,
+            "description": "Metadata describing an identified object.",
+            "properties": {
+                "object_description": {
+                    "description": "A textual description of the identified object, can be a longer description to include additional information not covered by the identified object name and state.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "object_id": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "pattern": "^GO:[0-9]{7}$",
+                            "type": "string"
+                        },
+                        {
+                            "pattern": "^UniProtKB:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$",
+                            "type": "string"
+                        }
+                    ],
+                    "description": "A placeholder for any type of data.",
+                    "pattern": "(^GO:[0-9]{7}$)|(^UniProtKB:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$)"
+                },
+                "object_name": {
+                    "description": "Name of the object that was identified (e.g. ribosome, nuclear pore complex, actin filament, membrane)",
+                    "type": "string"
+                },
+                "object_state": {
+                    "description": "Molecule state identified (e.g. open, closed)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "object_id",
+                "object_name"
+            ],
+            "title": "IdentifiedObject",
+            "type": "object"
+        },
+        "IdentifiedObjectList": {
+            "additionalProperties": false,
+            "description": "Metadata for a list of identified objects.",
+            "properties": {
+                "filter_value": {
+                    "description": "Filter value for the identified object, used to filter the list of identified objects by run name.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "IdentifiedObjectList",
+            "type": "object"
+        },
         "MetadataPicturePath": {
             "additionalProperties": false,
             "description": "A set of paths to representative images of a piece of data for metadata files.",
@@ -2691,6 +2751,16 @@
             "additionalProperties": false,
             "description": "Metadata pertaining to this run.",
             "properties": {
+                "identified_objects": {
+                    "description": "Metadata describing an identified object.",
+                    "items": {
+                        "$ref": "#/$defs/IdentifiedObject"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
                 "run_name": {
                     "description": "Name of the run this metadata file is a part of.",
                     "type": [

--- a/schema/metadata_files/v2.0.0/codegen/metadata_files_materialized.yaml
+++ b/schema/metadata_files/v2.0.0/codegen/metadata_files_materialized.yaml
@@ -1944,6 +1944,18 @@ classes:
         range: string
         inlined: true
         inlined_as_list: true
+      identified_objects:
+        name: identified_objects
+        description: Metadata describing an identified object.
+        from_schema: metadata
+        alias: identified_objects
+        owner: RunMetadata
+        domain_of:
+        - RunMetadata
+        range: IdentifiedObject
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
   TiltSeriesMetadata:
     name: TiltSeriesMetadata
     description: 'Metadata describing a tilt series.

--- a/schema/metadata_files/v2.0.0/metadata_files.yaml
+++ b/schema/metadata_files/v2.0.0/metadata_files.yaml
@@ -190,6 +190,11 @@ classes:
       run_name:
         exact_mappings:
           - cdp-common:metadata_run_name
+      identified_objects:
+        description: The objects identified in this run.
+        range: IdentifiedObject
+        multivalued: true
+        inlined_as_list: true
 
   # ============================================================================
 


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to Global Image Labels https://github.com/chanzuckerberg/cryoet-data-portal/issues/1823
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

In order to support global image labels, the respective fields and classes need to be added to the ingest config container and the metadata file schema. 

**Changes to common.yaml (fields common across schemas)**
Add common slots:
-  `identified_object_description`
-  `identified_object_id`
-  `identified_object_name`
-  `identified_object_state`
-  `identified_object_filter_value`

**Changes to metadata.yaml (classes common across schemas)**
Add Classes:
- `IdentifiedObject` (aggregation of id, name, state, description)
- `IdentifiedObjectList` (metadata of the input file, i.e. filter value)

**Changes to ingestion_config_models.yaml (ingest config schema)**
Add Class:
- `IdentifiedObjectEntity`

Add this entity to the container class.

Example config block: 
```yaml 
identified_objects:
 - metadata:
     filter_value: '{run_name}'
   sources:
     - source_glob:
         list_glob: '{run_name}/objects.csv'
```

**Changes to metadata_files.yaml (schema of S3 metadata files)**
Add `identified_objects` slot to `RunMetadata`.

Example output `run_metadata.json`: 

```json 
{
    "run_name": "TS_026",
    "identified_objects": [
        {
            "object_id": "GO:0009547",
            "object_name": "plastid ribosome"
        },
        {
            "object_id": "GO:0009547",
            "object_name": "plastid ribosome",
            "object_state": "open"
        },
        {
            "object_id": "GO:0009547",
            "object_name": "plastid ribosome",
            "object_state": "open",
            "object_description": "some stuff"
        }
    ]
}
```


