### PR TITLE
fix: expire DB-cache in conftest to fix flaky test.

### DIFF
--- a/apiv2/db_import/tests/conftest.py
+++ b/apiv2/db_import/tests/conftest.py
@@ -87,6 +87,8 @@ def verify_dataset_import(
         inputs.update(default_inputs)
         inputs["s3_prefix"] = str(DATASET_ID)
         load_func(**inputs)
+        # load_func writes via a separate session; expire ours so reads see DB state, not stale cache.
+        sync_db_session.expire_all()
         actual = sync_db_session.scalars(sa.select(Dataset).where(Dataset.id == DATASET_ID)).one()
         verify_model(actual, expected_dataset)
         return actual


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
-->

Relates to
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Provide a checklist of any relevant pre-deployment notes.
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues, so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description
DB-cache causes flaky test behavior (e.g. failure on 2 re-runs, pass on third here: https://github.com/chanzuckerberg/cryoet-data-portal-backend/actions/runs/25131509535). Can be avoided by clearing DB-cache after test-DB setup. 

<!--
Provide information about what your PR does and any background information for nuanced topics.
-->
