### PR TITLE
feat: enable --import-viz-config on annotation-only depositions by re…

### DIFF
--- a/ingestion_tools/scripts/importers/utils.py
+++ b/ingestion_tools/scripts/importers/utils.py
@@ -60,9 +60,9 @@ IMPORTER_DEP_TREE = {
                         AnnotationVisualizationImporter: {},
                     },
                     TomogramImporter: {
-                        VisualizationConfigImporter: {},
                         KeyImageImporter: {},
                     },
+                    VisualizationConfigImporter: {},
                 },
             },
             DatasetKeyPhotoImporter: {},

--- a/ingestion_tools/scripts/importers/visualization_config.py
+++ b/ingestion_tools/scripts/importers/visualization_config.py
@@ -1,8 +1,8 @@
 import json
-import os.path
+import os
 from pathlib import Path
 from time import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Generator, cast
 
 import cryoet_data_portal_neuroglancer.state_generator as state_generator
 
@@ -36,10 +36,42 @@ class VisualizationConfigImporter(BaseImporter):
             print(f"Skipping import of {self.name}")
             return
 
-        tomogram = self.get_tomogram()
-        ng_contents = self._create_config(tomogram.alignment_metadata_path)
-        meta = NeuroglancerMetadata(self.config.fs, self.get_deposition().name, ng_contents)
-        meta.write_metadata(self.get_output_path())
+        for tomo in self._get_tomograms_from_disk():
+            self.parents["tomogram"] = tomo
+            try:
+                ng_contents = self._create_config(tomo.alignment_metadata_path)
+                meta = NeuroglancerMetadata(self.config.fs, self.get_deposition().name, ng_contents)
+                meta.write_metadata(self.get_output_path())
+            finally:
+                self.parents.pop("tomogram", None)
+
+    def _get_tomograms_from_disk(self) -> Generator["TomogramImporter", None, None]:
+        from importers.tomogram import TomogramImporter
+
+        voxel_spacing_path = self.config.resolve_output_path("voxel_spacing", self)
+        metadata_glob = os.path.join(voxel_spacing_path, "Tomograms", "*", "tomogram_metadata.json")
+
+        for metadata_file in self.config.fs.glob(metadata_glob):
+            with open(self.config.fs.localreadable(metadata_file), "r") as f:
+                tomo_metadata = json.load(f)
+
+            alignment_metadata_path = tomo_metadata.get("alignment_metadata_path")
+            if not alignment_metadata_path:
+                print(f"Skipping tomogram {metadata_file}: missing alignment_metadata_path")
+                continue
+
+            omezarr_dir = tomo_metadata.get("omezarr_dir", "")
+            tomo = TomogramImporter(
+                config=self.config,
+                metadata=tomo_metadata,
+                name=omezarr_dir,
+                path=os.path.join(self.config.output_prefix, omezarr_dir) if omezarr_dir else "",
+                allow_imports=False,
+                parents={k: v for k, v in self.parents.items() if k != "tomogram"},
+                alignment_metadata_path=alignment_metadata_path,
+            )
+            tomo.identifier = int(Path(metadata_file).parent.name)
+            yield tomo
 
     def _get_annotation_metadata_files(self) -> list[str]:
         # Getting a list of paths to the annotation metadata files using glob instead of using the annotation finder

--- a/ingestion_tools/scripts/tests/s3_import/test_visualization_config.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_visualization_config.py
@@ -26,6 +26,8 @@ def get_parents(config: DepositionImportConfig) -> dict[str, BaseImporter]:
 
     # creates the tomogram volume files required for the visualization config
     parents["tomogram"].import_item()
+    # writes tomogram_metadata.json to disk, required by _get_tomograms_from_disk()
+    parents["tomogram"].import_metadata()
 
     return parents
 
