### PR TITLE
fix: properly parse IMOD CTF files

### DIFF
--- a/ingestion_tools/scripts/common/ctf_converter.py
+++ b/ingestion_tools/scripts/common/ctf_converter.py
@@ -1,3 +1,5 @@
+import math
+
 from common.config import DepositionImportConfig
 
 
@@ -111,34 +113,127 @@ class GctfCTF(BaseCTFConverter):
 
 
 class IMODCTF(BaseCTFConverter):
+    """Parser for IMOD ``.defocus`` files (ctfphaseflip / ctfplotter output).
+
+    Every data row begins with ``startView endView startTilt endTilt`` followed by a
+    defocus payload whose shape is determined by a bit ``flag``:
+
+    ====  ============================================  ===================================
+    bit   meaning                                       effect on the payload
+    ====  ============================================  ===================================
+    1     astigmatism values present                    ``defU defV azimuth`` (3 cols) vs a
+                                                         single ``defocus`` (1 col)
+    2     astigmatism axis angle is in radians          azimuth read as radians, not degrees
+    4     phase shift present                           +1 column
+    8     phase shift is in radians                     phase read as radians, not degrees
+    16    tilt angles need inverting                    no effect on the values we emit
+    32    cut-on frequency present                      +1 column (ignored)
+    ====  ============================================  ===================================
+
+    The flag is read from a version-3 header line (``<flag> 0 0.0 0.0 0.0 <version>``) when one
+    is present. Files without a header (the original single-defocus layout, optionally with a
+    trailing version number on the first row) are treated as ``flag == 0``. Defocus values are
+    nm in the file and converted to Angstrom; azimuth is emitted in degrees and phase shift in
+    radians, matching :class:`CTFInfo`.
+    """
+
+    ASTIGMATISM = 1
+    ASTIGMATISM_RADIANS = 2
+    PHASE_SHIFT = 4
+    PHASE_SHIFT_RADIANS = 8
+    CUT_ON_FREQUENCY = 32
+
     def get_ctf_info(self) -> list[CTFInfo]:
         local_path = self.config.fs.localreadable(self.path)
-        infos: list[CTFInfo] = []
         with open(local_path, "r") as f:
-            for raw in f:
-                line = raw.strip()
-                parts = line.split()
-                # Header/flag line typically has fewer than 7 columns
-                if len(parts) < 7:
-                    continue
-                infos.append(self.from_str(line))
-        return infos
+            lines = [ln for ln in (raw.strip() for raw in f) if ln]
+        if not lines:
+            return []
+
+        flag, data_lines = self._read_flag(lines)
+        expected = self._column_indices(flag)["min_columns"]
+        for n, ln in enumerate(data_lines):
+            width = len(ln.split())
+            # Tolerate a trailing version number on the first row of a header-less file.
+            allowed = {expected, expected + 1} if n == 0 else {expected}
+            if width not in allowed:
+                raise ValueError(
+                    f"IMOD defocus row has {width} columns, expected {expected} for flag {flag} "
+                    f"(a header-less astigmatism file would land here): {ln!r}",
+                )
+        # Modern IMOD numbers views 1-based; a minimum view of 0 means the pre-IMOD-4.1 off-by-one
+        # bug (views written from 0). Fail loudly rather than silently shift every section's CTF.
+        if min(int(float(ln.split()[0])) for ln in data_lines) == 0:
+            raise ValueError(
+                "IMOD defocus file uses 0-based view numbers (pre-IMOD-4.1 off-by-one bug); "
+                "regenerate it with a current IMOD so views are 1-based.",
+            )
+        return [self.from_str(ln, flag=flag) for ln in data_lines]
 
     @classmethod
