### PR TITLE
fix: correct pytest invocation on data validation with pytest v9

### DIFF
--- a/ingestion_tools/scripts/data_validation/shared/allure_runner.py
+++ b/ingestion_tools/scripts/data_validation/shared/allure_runner.py
@@ -102,6 +102,7 @@ def execute_allure_tests(
 
     executable_cmd_component = [
         "pytest",
+        ".",
         "--dist loadscope -n auto" if kwargs.get("multiprocessing") else "--dist no",
         f"--alluredir {localdir_raw}",
     ]


### PR DESCRIPTION
Without this, pytest will fail on the AWS Step Function instances that get launched to run validation (because of the recent dep upgrade to pytest v9).

When pytest encounters `--ingestion-config ../../../dataset_configs/10XXX.yaml` before the conftest has been loaded, it doesn't yet know --ingestion-config is an option. So pytest treats the value `../../../dataset_configs/10XXX.yaml` as a positional test path argument. That path resolves to `/usr/src/app/ingestion_tools/dataset_configs/10XXX.yaml` (a real file). Pytest then walks up from that file's directory looking for the inifile and lands on `/usr/src/app/ingestion_tools/pyproject.toml`, when it should be finding `ingestion_tools/scripts/data_validation/source/pytest.ini`