### PR TITLE
feat: Update SABER deposition to include authors, more data, instance segmentation masks. 

### DIFF
--- a/ingestion_tools/dataset_configs/deposition_10331.yaml
+++ b/ingestion_tools/dataset_configs/deposition_10331.yaml
@@ -818,9 +818,9 @@ depositions:
       name: Dari Kimanius
       primary_author_status: false
     dates:
-      deposition_date: '2025-05-22'
-      last_modified_date: '2025-05-22'
-      release_date: '2025-05-22'
+      deposition_date: '2026-03-09'
+      last_modified_date: '2026-03-09'
+      release_date: '2026-03-09'
     deposition_description: This deposition contains segmentations of whole cells,
       lysosomes and components of bacterial cells. The segmentations were generated
       using the SABER package, which is a SAM2-based segmentation framework that uses

--- a/ingestion_tools/dataset_configs/deposition_10331.yaml
+++ b/ingestion_tools/dataset_configs/deposition_10331.yaml
@@ -9,7 +9,7 @@ annotations:
 ############################ BEGIN Bacteria cell body SABER ############################
 - metadata:
     annotation_ingest_id: intracellular-anatomical-structure-1
-    annotation_method: Prediction using SABER
+    annotation_method: Prediction using SABER + Threshold at 0.5
     method_links: &method_links
       - link_type: source_code
         link: https://github.com/chanzuckerberg/saber
@@ -109,7 +109,7 @@ annotations:
 
 - metadata:
     annotation_ingest_id: intracellular-anatomical-structure-2
-    annotation_method: Prediction using SABER
+    annotation_method: Prediction using SABER + Threshold at 0.5
     method_links: *method_links
     annotation_object:
       id: GO:0005622
@@ -185,7 +185,7 @@ annotations:
 
 - metadata:
     annotation_ingest_id: intracellular-anatomical-structure-8
-    annotation_method: Semi-manual annotation using nnInteractive
+    annotation_method: Semi-manual annotation using nnInteractive + Threshold at 0.5
     method_links:
       - link_type: source_code
         link: https://github.com/MIC-DKFZ/nnInteractive
@@ -254,7 +254,7 @@ annotations:
 ############################ START Bacteria inclusion SABER ############################
 - metadata:
     annotation_ingest_id: inclusion-body-1
-    annotation_method: Prediction using SABER
+    annotation_method: Prediction using SABER + Threshold at 0.5
     method_links: *method_links
     annotation_object:
       id: GO:0016234
@@ -272,7 +272,9 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_(granules|inclusion)-multilabel.zarr'
+      glob_strings:
+        - '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_granules-multilabel.zarr'
+        - '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_inclusion-multilabel.zarr'
       is_visualization_default: false
       threshold: 0.5
     parent_filters:
@@ -300,7 +302,7 @@ annotations:
 
 - metadata:
     annotation_ingest_id: inclusion-body-2
-    annotation_method: Prediction using SABER
+    annotation_method: Prediction using SABER + Threshold at 0.5
     method_links: *method_links
     annotation_object:
       id: GO:0016234
@@ -358,7 +360,9 @@ annotations:
   sources:
   - InstanceSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_(granules|inclusion)-multilabel.zarr'
+      glob_strings:
+        - '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_granules-multilabel.zarr'
+        - '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_inclusion-multilabel.zarr'
       is_visualization_default: true
     parent_filters:
       include:
@@ -376,7 +380,7 @@ annotations:
 
 - metadata:
     annotation_ingest_id: inclusion-body-4
-    annotation_method: Semi-manual annotation using nnInteractive
+    annotation_method: Semi-manual annotation using nnInteractive + Threshold at 0.5
     method_links:
       - link_type: source_code
         link: https://github.com/MIC-DKFZ/nnInteractive
@@ -444,7 +448,7 @@ annotations:
 ############################ START Minicell cell body SABER ############################
 - metadata:
     annotation_ingest_id: intracellular-anatomical-structure-3
-    annotation_method: Prediction using SABER
+    annotation_method: Prediction using SABER + Threshold at 0.5
     method_links: *method_links
     annotation_object:
       id: GO:0005622
@@ -469,18 +473,18 @@ annotations:
     parent_filters:
       include:
         dataset:
-        - '10442'
-        - '10452'
-  - InstanceSegmentation:
-      binning: 5.006
-      file_format: copick
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_minicell.json'
-      is_visualization_default: false
-      order: xyz
-    parent_filters:
-      include:
-        dataset:
-        - '10442'
+          - '10452'
+        #- '10442'
+#  - InstanceSegmentation:
+#      binning: 5.006
+#      file_format: copick
+#      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_minicell.json'
+#      is_visualization_default: false
+#      order: xyz
+#    parent_filters:
+#      include:
+#        dataset:
+#        - '10442'
 
 - metadata:
     annotation_ingest_id: intracellular-anatomical-structure-5
@@ -508,15 +512,16 @@ annotations:
     parent_filters:
       include:
         dataset:
-        - '10442'
-        - '10452'
+          - '10452'
+        #- '10442'
+
 ############################ END Minicell cell body SABER ############################
 
 
 ############################ BEGIN VLP SABER ############################
 - metadata:
     annotation_ingest_id: virus-like-particle-1
