### PR TITLE
chore: Use asdf-action v4 to fix linting workflow

### DIFF
--- a/.github/workflows/py-formatting.yml
+++ b/.github/workflows/py-formatting.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: "3.12.5"
       - name: Install action-validator with asdf
-        uses: asdf-vm/actions/install@v3
+        uses: asdf-vm/actions/install@v4
         with:
           tool_versions: |
             action-validator 0.6.0


### PR DESCRIPTION
A recent release of ASDF broke `asdf-vm/actions/install@v3`, updating to v4 to fix the linting workflow. 