### PR TITLE
chore: migrate runner label from xl-amd64-privileged to lg-amd64-privileged

### DIFF
--- a/.github/workflows/apiv2-test.yml
+++ b/.github/workflows/apiv2-test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   py-test:
-    runs-on: xl-amd64-privileged
+    runs-on: lg-amd64-privileged
     name: "Run tests"
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The `xl-amd64-privileged` runner has been resized to 16 CPU / 64Gi (from 8 CPU / 48Gi). The `lg-amd64-privileged` runner (8 CPU / 32Gi) is the roughly equivalent replacement for workloads that don't need the larger size.