@@ -364,3 +366,79 @@ def test_viz_config_with_tomogram_and_annotation(
         args["name"] = args["name"].replace("orientedpoint", shape)
         args.pop("is_instance_segmentation", None)
         mock_state_generator.generate_oriented_point_mesh_layer.assert_called_once_with(**args)
+
+
+def test_viz_config_multiple_tomograms(
+    test_output_bucket: str,
+    s3_client: S3Client,
+    config: DepositionImportConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that a neuroglancer config is generated for each tomogram found on disk."""
+    parents = get_parents(config)
+    vs_path = get_vs_path(parents)
+
+    # Manually write a second tomogram_metadata.json under a different tomogram id
+    alignment_path = f"{parents['dataset'].name}/TS_run1/Alignments/100/alignment_metadata.json"
+    second_tomo_metadata = {
+        "alignment_metadata_path": alignment_path,
+        "omezarr_dir": "TS_run1_second.zarr",
+    }
+    second_metadata_key = os.path.join(vs_path, "Tomograms", "101", "tomogram_metadata.json")
+    s3_client.put_object(
+        Bucket=test_output_bucket,
+        Key=second_metadata_key,
+        Body=json.dumps(second_tomo_metadata).encode(),
+    )
+
+    # Patch _create_config so we don't need real zarr data for either tomogram
+    monkeypatch.setattr(
+        VisualizationConfigImporter,
+        "_create_config",
+        lambda self, alignment_metadata_path: {"key": "combine_json_layers", "foo": "bar"},
+    )
+
+    viz_config = list(VisualizationConfigImporter.finder(config, **parents))
+    for item in viz_config:
+        item.import_item()
+
+    precompute_dir = os.path.join(vs_path, "NeuroglancerPrecompute")
+    config_files = get_children(s3_client, test_output_bucket, precompute_dir)
+    assert "100-neuroglancer_config.json" in config_files, "Missing config for first tomogram"
+    assert "101-neuroglancer_config.json" in config_files, "Missing config for second tomogram"
+
+
+def test_viz_config_annotation_only_deposition(
+    test_output_bucket: str,
+    s3_client: S3Client,
+    config: DepositionImportConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Verify that viz config generation works when invoked from an annotation-only deposition
+    (i.e. no tomogram in the parent hierarchy). Tomograms already exist on disk from a prior
+    ingestion run; the importer must discover them via _get_tomograms_from_disk().
+    """
+    parents = get_parents(config)
+    vs_path = get_vs_path(parents)
+
+    # Simulate annotation-only deposition: remove tomogram from parents, as it would
+    # not be present when running --import-viz-config without re-ingesting tomograms.
+    parents_without_tomogram = {k: v for k, v in parents.items() if k != "tomogram"}
+
+    # Patch _create_config so we don't need real zarr data
+    monkeypatch.setattr(
+        VisualizationConfigImporter,
+        "_create_config",
+        lambda self, alignment_metadata_path: {"key": "combine_json_layers", "foo": "bar"},
+    )
+
+    viz_config = list(VisualizationConfigImporter.finder(config, **parents_without_tomogram))
+    for item in viz_config:
+        item.import_item()
+
+    precompute_dir = os.path.join(vs_path, "NeuroglancerPrecompute")
+    config_files = get_children(s3_client, test_output_bucket, precompute_dir)
+    assert "100-neuroglancer_config.json" in config_files, (
+        "Viz config not generated for annotation-only deposition — tomogram not discovered from disk"
+    )


### PR DESCRIPTION
…ading tomograms from disk

### Summary
`--import-viz-config` was broken for `annotation-only deposition` configs (no tomograms) - it silently did nothing, forcing unnecessary full re-ingestion jobs after adding annotations.

Root cause: `VisualizationConfigImporter` was nested under TomogramImporter in the dependency tree, so the dependency tree required iterating through tomograms to reach it. On annotation-only configs, TomogramImporter.finder() returned nothing and viz config generation was never triggered.

### Fix:
- Move `VisualizationConfigImporter` to a direct child of `VoxelSpacingImporter` in IMPORTER_DEP_TREE, removing TomogramImporter as a required parent.
- Refactor `import_item()` to discover tomograms by globbing `tomogram_metadata.json` files from the existing output on disk, rather than relying on a tomogram parent in the hierarchy.

###Tests added:
- `test_viz_config_multiple_tomograms` - one config file written per tomogram on disk.
- `test_viz_config_annotation_only_deposition` - viz config generated with annotation only deposition(no tomograms).