-    annotation_method: Prediction using SABER
+    annotation_method: Prediction using SABER + Threshold at 0.5
     method_links: *method_links
     annotation_object:
       id: GO:0170047
@@ -575,7 +580,7 @@ annotations:
 ############################ BEGIN Microsporidia nuclear envelope SABER ############################
 - metadata:
     annotation_ingest_id: nuclear-envelope-1
-    annotation_method: Prediction using SABER
+    annotation_method: Prediction using SABER + Threshold at 0.5
     method_links: *method_links
     annotation_object:
       id: GO:0005635
@@ -633,7 +638,7 @@ annotations:
 ############################ BEGIN Microsporidia polar tube SABER ############################
 - metadata:
     annotation_ingest_id: polar-tube-1
-    annotation_method: Prediction using SABER
+    annotation_method: Prediction using SABER + Threshold at 0.5
     method_links: *method_links
     annotation_object:
       id: GO:0044099
@@ -692,7 +697,7 @@ annotations:
 ############################ BEGIN Microsporidia spore SABER ############################
 - metadata:
     annotation_ingest_id: intracellular-anatomical-structure-6
-    annotation_method: Prediction using SABER
+    annotation_method: Prediction using SABER + Threshold at 0.5
     method_links: *method_links
     annotation_object:
       id: GO:0005622

--- a/ingestion_tools/dataset_configs/deposition_10331.yaml
+++ b/ingestion_tools/dataset_configs/deposition_10331.yaml
@@ -5,17 +5,71 @@ alignments:
       match_regex: .*
       name_regex: (.*)
 annotations:
+
+############################ BEGIN Bacteria cell body SABER ############################
 - metadata:
     annotation_ingest_id: intracellular-anatomical-structure-1
     annotation_method: Prediction using SABER
+    method_links: &method_links
+      - link_type: source_code
+        link: https://github.com/chanzuckerberg/saber
+        custom_name: SABER on GitHub
+      - link_type: documentation
+        link: https://chanzuckerberg.github.io/saber/
+        custom_name: SABER documentation
     annotation_object:
       id: GO:0005622
       name: intracellular anatomical structure
     annotation_software: SABER
-    authors:
-    - corresponding_author_status: true
-      name: Anonymous Author
-      primary_author_status: true
+    authors: &authors
+      - ORCID: 0000-0002-8063-6951
+        corresponding_author_status: false
+        name: Jonathan Schwartz
+        primary_author_status: true
+      - ORCID: 0000-0003-4685-037X
+        corresponding_author_status: false
+        name: Utz Ermel
+        primary_author_status: false
+      - ORCID: 0000-0002-7324-2559
+        corresponding_author_status: false
+        name: Saugat Kandel
+        primary_author_status: false
+      - ORCID: 0009-0002-6674-7601
+        corresponding_author_status: false
+        name: Hannah Siems
+        primary_author_status: false
+      - ORCID: 0000-0001-8560-7407
+        corresponding_author_status: false
+        name: Julia Peukes
+        primary_author_status: false
+      - ORCID: 0000-0002-0936-114X
+        corresponding_author_status: false
+        name: Ruiming Cao
+        primary_author_status: false
+      - ORCID: 0000-0001-9517-3075
+        corresponding_author_status: false
+        name: Shawn Zheng
+        primary_author_status: false
+      - ORCID: 0000-0002-6551-2432
+        corresponding_author_status: false
+        name: Jose Miguel Andrade Lopez
+        primary_author_status: false
+      - ORCID: 0000-0002-2666-0758
+        corresponding_author_status: false
+        name: Casper C. Hoogenraad
+        primary_author_status: false
+      - ORCID: 0000-0003-0758-4654
+        corresponding_author_status: false
+        name: Shu-Hsien Sheu
+        primary_author_status: false
+      - ORCID: 0000-0001-9010-7298
+        corresponding_author_status: false
+        name: Daniel Serwas
+        primary_author_status: false
+      - ORCID: 0000-0002-2662-6373
+        corresponding_author_status: true
+        name: Dari Kimanius
+        primary_author_status: false
     dates:
       deposition_date: '2025-05-22'
       last_modified_date: '2025-05-22'
@@ -27,36 +81,41 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/15.600_SABER_1_bacteria-multilabel.zarr'
-      is_visualization_default: true
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_bacteria-multilabel.zarr'
+      is_visualization_default: false
       threshold: 0.5
     parent_filters:
       include:
         dataset:
-        - '10062'
-        - '10064'
+          - '10062'
+          - '10063'
+          - '10064'
+          - '10076'
+          - '10079'
+          - '10082'
+          - '10083'
+          - '10085'
   - InstanceSegmentation:
       binning: 15.6
       file_format: copick
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_bacteria.json'
-      is_visualization_default: true
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_bacteria.json'
+      is_visualization_default: false
       order: xyz
     parent_filters:
       include:
         dataset:
-        - '10062'
-        - '10064'
+          - '10062'
+          - '10064'
+
 - metadata:
     annotation_ingest_id: intracellular-anatomical-structure-2
     annotation_method: Prediction using SABER
