### PR TITLE
fix: don't rescale annotation if dims are the same

### DIFF
--- a/ingestion_tools/scripts/common/image.py
+++ b/ingestion_tools/scripts/common/image.py
@@ -42,28 +42,20 @@ from common.retry import (
 class VolumeInfo:
     voxel_size: float
 
-    # start coords
-    xstart: int
-    ystart: int
-    zstart: int
-
-    # end coords
-    xend: int
-    yend: int
-    zend: int
+    # dimensions
+    xdim: int
+    ydim: int
+    zdim: int
 
     # Data we save
     rms: float
     dmean: float
 
     def get_dimensions(self) -> Dict[str, int]:
-        return {d: getattr(self, f"{d}end") - getattr(self, f"{d}start") for d in "xyz"}
+        return {d: getattr(self, f"{d}dim") for d in "xyz"}
 
     def get_max_dimension(self) -> int:
         return max(self.get_dimensions().values())
-
-    def get_center_coords(self) -> List[int]:
-        return [np.round(np.mean([getattr(self, f"{d}end"), getattr(self, f"{d}start")])) for d in "xyz"]
 
 
 class ZarrReader:
@@ -284,9 +276,6 @@ class MRCReader(VolumeReader):
     def get_volume_info(self) -> VolumeInfo:
         return VolumeInfo(
             self._voxel_size,
-            self.header.nxstart.item(),
-            self.header.nystart.item(),
-            self.header.nzstart.item(),
             self.header.nx.item(),
             self.header.ny.item(),
             self.header.nz.item(),
@@ -334,9 +323,6 @@ class OMEZarrReader(VolumeReader):
         z, y, x = self._shape
         return VolumeInfo(
             self._attrs["multiscales"][0]["datasets"][0]["coordinateTransformations"][0]["scale"][1],
-            0,
-            0,
-            0,
             x,
             y,
             z,

--- a/ingestion_tools/scripts/data_validation/source/test/test_tiltseries.py
+++ b/ingestion_tools/scripts/data_validation/source/test/test_tiltseries.py
@@ -69,7 +69,7 @@ class TestTiltSeries(TiltSeriesHelper):
         raw_tilt_data: pd.DataFrame,
     ):
         volume_info = get_volume_info(filesystem, tiltseries.volume_filename)
-        assert len(raw_tilt_data) == volume_info.zend - volume_info.zstart, (
+        assert len(raw_tilt_data) == volume_info.zdim, (
             f"Number of rawtlt entries: {len(raw_tilt_data)} != Number of z-sections: "
-            f"{volume_info.zend - volume_info.zstart}"
+            f"{volume_info.zdim}"
         )

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -14,7 +14,7 @@ from common.config import DepositionImportConfig
 from common.finders import BaseFinder, DepositionObjectImporterFactory, SourceGlobFinder, SourceMultiGlobFinder
 from common.fs import FileSystemApi
 from common.id_helper import IdentifierHelper
-from common.image import check_mask_for_label, make_pyramids
+from common.image import check_mask_for_label, get_volume_info, make_pyramids
 from common.metadata import AnnotationMetadata
 from importers.alignment import AlignmentImporter
 from importers.base_importer import BaseImporter
@@ -271,6 +271,16 @@ class VolumeAnnotationSource(BaseAnnotationSource):
         )
         return dims
 
+    def _get_resize_target(self) -> tuple[int, int, int] | None:
+        """Return target dims when rescaling is needed; None if rescale is off
+        or the source already matches the target dims (no-op resize)."""
+        if not getattr(self, "rescale", False):
+            return None
+        target = self.get_output_dim()
+        info = get_volume_info(self.config.fs, self.path)
+        src = (info.zend, info.yend, info.xend)
+        return None if src == target else target
+
     def get_metadata(self, output_prefix: str) -> list[dict[str, Any]]:
         metadata = [
             {
@@ -310,7 +320,7 @@ class SegmentationMaskAnnotation(VolumeAnnotationSource):
             raise ValueError("Thresholding and selecting by label are mutually exclusive")
 
     def convert(self, output_prefix: str):
-        output_dims = self.get_output_dim() if self.rescale else None
+        output_dims = self._get_resize_target()
         return make_pyramids(
             self.config.fs,
             self.get_output_filename(output_prefix),
@@ -342,7 +352,7 @@ class InstanceSegmentationMaskAnnotation(VolumeAnnotationSource):
         self.is_portal_standard = is_portal_standard
 
     def convert(self, output_prefix: str):
-        output_dims = self.get_output_dim() if self.rescale else None
+        output_dims = self._get_resize_target()
 
         return make_pyramids(
             self.config.fs,
@@ -399,7 +409,7 @@ class SemanticSegmentationMaskAnnotation(VolumeAnnotationSource):
             raise ValueError("Thresholding and selecting by label are mutually exclusive")
 
     def convert(self, output_prefix: str):
-        output_dims = self.get_output_dim() if self.rescale else None
+        output_dims = self._get_resize_target()
         return make_pyramids(
             self.config.fs,
             self.get_output_filename(output_prefix),

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -277,8 +277,8 @@ class VolumeAnnotationSource(BaseAnnotationSource):
         if not getattr(self, "rescale", False):
             return None
         target = self.get_output_dim()
-        info = get_volume_info(self.config.fs, self.path)
-        src = (info.zend, info.yend, info.xend)
+        d = get_volume_info(self.config.fs, self.path).get_dimensions()
+        src = (d["z"], d["y"], d["x"])
         return None if src == target else target
 
     def get_metadata(self, output_prefix: str) -> list[dict[str, Any]]:

--- a/ingestion_tools/scripts/importers/visualization_config.py
+++ b/ingestion_tools/scripts/importers/visualization_config.py
@@ -103,7 +103,7 @@ class VisualizationConfigImporter(BaseImporter):
             name=self.get_run().name,
             mean=volume_info.dmean,
             rms=volume_info.rms,
-            start={d: getattr(volume_info, f"{d}start") for d in "xyz"},
+            start={"x": 0, "y": 0, "z": 0},
             threedee_contrast_limits=contrast_limits,
         )
 

--- a/ingestion_tools/scripts/tests/s3_import/test_image.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_image.py
@@ -1,0 +1,46 @@
+import mrcfile
+import numpy as np
+
+from common.fs import FileSystemApi
+from common.image import MRCReader, VolumeInfo
+
+
+def test_volume_info_dimensions() -> None:
+    info = VolumeInfo(voxel_size=1.0, xdim=10, ydim=20, zdim=30, rms=0.5, dmean=0.1)
+    assert info.get_dimensions() == {"x": 10, "y": 20, "z": 30}
+    assert info.get_max_dimension() == 30
+
+
+def _write_mrc(path: str, shape: tuple[int, int, int], starts: tuple[int, int, int]) -> None:
+    """Write a minimal MRC at `path` with the given (z, y, x) shape and non-zero (nx,ny,nz)start."""
+    data = np.zeros(shape, dtype=np.float32)
+    with mrcfile.new(path, overwrite=True) as mrc:
+        mrc.set_data(data)
+        mrc.header.nxstart = starts[0]
+        mrc.header.nystart = starts[1]
+        mrc.header.nzstart = starts[2]
+        mrc.voxel_size = 1.0
+
+
+def test_mrc_reader_dimensions_ignore_nstart(local_fs: FileSystemApi, tmp_path) -> None:
+    """nxstart/nystart/nzstart are origin coords per MRC2014 spec; they must not affect reported dims."""
+    mrc_path = str(tmp_path / "with_nstart.mrc")
+    # shape is (z, y, x) -> nz=30, ny=20, nx=10; non-zero starts must be ignored for dims
+    _write_mrc(mrc_path, shape=(30, 20, 10), starts=(5, 7, 9))
+
+    reader = MRCReader(local_fs, mrc_path)
+    volume_info = reader.get_volume_info()
+
+    assert volume_info.get_dimensions() == {"x": 10, "y": 20, "z": 30}
+    assert volume_info.xdim == 10
+    assert volume_info.ydim == 20
+    assert volume_info.zdim == 30
+
+
+def test_mrc_reader_dimensions_zero_nstart(local_fs: FileSystemApi, tmp_path) -> None:
+    """Sanity check: zero nstart still produces correct dims."""
+    mrc_path = str(tmp_path / "zero_nstart.mrc")
+    _write_mrc(mrc_path, shape=(30, 20, 10), starts=(0, 0, 0))
+
+    volume_info = MRCReader(local_fs, mrc_path).get_volume_info()
+    assert volume_info.get_dimensions() == {"x": 10, "y": 20, "z": 30}


### PR DESCRIPTION
Currently, if you set `rescale: true` but the annotation dimensions and the tomogram dimensions are the same, an unnecessary rescale will be done. This wastes CPU and memory loading the full volume into Python and applying a no-op resize calculation.

In fixing this, we discovered another bug that was using the n{x,y,z}start value from MRC headers for volume dimension calculation, which is incorrect (should only be using the nx/ny/nz value). Resolved here as well. Added a test to ensure this fix works.