-    def from_str(cls, line: str) -> CTFInfo:
+    def _is_header(cls, parts: list[str]) -> bool:
+        # Version-3 header "<flag> 0 0.0 0.0 0.0 <version>": fields 2-5 (view/tilt/defocus) are 0.
+        return len(parts) >= 6 and all(float(parts[i]) == 0.0 for i in (1, 2, 3, 4))
+
+    @classmethod
+    def _read_flag(cls, lines: list[str]) -> tuple[int, list[str]]:
+        """Return ``(flag, data_lines)``, reading the flag from a version-3 header if present."""
+        first = lines[0].split()
+        if cls._is_header(first):
+            return int(float(first[0])), lines[1:]
+        # No header: original single-defocus layout (a trailing version number on the first row
+        # is tolerated as an extra column). This corresponds to flag 0.
+        return 0, lines
+
+    @classmethod
+    def _column_indices(cls, flag: int) -> dict[str, int]:
+        """Map payload fields to column indices for the given flag."""
+        idx: dict[str, int] = {}
+        if flag & cls.ASTIGMATISM:
+            idx["defocus_1"], idx["defocus_2"], idx["azimuth"] = 4, 5, 6
+            nxt = 7
+        else:
+            idx["defocus_1"] = idx["defocus_2"] = 4
+            nxt = 5
+        if flag & cls.PHASE_SHIFT:
+            idx["phase_shift"] = nxt
+            nxt += 1
+        if flag & cls.CUT_ON_FREQUENCY:
+            nxt += 1  # cut-on frequency column is present but unused
+        idx["min_columns"] = nxt
+        return idx
+
+    @classmethod
+    def from_str(cls, line: str, flag: int = 0) -> CTFInfo:
         parts = line.split()
-        # IMOD defocus file: startView endView startTilt endTilt defU[nm] defV[nm] azimuth[deg] ...
-        section = int(parts[0])
-        defocus_1_nm = float(parts[4])
-        defocus_2_nm = float(parts[5])
-        azimuth = float(parts[6])
+        idx = cls._column_indices(flag)
+        if len(parts) < idx["min_columns"]:
+            raise ValueError(
+                f"IMOD defocus row has {len(parts)} columns, expected >= {idx['min_columns']} "
+                f"for flag {flag}: {line!r}",
+            )
+
+        defocus_1_nm = float(parts[idx["defocus_1"]])
+        defocus_2_nm = float(parts[idx["defocus_2"]])
+
+        azimuth = 0.0
+        if flag & cls.ASTIGMATISM:
+            azimuth = float(parts[idx["azimuth"]])
+            if flag & cls.ASTIGMATISM_RADIANS:
+                azimuth = math.degrees(azimuth)  # CTFInfo.azimuth is degrees
+
+        phase_shift = 0.0
+        if flag & cls.PHASE_SHIFT:
+            phase_shift = float(parts[idx["phase_shift"]])
+            if not flag & cls.PHASE_SHIFT_RADIANS:
+                phase_shift = math.radians(phase_shift)  # IMOD default is degrees; CTFInfo is radians
 
         return CTFInfo(
-            section=section,
-            defocus_1=defocus_1_nm * 10.0,  # nm → A
+            section=int(float(parts[0])),
+            defocus_1=defocus_1_nm * 10.0,  # nm -> A
             defocus_2=defocus_2_nm * 10.0,
             azimuth=azimuth,
-            phase_shift=0.0,
+            phase_shift=phase_shift,
             cross_correlation=0.0,
             max_resolution=0.0,
         )