+    method_links: *method_links
     annotation_object:
       id: GO:0005622
       name: intracellular anatomical structure
     annotation_software: SABER
-    authors:
-    - corresponding_author_status: true
-      name: Anonymous Author
-      primary_author_status: true
+    authors: *authors
     dates:
       deposition_date: '2025-05-22'
       last_modified_date: '2025-05-22'
@@ -66,38 +125,142 @@ annotations:
     method_type: automated
     version: 1.0
   sources:
-  - SemanticSegmentationMask:
-      file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/16.800_SABER_1_bacteria-multilabel.zarr'
-      is_visualization_default: true
-      threshold: 0.5
-    parent_filters:
-      include:
-        dataset:
-        - '10077'
-        - '10084'
-  - InstanceSegmentation:
-      binning: 16.8
-      file_format: copick
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_bacteria.json'
-      is_visualization_default: true
-      order: xyz
-    parent_filters:
-      include:
-        dataset:
-        - '10077'
-        - '10084'
+    - SemanticSegmentationMask:
+        file_format: zarr
+        glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/16.800_SABER_1_bacteria-multilabel.zarr'
+        is_visualization_default: false
+        threshold: 0.5
+      parent_filters:
+        include:
+          dataset:
+            - '10077'
+            - '10084'
+    - InstanceSegmentation:
+        binning: 16.8
+        file_format: copick
+        glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_bacteria.json'
+        is_visualization_default: false
+        order: xyz
+      parent_filters:
+        include:
+          dataset:
+            - '10077'
+            - '10084'
+
+- metadata:
+    annotation_ingest_id: intracellular-anatomical-structure-4
+    annotation_method: Prediction using SABER
+    method_links: *method_links
+    annotation_object:
+      id: GO:0005622
+      name: intracellular anatomical structure
+    annotation_software: SABER
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: false
+    is_curator_recommended: true
+    method_type: automated
+    version: 1.0
+  sources:
+    - InstanceSegmentationMask:
+        file_format: zarr
+        glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_SABER_1_bacteria-multilabel.zarr'
+        is_visualization_default: true
+      parent_filters:
+        include:
+          dataset:
+            - '10062'
+            - '10063'
+            - '10064'
+            - '10076'
+            - '10077'
+            - '10079'
+            - '10082'
+            - '10083'
+            - '10084'
+            - '10085'
+
+- metadata:
+    annotation_ingest_id: intracellular-anatomical-structure-8
+    annotation_method: Semi-manual annotation using nnInteractive
+    method_links:
+      - link_type: source_code
+        link: https://github.com/MIC-DKFZ/nnInteractive
+        custom_name: nnInteractive on GitHub
+    annotation_object:
+      id: GO:0005622
+      name: intracellular anatomical structure
+    annotation_software: nnInteractive
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: true
+    is_curator_recommended: true
+    method_type: hybrid
+    version: 1.0
+  sources:
+    - SemanticSegmentationMask:
+        file_format: zarr
+        glob_string: '20250522_sam2/{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_whole-cell-multilabel.zarr'
+        is_visualization_default: false
+        threshold: 0.5
+      parent_filters:
+        include:
+          dataset:
+            - '10062'
+            - '10064'
+            - '10077'
+
+- metadata:
+    annotation_ingest_id: intracellular-anatomical-structure-9
+    annotation_method: Semi-manual annotation using nnInteractive
+    method_links:
+      - link_type: source_code
+        link: https://github.com/MIC-DKFZ/nnInteractive
+        custom_name: nnInteractive on GitHub
+    annotation_object:
+      id: GO:0005622
+      name: intracellular anatomical structure
+    annotation_software: nnInteractive
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: true
+    is_curator_recommended: true
+    method_type: hybrid
+    version: 1.0
+  sources:
+    - InstanceSegmentationMask:
+        file_format: zarr
+        glob_string: '20250522_sam2/{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_whole-cell-multilabel.zarr'
+        is_visualization_default: true
+      parent_filters:
+        include:
+          dataset:
+            - '10062'
+            - '10064'
+            - '10077'
+
+############################ END Bacteria cell body SABER ############################
+
+
+############################ START Bacteria inclusion SABER ############################
 - metadata:
     annotation_ingest_id: inclusion-body-1
     annotation_method: Prediction using SABER
+    method_links: *method_links
     annotation_object:
       id: GO:0016234
       name: inclusion body
     annotation_software: SABER
-    authors:
-    - corresponding_author_status: true
-      name: Anonymous Author
-      primary_author_status: true
+    authors: *authors
     dates:
       deposition_date: '2025-05-22'
       last_modified_date: '2025-05-22'
@@ -109,36 +272,41 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/15.600_SABER_1_granules-multilabel.zarr'
-      is_visualization_default: true
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_(granules|inclusion)-multilabel.zarr'
+      is_visualization_default: false
       threshold: 0.5
     parent_filters:
       include:
         dataset:
-        - '10062'
-        - '10064'
+          - '10062'
+          - '10063'
+          - '10064'
+          - '10076'
+          - '10079'
+          - '10082'
+          - '10083'
+          - '10085'
   - InstanceSegmentation:
       binning: 15.6
       file_format: copick
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_granules.json'
-      is_visualization_default: true
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_granules.json'
+      is_visualization_default: false
       order: xyz
     parent_filters:
       include:
         dataset:
-        - '10062'
-        - '10064'
+          - '10062'
+          - '10064'
+
 - metadata:
     annotation_ingest_id: inclusion-body-2
     annotation_method: Prediction using SABER
+    method_links: *method_links
     annotation_object:
       id: GO:0016234
       name: inclusion body
     annotation_software: SABER
-    authors:
-    - corresponding_author_status: true
-      name: Anonymous Author
-      primary_author_status: true
+    authors: *authors
     dates:
       deposition_date: '2025-05-22'
       last_modified_date: '2025-05-22'
@@ -150,8 +318,8 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/16.800_SABER_1_granules-multilabel.zarr'
-      is_visualization_default: true
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/16.800_SABER_1_granules-multilabel.zarr'
+      is_visualization_default: false
       threshold: 0.5
     parent_filters:
       include:
@@ -161,25 +329,128 @@ annotations:
   - InstanceSegmentation:
       binning: 16.8
       file_format: copick
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_granules.json'
-      is_visualization_default: true
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_granules.json'
+      is_visualization_default: false
       order: xyz
     parent_filters:
       include:
         dataset:
         - '10077'
         - '10084'
+
+- metadata:
+    annotation_ingest_id: inclusion-body-3
+    annotation_method: Prediction using SABER
+    method_links: *method_links
+    annotation_object:
+      id: GO:0016234
+      name: inclusion body
+    annotation_software: SABER
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: false
+    is_curator_recommended: true
+    method_type: automated
+    version: 1.0
+  sources:
+  - InstanceSegmentationMask:
+      file_format: zarr
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_(granules|inclusion)-multilabel.zarr'
+      is_visualization_default: true
+    parent_filters:
+      include:
+        dataset:
+          - '10062'
+          - '10063'
+          - '10064'
+          - '10076'
+          - '10077'
+          - '10079'
+          - '10082'
+          - '10083'
+          - '10084'
+          - '10085'
+
+- metadata:
+    annotation_ingest_id: inclusion-body-4
+    annotation_method: Semi-manual annotation using nnInteractive
+    method_links:
+      - link_type: source_code
+        link: https://github.com/MIC-DKFZ/nnInteractive
+        custom_name: nnInteractive on GitHub
+    annotation_object:
+      id: GO:0016234
+      name: inclusion body
+    annotation_software: SABER
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: true
+    is_curator_recommended: true
+    method_type: hybrid
+    version: 1.0
+  sources:
+    - SemanticSegmentationMask:
+        file_format: zarr
+        glob_string: '20250522_sam2/{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_inclusion-multilabel.zarr'
+        is_visualization_default: false
+        threshold: 0.5
+      parent_filters:
+        include:
+          dataset:
+            - '10062'
+            - '10064'
+            - '10077'
+
+- metadata:
+    annotation_ingest_id: inclusion-body-5
+    annotation_method: Semi-manual annotation using nnInteractive
+    method_links:
+      - link_type: source_code
+        link: https://github.com/MIC-DKFZ/nnInteractive
+        custom_name: nnInteractive on GitHub
+    annotation_object:
+      id: GO:0016234
+      name: inclusion body
+    annotation_software: SABER
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: true
+    is_curator_recommended: true
+    method_type: hybrid
+    version: 1.0
+  sources:
+    - SemanticSegmentationMask:
+        file_format: zarr
+        glob_string: '20250522_sam2/{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_inclusion-multilabel.zarr'
+        is_visualization_default: true
+        threshold: 0.5
+      parent_filters:
+        include:
+          dataset:
+            - '10062'
+            - '10064'
+            - '10077'
+############################ END Bacteria inclusion SABER ############################
+
+############################ START Minicell cell body SABER ############################
 - metadata:
     annotation_ingest_id: intracellular-anatomical-structure-3
     annotation_method: Prediction using SABER
+    method_links: *method_links
     annotation_object:
       id: GO:0005622
       name: intracellular anatomical structure
     annotation_software: SABER
-    authors:
-    - corresponding_author_status: true
-      name: Anonymous Author
-      primary_author_status: true
+    authors: *authors
     dates:
       deposition_date: '2025-05-22'
       last_modified_date: '2025-05-22'
@@ -191,35 +462,67 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/10.000_SABER_1_minicell-multilabel.zarr'
-      is_visualization_default: true
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_minicell*-multilabel.zarr'
+      is_visualization_default: false
       rescale: true
       threshold: 0.5
     parent_filters:
       include:
         dataset:
         - '10442'
+        - '10452'
   - InstanceSegmentation:
       binning: 5.006
       file_format: copick
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_minicell.json'
-      is_visualization_default: true
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_minicell.json'
+      is_visualization_default: false
       order: xyz
     parent_filters:
       include:
         dataset:
         - '10442'
+
 - metadata:
-    annotation_ingest_id: lysosome-1
+    annotation_ingest_id: intracellular-anatomical-structure-5
     annotation_method: Prediction using SABER
