### PR TITLE
fix: fix identified object re-ingestion crash and run filtering

### DIFF
--- a/ingestion_tools/scripts/importers/identified_object.py
+++ b/ingestion_tools/scripts/importers/identified_object.py
@@ -35,7 +35,8 @@ class IdentifiedObjectIdentifierHelper(IdentifierHelper):
             except (ValueError, TypeError):
                 identifier = 100
             cls.cached_identifiers[current_ids_key] = identifier
-            cls.next_identifier[container_key] = identifier + 1
+            if identifier >= cls.next_identifier[container_key]:
+                cls.next_identifier[container_key] = identifier + 1
         cls.loaded_containers.add(container_key)
 
     @classmethod

--- a/ingestion_tools/scripts/importers/identified_object.py
+++ b/ingestion_tools/scripts/importers/identified_object.py
@@ -98,9 +98,11 @@ class IdentifiedObjectImporter(BaseFileImporter):
         except Exception as e:
             print(f"Error reading CSV {self.path}: {e}")
             return
-        # Filter by run name and exclude run_name column
         run_name = self.parents["run"].name
-        df_filtered = df[df['run_identifier'] == run_name].drop(columns=['run_identifier']) if 'run_identifier' in df.columns else df
+        if 'run_name' not in df.columns:
+            print(f"Warning: CSV at {self.path} has no 'run_name' column — skipping import for run {run_name}")
+            return
+        df_filtered = df[df['run_name'] == run_name].drop(columns=['run_name'])
 
         output_file = f"{dest_path}/identified_objects.json"
         with self.config.fs.open(output_file, "w") as f:

--- a/ingestion_tools/scripts/importers/identified_object.py
+++ b/ingestion_tools/scripts/importers/identified_object.py
@@ -23,6 +23,22 @@ class IdentifiedObjectIdentifierHelper(IdentifierHelper):
         return metadata_glob
 
     @classmethod
+    def _load_ids_for_container(cls, container_key, config, parents, *args, **kwargs):
+        if container_key in cls.loaded_containers:
+            return
+        metadata_glob = cls._get_metadata_glob(config, parents, *args, **kwargs)
+        for file in config.fs.glob(metadata_glob):
+            metadata = json.loads(config.fs.open(file, "r").read())
+            current_ids_key = cls._generate_hash_key(container_key, metadata, parents, *args, **kwargs)
+            try:
+                identifier = int(metadata.get("identifier", 100))
+            except (ValueError, TypeError):
+                identifier = 100
+            cls.cached_identifiers[current_ids_key] = identifier
+            cls.next_identifier[container_key] = identifier + 1
+        cls.loaded_containers.add(container_key)
+
+    @classmethod
     def _generate_hash_key(
         cls,
         container_key: str,
@@ -83,7 +99,7 @@ class IdentifiedObjectImporter(BaseFileImporter):
             return
         # Filter by run name and exclude run_name column
         run_name = self.parents["run"].name
-        df_filtered = df[df['run_name'] == run_name].drop(columns=['run_name']) if 'run_name' in df.columns else df
+        df_filtered = df[df['run_identifier'] == run_name].drop(columns=['run_identifier']) if 'run_identifier' in df.columns else df
 
         output_file = f"{dest_path}/identified_objects.json"
         with self.config.fs.open(output_file, "w") as f:
@@ -108,7 +124,7 @@ class IdentifiedObjectImporter(BaseFileImporter):
             "columns": list(data[0].keys()) if data else [],
             "file_format": "json",
             "source_file": self.path,
-            "identifier": self.path,
+            "identifier": self.identifier,
         }
 
         metadata = IdentifiedObjectMetadata(

--- a/ingestion_tools/scripts/tests/fixtures/identified_objects/identified_objects.csv
+++ b/ingestion_tools/scripts/tests/fixtures/identified_objects/identified_objects.csv
@@ -1,4 +1,4 @@
-run_identifier,object_id,object_name,object_state,object_description
+run_name,object_id,object_name,object_state,object_description
 TS_run1,GO:0005739,mitochondrion,active,Mitochondrial organelle
 TS_run1,GO:0005794,Golgi apparatus,inactive,Golgi apparatus organelle
 TS_run1,GO:0005783,endoplasmic reticulum,active,ER organelle

--- a/test_infra/test_files/input_bucket/10001_input/identified_objects/identified_objects.csv
+++ b/test_infra/test_files/input_bucket/10001_input/identified_objects/identified_objects.csv
@@ -1,4 +1,4 @@
-run_identifier,object_id,object_name,object_state,object_description
+run_name,object_id,object_name,object_state,object_description
 TS_run1,GO:0005739,mitochondrion,active,Mitochondrial organelle
 TS_run1,GO:0005794,Golgi apparatus,inactive,Golgi apparatus organelle
 TS_run1,GO:0005783,endoplasmic reticulum,active,ER organelle


### PR DESCRIPTION
- **Add `_load_ids_for_container` override** on`IdentifiedObjectIdentifierHelper` to handle the flat directory structure. Instead of parsing the directory name, it reads the integer `identifier` directly from the stored metadata JSON. Falls back to `100` with a `try/except` for backward compatibility with any existing metadata files that still contain the old file-path string.
- **Fix CSV column filter** in `import_item`: `run_name` → `run_identifier`. Now correctly filters rows to the current run and drops the `run_identifier` column from the output JSON.
- **Fix stored identifier** in `import_metadata`: `self.path` → `self.identifier`. The metadata file now stores the actual integer ID, which the new `_load_ids_for_container` reads back on re-ingestion.