--- a/ingestion_tools/scripts/tests/s3_import/test_ctf_converter.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_ctf_converter.py
@@ -1,0 +1,178 @@
+"""Unit tests for the IMOD CTF (.defocus) parser.
+
+The parser is flag-driven: the bit ``flag`` (read from a version-3 header line, or assumed 0
+for the header-less single-defocus layout) determines the column layout. Flag bits:
+``1`` astigmatism, ``2`` astigmatism angle in radians, ``4`` phase shift, ``8`` phase shift in
+radians, ``16`` invert tilt angles, ``32`` cut-on frequency.
+
+See https://bio3d.colorado.edu/imod/doc/man/ctfphaseflip.html for the format and the flag
+definitions reproduced in ``imod.utils.getDefocusFileFlag`` (scipion-em-imod).
+"""
+
+import math
+from unittest.mock import Mock
+
+import pytest
+
+from common.ctf_converter import IMODCTF
+
+
+def _imod(tmp_path, contents: str) -> IMODCTF:
+    path = tmp_path / "ctf.defocus"
+    path.write_text(contents)
+    config = Mock()
+    config.fs.localreadable.return_value = str(path)
+    return IMODCTF(config, str(path))
+
+
+# --- from_str: one row under an explicit flag ---------------------------------------------------
+
+
+def test_from_str_single_defocus():
+    # flag 0, 5 columns: startView endView startTilt endTilt defocus[nm]
+    info = IMODCTF.from_str("3  3  -58.86  -58.86  7589")
+    assert info.section == 3
+    assert info.defocus_1 == 75890.0  # 7589 nm -> A
+    assert info.defocus_2 == 75890.0  # no astigmatism: defocus_2 mirrors defocus_1
+    assert info.azimuth == 0.0
+    assert info.phase_shift == 0.0
+
+
+def test_from_str_single_defocus_tolerates_trailing_version():
+    # The first row of a header-less file may carry a trailing version number (6 cols); ignore it.
+    info = IMODCTF.from_str("1  1  -64.88  -64.88  7643  2")
+    assert info.section == 1
+    assert info.defocus_1 == info.defocus_2 == 76430.0
+    assert info.azimuth == 0.0
+
+
+def test_from_str_astigmatism():
+    # flag 1, 7 columns: startView endView startTilt endTilt defU[nm] defV[nm] azimuth[deg]
+    info = IMODCTF.from_str("1  1  -50.00  -50.00  3665  3472  -62.10", flag=IMODCTF.ASTIGMATISM)
+    assert info.section == 1
+    assert info.defocus_1 == 36650.0
+    assert info.defocus_2 == 34720.0
+    assert info.azimuth == -62.10
+
+
+def test_from_str_phase_only_no_astigmatism():
+    # flag 4, 6 columns: ... defocus[nm] phaseShift[deg]; phase emitted in radians.
+    info = IMODCTF.from_str("1 1 -50 -50 7000 90", flag=IMODCTF.PHASE_SHIFT)
+    assert info.defocus_1 == info.defocus_2 == 70000.0
+    assert info.azimuth == 0.0
+    assert info.phase_shift == pytest.approx(math.pi / 2)
+
+
+def test_from_str_astigmatism_phase_cuton():
+    # flag 37 (1+4+32), 9 columns: ... defU defV azimuth phaseShift cutOn (cut-on ignored).
+    flag = IMODCTF.ASTIGMATISM | IMODCTF.PHASE_SHIFT | IMODCTF.CUT_ON_FREQUENCY
+    info = IMODCTF.from_str("1 1 -50 -50 3665 3472 -62.10 180 0.1686", flag=flag)
+    assert info.defocus_1 == 36650.0
+    assert info.defocus_2 == 34720.0
+    assert info.azimuth == -62.10
+    assert info.phase_shift == pytest.approx(math.pi)  # 180 deg -> pi rad
+
+
+def test_from_str_radian_units_converted():
+    # flag 3 (1+2): astigmatism angle is in radians; emit degrees.
+    info = IMODCTF.from_str("1 1 -50 -50 3665 3472 -1.0838", flag=IMODCTF.ASTIGMATISM | IMODCTF.ASTIGMATISM_RADIANS)
+    assert info.azimuth == pytest.approx(-62.10, abs=1e-2)
+    # flag 12 (4+8): phase shift already in radians; pass through unchanged.
+    info = IMODCTF.from_str("1 1 -50 -50 7000 1.5708", flag=IMODCTF.PHASE_SHIFT | IMODCTF.PHASE_SHIFT_RADIANS)
+    assert info.phase_shift == pytest.approx(1.5708)
+
+
+def test_from_str_too_few_columns():
+    with pytest.raises(ValueError, match="expected >= 7"):
+        IMODCTF.from_str("1 1 -50 -50 3665", flag=IMODCTF.ASTIGMATISM)
+
+
+# --- get_ctf_info: whole-file parsing, header/version detection -----------------------------------
+
+
+def test_get_ctf_info_v2_single_defocus_file(tmp_path):
+    # Version 2 (BYU-style): first line carries a trailing version number (6 cols), rest are 5-col.
+    contents = "1\t1\t-64.88\t-64.88\t7643\t2\n2\t2\t-61.87\t-61.87\t7650\n3\t3\t-58.86\t-58.86\t7589\n"
+    infos = _imod(tmp_path, contents).get_ctf_info()
+    assert [i.section for i in infos] == [1, 2, 3]
+    assert infos[0].defocus_1 == infos[0].defocus_2 == 76430.0
+    assert all(i.azimuth == 0.0 for i in infos)
+
+
+def test_get_ctf_info_v1_single_defocus_file(tmp_path):
+    # Version 1: every line (including the first) is 5-column single defocus, no version/header.
+    contents = "1 1 -60.0 -60.0 7000\n2 2 -57.0 -57.0 7100\n"
+    infos = _imod(tmp_path, contents).get_ctf_info()
+    assert [i.section for i in infos] == [1, 2]
+    assert infos[0].defocus_1 == infos[0].defocus_2 == 70000.0
+
+
+def test_get_ctf_info_v3_single_defocus_with_header(tmp_path):
+    # Version-3 flag-0 header ("0 0 0.0 0.0 0.0 3") followed by 5-column single-defocus data.
+    contents = "0 0 0.0 0.0 0.0 3\n1 1 -60.0 -60.0 7000\n2 2 -57.0 -57.0 7100\n"
+    infos = _imod(tmp_path, contents).get_ctf_info()
+    assert len(infos) == 2  # header dropped
+    assert infos[0].defocus_1 == infos[0].defocus_2 == 70000.0
+    assert infos[0].azimuth == 0.0
+
+
+def test_get_ctf_info_v3_astigmatism_file_skips_header(tmp_path):
+    # Version-3 astigmatism file (flag 1): a header line precedes the 7-column data.
+    contents = "1 0 0.0 0.0 0.0 3\n1 1 -50.00 -50.00 3665 3472 -62.10\n2 2 -47.00 -47.00 3600 3400 -61.0\n"
+    infos = _imod(tmp_path, contents).get_ctf_info()
+    assert len(infos) == 2  # header dropped
+    assert infos[0].defocus_1 == 36650.0
+    assert infos[0].defocus_2 == 34720.0
+    assert infos[0].azimuth == -62.10
+
+
+def test_get_ctf_info_v3_phase_only_file(tmp_path):
+    # flag 4: phase shift, no astigmatism -> 6-column data. Previously rejected outright.
+    contents = "4 0 0.0 0.0 0.0 3\n1 1 -50 -50 7000 180\n2 2 -47 -47 7100 180\n"
+    infos = _imod(tmp_path, contents).get_ctf_info()
+    assert len(infos) == 2
+    assert infos[0].defocus_1 == infos[0].defocus_2 == 70000.0
+    assert infos[0].azimuth == 0.0
+    assert infos[0].phase_shift == pytest.approx(math.pi)
+
+
+def test_get_ctf_info_v3_phase_cuton_no_astigmatism(tmp_path):
+    # flag 36 (4+32): phase + cut-on, NO astigmatism -> 7-column data that must NOT be read as astig.
+    contents = "36 0 0.0 0.0 0.0 3\n1 1 -50 -50 7000 180 0.17\n"
+    infos = _imod(tmp_path, contents).get_ctf_info()
+    assert infos[0].defocus_1 == infos[0].defocus_2 == 70000.0  # not 7000/180 misread as defU/defV
+    assert infos[0].azimuth == 0.0  # cut-on (0.17) is NOT mistaken for azimuth
+    assert infos[0].phase_shift == pytest.approx(math.pi)
+
+
+def test_get_ctf_info_keeps_zero_tilt_data(tmp_path):
+    # A 0-degree tilt data line has nonzero defocus and must not be mistaken for the header.
+    infos = _imod(tmp_path, "20\t20\t0.0\t0.0\t7000\n").get_ctf_info()
+    assert len(infos) == 1
+    assert infos[0].defocus_1 == 70000.0
+
+
+def test_get_ctf_info_rejects_headerless_astigmatism(tmp_path):
+    # Astigmatism (>=7-col) data with no header is assumed flag 0; the width guard rejects it
+    # rather than silently reading defU as a single defocus.
+    contents = "1 1 -60.0 -60.0 3665 3472 -62.0\n2 2 -57.0 -57.0 3600 3400 -61.0\n"
+    with pytest.raises(ValueError, match="header-less astigmatism"):
+        _imod(tmp_path, contents).get_ctf_info()
+
+
+def test_get_ctf_info_rejects_truncated_row(tmp_path):
+    # A row narrower than the flag implies is a hard error.
+    contents = "1 0 0.0 0.0 0.0 3\n1 1 -50 -50 3665 3472 -62.0\n2 2 -47 -47 3600\n"
+    with pytest.raises(ValueError, match="columns, expected 7"):
+        _imod(tmp_path, contents).get_ctf_info()
+
+
+def test_get_ctf_info_rejects_zero_based_views(tmp_path):
+    # Pre-IMOD-4.1 0-based view numbering (off-by-one bug) is rejected, not silently shifted.
+    contents = "0 0 -60.0 -60.0 7000\n1 1 -57.0 -57.0 7100\n"
+    with pytest.raises(ValueError, match="0-based view numbers"):
+        _imod(tmp_path, contents).get_ctf_info()
+
+
+def test_get_ctf_info_empty_file(tmp_path):
+    assert _imod(tmp_path, "\n  \n").get_ctf_info() == []