+    method_links: *method_links
     annotation_object:
-      id: GO:0005764
-      name: lysosome
+      id: GO:0005622
+      name: intracellular anatomical structure
     annotation_software: SABER
-    authors:
-    - corresponding_author_status: true
-      name: Anonymous Author
-      primary_author_status: true
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: false
+    is_curator_recommended: true
+    method_type: automated
+    version: 1.0
+  sources:
+  - InstanceSegmentationMask:
+      file_format: zarr
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_minicell*-multilabel.zarr'
+      is_visualization_default: true
+      rescale: true
+    parent_filters:
+      include:
+        dataset:
+        - '10442'
+        - '10452'
+############################ END Minicell cell body SABER ############################
+
+
+############################ BEGIN VLP SABER ############################
+- metadata:
+    annotation_ingest_id: virus-like-particle-1
+    annotation_method: Prediction using SABER
+    method_links: *method_links
+    annotation_object:
+      id: GO:0170047
+      name: virus-like particle
+    annotation_software: SABER
+    authors: *authors
     dates:
       deposition_date: '2025-05-22'
       last_modified_date: '2025-05-22'
@@ -231,18 +534,233 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/10.000_SABER_2_lysosome-multilabel.zarr'
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_saber_1_virus-multilabel.zarr'
       is_visualization_default: true
       rescale: true
       threshold: 0.5
     parent_filters:
       include:
         dataset:
-        - '10444'
+        - '10006'
+
+- metadata:
+    annotation_ingest_id: virus-like-particle-2
+    annotation_method: Prediction using SABER
+    method_links: *method_links
+    annotation_object:
+      id: GO:0170047
+      name: virus-like particle
+    annotation_software: SABER
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: false
+    is_curator_recommended: true
+    method_type: automated
+    version: 1.0
+  sources:
+  - InstanceSegmentationMask:
+      file_format: zarr
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_saber_1_virus-multilabel.zarr'
+      is_visualization_default: true
+      rescale: true
+    parent_filters:
+      include:
+        dataset:
+        - '10006'
+############################ END VLP SABER ############################
+
+############################ BEGIN Microsporidia nuclear envelope SABER ############################
+- metadata:
+    annotation_ingest_id: nuclear-envelope-1
+    annotation_method: Prediction using SABER
+    method_links: *method_links
+    annotation_object:
+      id: GO:0005635
+      name: nuclear envelope
+    annotation_software: SABER
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: false
+    is_curator_recommended: true
+    method_type: automated
+    version: 1.0
+  sources:
+  - SemanticSegmentationMask:
+      file_format: zarr
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_nuclear-envelope-multilabel.zarr'
+      is_visualization_default: false
+      rescale: true
+      threshold: 0.5
+    parent_filters:
+      include:
+        dataset:
+        - '10437'
+- metadata:
+    annotation_ingest_id: nuclear-envelope-2
+    annotation_method: Prediction using SABER
+    method_links: *method_links
+    annotation_object:
+      id: GO:0005635
+      name: nuclear envelope
+    annotation_software: SABER
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: false
+    is_curator_recommended: true
+    method_type: automated
+    version: 1.0
+  sources:
+  - InstanceSegmentationMask:
+      file_format: zarr
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_nuclear-envelope-multilabel.zarr'
+      is_visualization_default: true
+      rescale: true
+    parent_filters:
+      include:
+        dataset:
+        - '10437'
+############################ END Microsporidia nuclear envelope SABER ############################
+
+############################ BEGIN Microsporidia polar tube SABER ############################
+- metadata:
+    annotation_ingest_id: polar-tube-1
+    annotation_method: Prediction using SABER
+    method_links: *method_links
+    annotation_object:
+      id: GO:0044099
+      name: polar tube
+    annotation_software: SABER
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: false
+    is_curator_recommended: true
+    method_type: automated
+    version: 1.0
+  sources:
+  - SemanticSegmentationMask:
+      file_format: zarr
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_polar-tube-multilabel.zarr'
+      is_visualization_default: false
+      threshold: 0.5
+      rescale: true
+    parent_filters:
+      include:
+        dataset:
+        - '10437'
+
+- metadata:
+    annotation_ingest_id: polar-tube-2
+    annotation_method: Prediction using SABER
+    method_links: *method_links
+    annotation_object:
+      id: GO:0044099
+      name: polar tube
+    annotation_software: SABER
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: false
+    is_curator_recommended: true
+    method_type: automated
+    version: 1.0
+  sources:
+  - InstanceSegmentationMask:
+      file_format: zarr
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_polar-tube-multilabel.zarr'
+      is_visualization_default: true
+      rescale: true
+    parent_filters:
+      include:
+        dataset:
+        - '10437'
+############################ END Microsporidia polar tube SABER ############################
+
+############################ BEGIN Microsporidia spore SABER ############################
+- metadata:
+    annotation_ingest_id: intracellular-anatomical-structure-6
+    annotation_method: Prediction using SABER
+    method_links: *method_links
+    annotation_object:
+      id: GO:0005622
+      name: intracellular anatomical structure
+    annotation_software: SABER
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: false
+    is_curator_recommended: true
+    method_type: automated
+    version: 1.0
+  sources:
+  - SemanticSegmentationMask:
+      file_format: zarr
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_spores-multilabel.zarr'
+      is_visualization_default: false
+      rescale: true
+      threshold: 0.5
+    parent_filters:
+      include:
+        dataset:
+        - '10437'
+
+- metadata:
+    annotation_ingest_id: intracellular-anatomical-structure-7
+    annotation_method: Prediction using SABER
+    method_links: *method_links
+    annotation_object:
+      id: GO:0005622
+      name: intracellular anatomical structure
+    annotation_software: SABER
+    authors: *authors
+    dates:
+      deposition_date: '2025-05-22'
+      last_modified_date: '2025-05-22'
+      release_date: '2025-05-22'
+    ground_truth_status: false
+    is_curator_recommended: true
+    method_type: automated
+    version: 1.0
+  sources:
+  - InstanceSegmentationMask:
+      file_format: zarr
+      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_spores-multilabel.zarr'
+      is_visualization_default: true
+      rescale: true
+    parent_filters:
+      include:
+        dataset:
+        - '10437'
+############################ END Microsporidia spore SABER ############################
+
+
 datasets:
 - sources:
   - source_glob:
-      list_glob: 10???
+      list_glob: '20250522_sam2/10???'
+      match_regex: .*
+      name_regex: (.*)
+  - source_glob:
+      list_glob: '20260306_SABER_paper/10???'
+      match_regex: .*
+      name_regex: (.*)
+  - source_glob:
+      list_glob: '20260306_SABER_paper/10???'
       match_regex: .*
       name_regex: (.*)
 deposition_keyphotos:
@@ -254,9 +772,54 @@ deposition_keyphotos:
 depositions:
 - metadata:
     authors:
-    - corresponding_author_status: true
-      name: Anonymous Author
+    - ORCID: 0000-0002-8063-6951
+      corresponding_author_status: false
+      name: Jonathan Schwartz
       primary_author_status: true
+    - ORCID: 0000-0003-4685-037X
+      corresponding_author_status: false
+      name: Utz Ermel
+      primary_author_status: false
+    - ORCID: 0000-0002-7324-2559
+      corresponding_author_status: false
+      name: Saugat Kandel
+      primary_author_status: false
+    - ORCID: 0009-0002-6674-7601
+      corresponding_author_status: false
+      name: Hannah Siems
+      primary_author_status: false
+    - ORCID: 0000-0001-8560-7407
+      corresponding_author_status: false
+      name: Julia Peukes
+      primary_author_status: false
+    - ORCID: 0000-0002-0936-114X
+      corresponding_author_status: false
+      name: Ruiming Cao
+      primary_author_status: false
+    - ORCID: 0000-0001-9517-3075
+      corresponding_author_status: false
+      name: Shawn Zheng
+      primary_author_status: false
+    - ORCID: 0000-0002-6551-2432
+      corresponding_author_status: false
+      name: Jose Miguel Andrade Lopez
+      primary_author_status: false
+    - ORCID: 0000-0002-2666-0758
+      corresponding_author_status: false
+      name: Casper C. Hoogenraad
+      primary_author_status: false
+    - ORCID: 0000-0003-0758-4654
+      corresponding_author_status: false
+      name: Shu-Hsien Sheu
+      primary_author_status: false
+    - ORCID: 0000-0001-9010-7298
+      corresponding_author_status: false
+      name: Daniel Serwas
+      primary_author_status: false
+    - ORCID: 0000-0002-2662-6373
+      corresponding_author_status: true
+      name: Dari Kimanius
+      primary_author_status: false
     dates:
       deposition_date: '2025-05-22'
       last_modified_date: '2025-05-22'
@@ -280,12 +843,13 @@ depositions:
 runs:
 - sources:
   - source_glob:
-      list_glob: '{dataset_name}/overlay/ExperimentRuns/*'
+      list_glob: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/*'
       match_regex: .*
       name_regex: (.*)
+
 standardization_config:
   deposition_id: 10331
-  source_prefix: CZII/20250522_sam2/
+  source_prefix: CZII/
 version: 1.3.0
 voxel_spacings:
 - sources:

--- a/ingestion_tools/dataset_configs/deposition_10331.yaml
+++ b/ingestion_tools/dataset_configs/deposition_10331.yaml
@@ -81,7 +81,7 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_bacteria-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_bacteria-multilabel.zarr'
       is_visualization_default: false
       threshold: 0.5
     parent_filters:
@@ -167,7 +167,7 @@ annotations:
   sources:
     - InstanceSegmentationMask:
         file_format: zarr
-        glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_bacteria-multilabel.zarr'
+        glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_bacteria-multilabel.zarr'
         is_visualization_default: true
       parent_filters:
         include:
@@ -272,7 +272,7 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_(granules|inclusion)-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_(granules|inclusion)-multilabel.zarr'
       is_visualization_default: false
       threshold: 0.5
     parent_filters:
@@ -358,7 +358,7 @@ annotations:
   sources:
   - InstanceSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_(granules|inclusion)-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_(granules|inclusion)-multilabel.zarr'
       is_visualization_default: true
     parent_filters:
       include:
@@ -462,7 +462,7 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_minicell*-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_minicell*-multilabel.zarr'
       is_visualization_default: false
       rescale: true
       threshold: 0.5
@@ -502,7 +502,7 @@ annotations:
   sources:
   - InstanceSegmentationMask:
       file_format: zarr
-      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_minicell*-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_[Ss][Aa][Bb][Ee][Rr]_1_minicell*-multilabel.zarr'
       is_visualization_default: true
       rescale: true
     parent_filters:

--- a/ingestion_tools/dataset_configs/deposition_10331.yaml
+++ b/ingestion_tools/dataset_configs/deposition_10331.yaml
@@ -81,7 +81,7 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_bacteria-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_bacteria-multilabel.zarr'
       is_visualization_default: false
       threshold: 0.5
     parent_filters:
@@ -98,7 +98,7 @@ annotations:
   - InstanceSegmentation:
       binning: 15.6
       file_format: copick
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_bacteria.json'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_bacteria.json'
       is_visualization_default: false
       order: xyz
     parent_filters:
@@ -127,7 +127,7 @@ annotations:
   sources:
     - SemanticSegmentationMask:
         file_format: zarr
-        glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/16.800_SABER_1_bacteria-multilabel.zarr'
+        glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/16.800_SABER_1_bacteria-multilabel.zarr'
         is_visualization_default: false
         threshold: 0.5
       parent_filters:
@@ -138,7 +138,7 @@ annotations:
     - InstanceSegmentation:
         binning: 16.8
         file_format: copick
-        glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_bacteria.json'
+        glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_bacteria.json'
         is_visualization_default: false
         order: xyz
       parent_filters:
@@ -167,7 +167,7 @@ annotations:
   sources:
     - InstanceSegmentationMask:
         file_format: zarr
-        glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_SABER_1_bacteria-multilabel.zarr'
+        glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_bacteria-multilabel.zarr'
         is_visualization_default: true
       parent_filters:
         include:
@@ -206,7 +206,7 @@ annotations:
   sources:
     - SemanticSegmentationMask:
         file_format: zarr
-        glob_string: '20250522_sam2/{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_whole-cell-multilabel.zarr'
+        glob_string: '{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_whole-cell-multilabel.zarr'
         is_visualization_default: false
         threshold: 0.5
       parent_filters:
@@ -239,7 +239,7 @@ annotations:
   sources:
     - InstanceSegmentationMask:
         file_format: zarr
-        glob_string: '20250522_sam2/{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_whole-cell-multilabel.zarr'
+        glob_string: '{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_whole-cell-multilabel.zarr'
         is_visualization_default: true
       parent_filters:
         include:
@@ -272,7 +272,7 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_(granules|inclusion)-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_(granules|inclusion)-multilabel.zarr'
       is_visualization_default: false
       threshold: 0.5
     parent_filters:
@@ -289,7 +289,7 @@ annotations:
   - InstanceSegmentation:
       binning: 15.6
       file_format: copick
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_granules.json'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_granules.json'
       is_visualization_default: false
       order: xyz
     parent_filters:
@@ -318,7 +318,7 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/16.800_SABER_1_granules-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/16.800_SABER_1_granules-multilabel.zarr'
       is_visualization_default: false
       threshold: 0.5
     parent_filters:
@@ -329,7 +329,7 @@ annotations:
   - InstanceSegmentation:
       binning: 16.8
       file_format: copick
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_granules.json'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_granules.json'
       is_visualization_default: false
       order: xyz
     parent_filters:
@@ -358,7 +358,7 @@ annotations:
   sources:
   - InstanceSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_(granules|inclusion)-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_(granules|inclusion)-multilabel.zarr'
       is_visualization_default: true
     parent_filters:
       include:
@@ -397,7 +397,7 @@ annotations:
   sources:
     - SemanticSegmentationMask:
         file_format: zarr
-        glob_string: '20250522_sam2/{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_inclusion-multilabel.zarr'
+        glob_string: '{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_inclusion-multilabel.zarr'
         is_visualization_default: false
         threshold: 0.5
       parent_filters:
@@ -430,7 +430,7 @@ annotations:
   sources:
     - SemanticSegmentationMask:
         file_format: zarr
-        glob_string: '20250522_sam2/{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_inclusion-multilabel.zarr'
+        glob_string: '{dataset_name}/overlay_gt/ExperimentRuns/{run_name}/Segmentations/*_nnInteractive_0_inclusion-multilabel.zarr'
         is_visualization_default: true
         threshold: 0.5
       parent_filters:
@@ -462,7 +462,7 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_minicell*-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_minicell*-multilabel.zarr'
       is_visualization_default: false
       rescale: true
       threshold: 0.5
@@ -474,7 +474,7 @@ annotations:
   - InstanceSegmentation:
       binning: 5.006
       file_format: copick
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_minicell.json'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_minicell.json'
       is_visualization_default: false
       order: xyz
     parent_filters:
@@ -502,7 +502,7 @@ annotations:
   sources:
   - InstanceSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_minicell*-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_(SABER|saber)_1_minicell*-multilabel.zarr'
       is_visualization_default: true
       rescale: true
     parent_filters:
@@ -534,7 +534,7 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_saber_1_virus-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_saber_1_virus-multilabel.zarr'
       is_visualization_default: true
       rescale: true
       threshold: 0.5
@@ -563,7 +563,7 @@ annotations:
   sources:
   - InstanceSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_saber_1_virus-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_saber_1_virus-multilabel.zarr'
       is_visualization_default: true
       rescale: true
     parent_filters:
@@ -593,7 +593,7 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_nuclear-envelope-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_nuclear-envelope-multilabel.zarr'
       is_visualization_default: false
       rescale: true
       threshold: 0.5
@@ -621,7 +621,7 @@ annotations:
   sources:
   - InstanceSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_nuclear-envelope-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_nuclear-envelope-multilabel.zarr'
       is_visualization_default: true
       rescale: true
     parent_filters:
@@ -651,7 +651,7 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_polar-tube-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_polar-tube-multilabel.zarr'
       is_visualization_default: false
       threshold: 0.5
       rescale: true
@@ -680,7 +680,7 @@ annotations:
   sources:
   - InstanceSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_polar-tube-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_polar-tube-multilabel.zarr'
       is_visualization_default: true
       rescale: true
     parent_filters:
@@ -710,7 +710,7 @@ annotations:
   sources:
   - SemanticSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_spores-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_spores-multilabel.zarr'
       is_visualization_default: false
       rescale: true
       threshold: 0.5
@@ -739,7 +739,7 @@ annotations:
   sources:
   - InstanceSegmentationMask:
       file_format: zarr
-      glob_string: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_spores-multilabel.zarr'
+      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/13.720_saber_1_spores-multilabel.zarr'
       is_visualization_default: true
       rescale: true
     parent_filters:
@@ -752,15 +752,7 @@ annotations:
 datasets:
 - sources:
   - source_glob:
-      list_glob: '20250522_sam2/10???'
-      match_regex: .*
-      name_regex: (.*)
-  - source_glob:
-      list_glob: '20260306_SABER_paper/10???'
-      match_regex: .*
-      name_regex: (.*)
-  - source_glob:
-      list_glob: '20260306_SABER_paper/10???'
+      list_glob: '10???'
       match_regex: .*
       name_regex: (.*)
 deposition_keyphotos:
@@ -843,13 +835,13 @@ depositions:
 runs:
 - sources:
   - source_glob:
-      list_glob: '20250522_sam2/{dataset_name}/overlay/ExperimentRuns/*'
+      list_glob: '{dataset_name}/overlay/ExperimentRuns/*'
       match_regex: .*
       name_regex: (.*)
 
 standardization_config:
   deposition_id: 10331
-  source_prefix: CZII/
+  source_prefix: CZII/20250522_sam2/
 version: 1.3.0
 voxel_spacings:
 - sources:

--- a/ingestion_tools/dataset_configs/deposition_10331.yaml
+++ b/ingestion_tools/dataset_configs/deposition_10331.yaml
@@ -388,7 +388,7 @@ annotations:
     annotation_object:
       id: GO:0016234
       name: inclusion body
-    annotation_software: SABER
+    annotation_software: nnInteractive
     authors: *authors
     dates:
       deposition_date: '2025-05-22'
@@ -421,7 +421,7 @@ annotations:
     annotation_object:
       id: GO:0016234
       name: inclusion body
-    annotation_software: SABER
+    annotation_software: nnInteractive
     authors: *authors
     dates:
       deposition_date: '2025-05-22'
@@ -474,17 +474,6 @@ annotations:
       include:
         dataset:
           - '10452'
-        #- '10442'
-#  - InstanceSegmentation:
-#      binning: 5.006
-#      file_format: copick
-#      glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Picks/SABER_1_minicell.json'
-#      is_visualization_default: false
-#      order: xyz
-#    parent_filters:
-#      include:
-#        dataset:
-#        - '10442'
 
 - metadata:
     annotation_ingest_id: intracellular-anatomical-structure-5
@@ -540,7 +529,7 @@ annotations:
   - SemanticSegmentationMask:
       file_format: zarr
       glob_string: '{dataset_name}/overlay/ExperimentRuns/{run_name}/Segmentations/*_saber_1_virus-multilabel.zarr'
-      is_visualization_default: true
+      is_visualization_default: false
       rescale: true
       threshold: 0.5
     parent_filters:
@@ -825,9 +814,7 @@ depositions:
       lysosomes and components of bacterial cells. The segmentations were generated
       using the SABER package, which is a SAM2-based segmentation framework that uses
       an expert-in-the-loop approach to refine segmentations based on the embedding
-      space of SAM2. Segmentations are provided as semantic masks, with a point at
-      the center of mask indicating object instances. Authors are redacted pending
-      peer review process.
+      space of SAM2. Segmentations are provided as semantic masks and instance segmentation masks.
     deposition_identifier: 10331
     deposition_title: Expert-in-the-loop guided automatic segmentations of cells and
       cellular structures using SABER


### PR DESCRIPTION
Updating SABER-depostion to: 

- include authors
- include now available instance segmentations
- include annotations for more datasets