### PR TITLE
fix: stop re-running the annotation finder per annotation when writing metadata

### DIFF
--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -138,7 +138,13 @@ class AnnotationImporter(BaseImporter):
     has_metadata = True
     dir_path = "{dataset_name}/{run_name}/Reconstructions/VoxelSpacing{voxel_spacing_name}/Annotations/{annotation_id}"
     metadata_path = dir_path
-    written_metadata_files = []  # This is a *class* variable that helps us avoid writing metadata files multiple times.
+
+    # Multiple annotation sources can map to one logical annotation (same identifier -> same output
+    # path) and thus one metadata.json. We accumulate each source's metadata here, keyed by the
+    # fully-qualified output path. Keying by output path -- not the bare identifier, which only counts
+    # up from 100 *per run/voxel-spacing* -- groups sibling sources without colliding across runs or
+    # voxel spacings.
+    identifier_metadata_map: dict[str, dict[str, Any]] = {}
 
     def __init__(
         self,
@@ -170,39 +176,49 @@ class AnnotationImporter(BaseImporter):
         self.config.fs.makedirs(output_dir)
         return self.annotation_metadata.get_filename_prefix(output_dir)
 
+    def get_object_count(self, output_prefix: str) -> int:
+        # To be overridden by subclasses where necessary to return the number of objects in the annotation.
+        return 0
+
+    @abstractmethod
+    def get_metadata(self, output_prefix: str) -> list[dict[str, Any]]:
+        # To be overridden by subclasses to return the metadata for the "files" property of the
+        # annotation metadata, e.g.:
+        # [{"format": FORMAT, "path": OUTPUT_PATH, "shape": SHAPE, "is_visualization_default": BOOL}]
+        pass
+
     def import_metadata(self):
         if not self.is_import_allowed():
             print(f"Skipping import of {self.name} metadata")
             return
+
         dest_prefix = self.get_output_path()
         filename = f"{dest_prefix}.json"
-        if filename in self.written_metadata_files:
-            return  # We've already written this metadata file
+        path = os.path.relpath(dest_prefix, self.config.output_prefix)
 
-        anno_files = [
-            item
-            for item in AnnotationImporter.finder(self.config, **self.parents)
-            if item.identifier == self.identifier
-        ]
-
-        output_dir = self.get_output_path()
-        path = os.path.relpath(output_dir, self.config.output_prefix)
-        files = []
-        for source in anno_files:
-            files.extend(source.get_metadata(path))
+        # Several sources can belong to the same logical annotation (same identifier -> same output
+        # path); accumulate their files into one metadata doc as each source is imported, instead of
+        # re-discovering siblings via the finder. Re-running the finder here re-globbed and re-read
+        # every annotation source once per annotation -- O(annotations x sources).
+        meta = self.identifier_metadata_map.setdefault(
+            filename,
+            {
+                "object_count": 0,
+                "files": [],
+                "alignment_metadata_path": self.local_metadata["alignment_metadata_path"],
+            },
+        )
+        # Point this instance at the shared accumulator so local_metadata reflects the written doc.
+        self.local_metadata = meta
+        meta["files"].extend(self.get_metadata(path))
 
         try:
-            self.local_metadata["object_count"] = max(
-                [anno.get_object_count(output_dir) for anno in anno_files],
-                default=0,
-            )
-            self.local_metadata["files"] = files
+            object_count = self.get_object_count(dest_prefix)
         except FileNotFoundError:
-            print("Skipping metadata write since not all files have been written yet")
-            return
+            object_count = 0
+        meta["object_count"] = max(meta["object_count"], object_count)
 
-        self.written_metadata_files.append(filename)
-        self.annotation_metadata.write_metadata(filename, self.local_metadata)
+        self.annotation_metadata.write_metadata(filename, meta)
 
 
 class BaseAnnotationSource(AnnotationImporter):
@@ -232,19 +248,10 @@ class BaseAnnotationSource(AnnotationImporter):
         # To be overridden by subclasses to handle the import of the annotation.
         pass
 
-    def get_object_count(self, output_prefix: str) -> int:
-        # To be overridden by subclasses where necessary to return the number of objects in the annotation.
-        return 0
-
     def is_valid(self, *args, **kwargs) -> bool:
         # To be overridden by subclasses when additional check needed to validate if a source contains valid information
         # for this run.
         return True
-
-    @abstractmethod
-    def get_metadata(self, output_prefix: str) -> list[dict[str, Any]]:
-        # To be overridden by subclasses to return the metadata for the files property of the metadata.
-        pass
 
     def get_output_filename(self, output_prefix: str, extension: str | None = None) -> str:
         filename = f"{output_prefix}_{self.shape.lower()}"


### PR DESCRIPTION
To be merged before #676.

`AnnotationImporter.import_metadata()` writes one `metadata.json` per logical
annotation (`identifier`), whose `files` list must include every source that shares
that identifier (e.g. a mask + its oriented-points + a mesh). To find those siblings
it re-ran the global annotation finder and filtered by identifier:

```python
anno_files = [
    item
    for item in AnnotationImporter.finder(self.config, **self.parents)
    if item.identifier == self.identifier
]
```

The finder is global: one call walks all annotation source blocks, globs
each, instantiates it, and calls `is_valid()` — which for masks loads + numpy-scans
the full MRC file. So one finder pass reads all source files. `import_metadata` runs
once per annotation, so the whole pass is repeated `N` annotation times just to keep the 1–2
siblings of each annotation.

## Fix (this PR)
Don't call the finder in `import_metadata`. Accumulate each annotation's metadata
incrementally as its sources are imported, into a class-level map keyed by the
fully-qualified output path:

```python
identifier_metadata_map: dict[str, dict] = {}   # on AnnotationImporter

def import_metadata(self):
    ...
    meta = self.identifier_metadata_map.setdefault(filename, {...})
    meta["files"].extend(self.get_metadata(path))
    meta["object_count"] = max(meta["object_count"], self.get_object_count(dest_prefix))
    self.annotation_metadata.write_metadata(filename, meta)
```

Each source adds its own files + `object_count` to the shared doc and rewrites it;
the last sibling's write contains everything. The finder is no longer called from
`import_metadata` at all.

## Notes / scope
- Single file: `ingestion_tools/scripts/importers/annotation.py` (~40/33 +/-).
- Moved `get_object_count` + abstract `get_metadata` up from `BaseAnnotationSource`
  to `AnnotationImporter` (`import_metadata` now lives on the base and calls them).
- Removed the now-dead `written_metadata_files` guard. **IMPORTANT:** do not re-add
  `written_metadata_files.append(filename)` — with incremental writes it would make
  the 2nd+ sibling early-return and silently drop its files.
- `import_metadata` sets `self.local_metadata = meta` so the per-instance accessor
  still reflects the written doc (keeps existing tests' assertions valid).
- Behavior preserved for the "points defined after non-points sources" case
  (`object_count` = max across siblings, `files` accumulated) — no longer relies on
  the old `FileNotFoundError` "wait for all siblings" retry.

## Validation
- `py_compile` passes.
- Local-fs end-to-end tests pass: `test_ingest_triangular_mesh` / `_hff`
  (exercise `import_item` + `import_metadata` + `local_metadata` assertions).
- No regression vs baseline in local moto run (7 passed / 39 failed identical with
  and without the change; the 39 are `bucket does not exist` from an incomplete
  local moto harness, not the change — they pass in CI).
- Traced `test_import_annotation_metadata_with_multiple_sources` by hand: yields
  `object_count == 3`, 3 files `{zarr, ndjson, mrc}`, shapes `{Point, SegmentationMask}`.