### PR TITLE
fix: update Dockerfile to use later Poetry version

### DIFF
--- a/apiv2/Dockerfile
+++ b/apiv2/Dockerfile
@@ -8,14 +8,14 @@ RUN apt-get update && \
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir --upgrade --force-reinstall setuptools wheel packaging
 
-ENV POETRY_VERSION=1.8
+ENV POETRY_VERSION=2.2.1
 # Some base python dependencies to kickstart our container build.
 RUN python3 -m pip install --no-cache-dir poetry==$POETRY_VERSION supervisor
 
 # Install dev deps
 RUN poetry config virtualenvs.create false
 COPY pyproject.toml poetry.lock ./
-RUN poetry install
+RUN poetry install --no-root
 
 # Create an empty dir to mount our test app to.
 RUN mkdir -p /app


### PR DESCRIPTION
The apiv2 image pinned Poetry 1.8 while poetry.lock is generated by Poetry 2.2.1, and the
`--force-reinstall ... packaging` step now pulls a `packaging` release whose layout breaks
Poetry 1.8's build isolation. Bumping to Poetry 2.2.1 (matching the lock + ingestion_tools)
fixes the install; adding `--no-root` skips the root-project build, which 2.x errors on at
this layer (only pyproject/lock are present — no README/source).


--- Error before fix (Poetry 1.8): ---

```
0.795 The lock file might not be compatible with the current version of Poetry.
0.795 Upgrade Poetry to ensure the lock file is read properly or, alternatively, regenerate the lock file with the `poetry lock` command.
...
1.689   - Downgrading packaging (26.2 -> 26.0)
...
2.514   ChefInstallError
2.514
2.515   Failed to install setuptools >= 40.8.0.
...
2.515     FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.12/site-packages/packaging/tags.py'
...
2.517 Cannot install build-system.requires for antlr4-python3-runtime.
...
ERROR: failed to build: failed to solve: process "/bin/sh -c poetry install" did not complete successfully: exit code: 1
```

--- Error after Poetry bump, before --no-root (Poetry 2.2.1): ---

```
42.02 Installing the current project: platformics (0.1.0)
42.02
42.02 Error: The current project could not be installed: Readme path `/README.md` does not exist.
42.02 If you do not want to install the current project use --no-root.
...
ERROR: failed to build: failed to solve: process "/bin/sh -c poetry install" did not complete successfully: exit code: 1
```