### PR DESCRIPTION
Addresses #717.

Rewrites `IMODCTF` to be flag-driven: it reads the IMOD flag from the version-3 header (or
assumes flag 0 for the header-less single-defocus layout) and derives the column layout from the
[documented flag bits](https://scipion-em.github.io/docs/release-3.0.0/_modules/imod/utils.html)
instead of guessing from the column count.

### Fixes
- Single-defocus files (5/6-col) are no longer dropped. The old `if len(parts) < 7: continue`
  guard skipped every row of these files, leaving per-section defocus null. This is 100% of the
  IMOD CTF data on the portal — deposition `10347` (`10485`–`10489`), 681 files.
- **Layout from the flag, not column count** — phase-only (flag 4), phase+cut-on without
  astigmatism (flag 36, previously *silently mis-slotted*), and astig+phase(+cut-on) (5/37) parse
  correctly; phase shift is now captured (radians, per `CTFInfo`).
- Radian-encoded angles (flag bits 2/8) converted to the units `CTFInfo` documents.
- Loud guards for a header-less astigmatism file and for 0-based view numbers (the pre-IMOD-4.1
  off-by-one), instead of silent mis-mapping.

### Validation
- 18 unit tests (`test_ctf_converter.py`) covering every flag + the guards.
- Re-parsed all 681 real `*_IMOD_ctf.txt` files in `10485`–`10489`: 0 failures, 0 empty, no
  regression.

### Follow-up
Deposition `10347`'s five datasets must be re-ingested for the corrected defocus to reach the
public portal (their published values are currently null).
