### PR TITLE
fix: 10440.yaml and 10453.yaml files, bug in enqueuing runs

### DIFF
--- a/ingestion_tools/dataset_configs/10440.yaml
+++ b/ingestion_tools/dataset_configs/10440.yaml
@@ -422,7 +422,6 @@ depositions:
     deposition_title: CZII - CryoET Object Identification Challenge
     deposition_types:
     - dataset
-    - annotation
   sources:
   - literal:
       value:

--- a/ingestion_tools/dataset_configs/10453.yaml
+++ b/ingestion_tools/dataset_configs/10453.yaml
@@ -101,7 +101,7 @@ annotations:
       version: 1.0
     sources:
       - OrientedPoint:
-          binning: 16
+          binning: 8
           order: xyz
           file_format: relion4_star
           glob_string: particle_tables/CCVs_fragment_relion_dataset_1_fixed.star

--- a/ingestion_tools/scripts/enqueue_runs.py
+++ b/ingestion_tools/scripts/enqueue_runs.py
@@ -432,7 +432,7 @@ def queue(
                     excluded_args = ["filter_dataset_name", "filter_run_name"]
                     for k, v in kwargs.items():
                         if any(substring in k for substring in excluded_args):
-                            break
+                            continue
                         per_run_args[k] = v
                     new_args = to_args(
                         https_prefix=https_prefix,


### PR DESCRIPTION
Reingested 10453 annotations due to wrong binning level in the config.

When enqueuing runs, flags after a filter should not be deleted, for example, the `--import*` flags will be ignored in this case because it comes after a `filter` flag:

`python enqueue_runs.py queue ../dataset_configs/10453.yaml cryoetportal-rawdatasets-dev cryoet-data-portal-staging --ecr-tag 10453-fix-1 --filter-run-name "^tomogram_008$" --import-annotations --import-annotation-metadata --import-annotation-viz`