### PR TITLE
fix: remove broken asdf step from Python linting CI

### DIFF
--- a/.github/workflows/py-formatting.yml
+++ b/.github/workflows/py-formatting.yml
@@ -10,15 +10,10 @@ jobs:
     name: pre-commit checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12.5"
-      - name: Install action-validator with asdf
-        uses: asdf-vm/actions/install@v4
-        with:
-          tool_versions: |
-            action-validator 0.6.0
       - name: disable pre-commit validation
         run: echo "SKIP=dataset-config-validation" >> $GITHUB_ENV
       - name: check backend


### PR DESCRIPTION
## Summary
- Remove the `asdf-vm/actions/install` step from the Python linting workflow, which was failing with
  "Unable to locate executable file: asdf" on both v3 and v4
- The asdf step was only used to install `action-validator`, which is already handled automatically by
  pre-commit via the `mpalmer/action-validator` hook in `.pre-commit-config.yaml`
- Update `actions/checkout` from v3 to v4 and `actions/setup-python` from v4 to v5 (Node 16 deprecation)

