### PR TITLE
feat: enable stale annotation cleanup during db import

### DIFF
--- a/apiv2/db_import/importers/annotation.py
+++ b/apiv2/db_import/importers/annotation.py
@@ -4,6 +4,7 @@ from typing import Any
 from database import models
 from db_import.common.finders import JsonDataFinder, MetadataFileFinder
 from db_import.importers.base import IntegratedDBImporter, ItemDBImporter
+from db_import.importers.base_importer import StaleParentDeletionDBImporter
 
 
 class AnnotationItem(ItemDBImporter):
@@ -90,10 +91,7 @@ class AnnotationFileItem(ItemDBImporter):
 class AnnotationImporter(IntegratedDBImporter):
     finder = MetadataFileFinder
     row_importer = AnnotationItem
-    # TODO This should ideally be True, but we've disabled it for the moment since
-    # we are only looking for annotations within a voxel spacing, however those
-    # annotations are only associated with runs.
-    clean_up_siblings = False
+    clean_up_siblings = True
 
     def __init__(self, config, run: models.Run, tomogram_voxel_spacing: models.TomogramVoxelSpacing, **unused_parents):
         self.run = run
@@ -102,7 +100,7 @@ class AnnotationImporter(IntegratedDBImporter):
         self.parents = {"run": run, "tomogram_voxel_spacing": tomogram_voxel_spacing}
 
     def get_filters(self) -> dict[str, Any]:
-        raise NotImplementedError("This method should not be called, since annotations don't support sibling cleanup")
+        return {"tomogram_voxel_spacing_id": self.tomogram_voxel_spacing.id}
 
     def get_finder_args(self) -> dict[str, Any]:
         return {
@@ -259,3 +257,13 @@ class AnnotationMethodLinkImporter(IntegratedDBImporter):
             "path": self.convert_to_finder_path(metadata_path),
             "list_key": ["method_links"],
         }
+
+
+class StaleAnnotationDeletionDBImporter(StaleParentDeletionDBImporter):
+    ref_klass = AnnotationItem
+
+    def get_filters(self) -> dict[str, Any]:
+        return {"tomogram_voxel_spacing_id": self.parent_id}
+
+    def children_tables_references(self) -> dict[str, None]:
+        return {}

--- a/apiv2/db_import/tests/populate_db.py
+++ b/apiv2/db_import/tests/populate_db.py
@@ -537,6 +537,7 @@ def populate_stale_annotations(session: sa.orm.Session) -> Annotation:
     return Annotation(
         id=STALE_ANNOTATION_ID,
         run_id=RUN1_ID,
+        tomogram_voxel_spacing_id=TOMOGRAM_VOXEL_ID1,
         annotation_ingest_id="100-bar-1.0",
         s3_metadata_path="foo",
         https_metadata_path="foo",

--- a/apiv2/db_import/tests/test_db_annotation_import.py
+++ b/apiv2/db_import/tests/test_db_annotation_import.py
@@ -196,8 +196,6 @@ def test_import_annotations(
     assert len(files) == len(expected_annotation_files)
 
 
-# Tests state annotation and files are removed
-@pytest.mark.skip(reason="Cleaning up stale annotations is currently disabled.")
 def test_import_annotations_files_removes_stale(
     sync_db_session: Session,
     verify_dataset_import: Callable[[list[str]], models.Dataset],
@@ -212,12 +210,15 @@ def test_import_annotations_files_removes_stale(
     expected_annotations_iter = iter(expected_annotations)
     expected_annotations_files_iter = iter(expected_annotation_files)
     actual_runs = sync_db_session.get(models.Run, RUN1_ID)
+    files = []
     for annotation in sorted(actual_runs.annotations, key=lambda x: x.s3_metadata_path):
         verify_model(annotation, next(expected_annotations_iter))
-        assert len(annotation.files) == len(expected_annotation_files)
-        for file in annotation.files.order_by(models.AnnotationFile.shape_type, models.AnnotationFile.format):
-            verify_model(file, next(expected_annotations_files_iter))
+        for shape in sorted(annotation.annotation_shapes, key=lambda x: x.shape_type):
+            files.extend(shape.annotation_files)
+            for file in sorted(shape.annotation_files, key=lambda x: x.format):
+                verify_model(file, next(expected_annotations_files_iter))
         assert len(annotation.authors) == 0
+    assert len(files) == len(expected_annotation_files)
 
 
 # Tests update of existing annotation authors, addition of new authors


### PR DESCRIPTION
### Summary

https://docs.google.com/document/d/12KE8VLn1f1KzRxg6b_nTtUFqtwS03rRv3fOPCx4_w5Y/edit?tab=t.0#heading=h.lzmbkndc353e

- Enable stale annotation cleanup by setting `clean_up_siblings = True` on `AnnotationImporter` and implementing `get_filters()` to scope cleanup by `tomogram_voxel_spacing_id`.
- Add `StaleAnnotationDeletionDBImporter` class (already referenced by `StaleVoxelSpacingDeletionDBImporter` but was missing).
- Fix and unskip `test_import_annotations_files_removes_stale` test, and update `populate_stale_annotations` fixture to include `tomogram_voxel_spacing_id`.

### Context
Previously, stale annotation cleanup was disabled because annotations were only associate with runs, but the importer searched for annotations within a voxel spacing. Now that `tomogram_voxel_spacing_id` has been added (#641), we can safely filter annotations by voxel spacing and clean up stale ones.
