### PR TITLE
fix: delete half-written annotation folders before importing new annotations

### DIFF
--- a/ingestion_tools/scripts/common/fs.py
+++ b/ingestion_tools/scripts/common/fs.py
@@ -73,6 +73,10 @@ class FileSystemApi(ABC):
     def move(self, src_path: str, dest_path: str, **kwargs) -> None:
         pass
 
+    @abstractmethod
+    def rm(self, path: str, recursive: bool = False) -> None:
+        pass
+
 
 class S3Filesystem(FileSystemApi):
     def __init__(self, force_overwrite: bool, client_kwargs: None | dict[str, str] = None, **kwargs):
@@ -186,6 +190,28 @@ class S3Filesystem(FileSystemApi):
     def move(self, src_path: str, dest_path: str, **kwargs) -> None:
         self.s3fs.mv(src_path, dest_path, **kwargs)
 
+    @s3_retry_decorator
+    def rm(self, path: str, recursive: bool = False) -> None:
+        # Use boto3 delete_objects on explicitly-listed keys rather than s3fs.rm/glob so that
+        # keys containing glob metacharacters (e.g. "[]" -- see copy() above) are deleted as
+        # literals. On versioned buckets this writes delete-markers, so removals are recoverable.
+        bucket, _, key = path.partition("/")
+        s3 = boto3.client("s3", **self.client_kwargs)
+        if recursive:
+            paginator = s3.get_paginator("list_objects_v2")
+            batch: list[dict[str, str]] = []
+            for page in paginator.paginate(Bucket=bucket, Prefix=key.rstrip("/") + "/"):
+                for obj in page.get("Contents", []):
+                    batch.append({"Key": obj["Key"]})
+                    if len(batch) == 1000:  # delete_objects accepts at most 1000 keys per call
+                        s3.delete_objects(Bucket=bucket, Delete={"Objects": batch})
+                        batch = []
+            if batch:
+                s3.delete_objects(Bucket=bucket, Delete={"Objects": batch})
+        else:
+            s3.delete_object(Bucket=bucket, Key=key)
+        self.s3fs.invalidate_cache(path)
+
 
 class LocalFilesystem(FileSystemApi):
     def __init__(self, force_overwrite: bool):
@@ -224,3 +250,12 @@ class LocalFilesystem(FileSystemApi):
 
     def move(self, src_path: str, dest_path: str, **kwargs) -> None:
         shutil.move(src_path, dest_path)
+
+    def rm(self, path: str, recursive: bool = False) -> None:
+        if os.path.isdir(path):
+            if recursive:
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                os.rmdir(path)
+        elif os.path.exists(path):
+            os.remove(path)

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -162,6 +162,35 @@ class AnnotationImporter(BaseImporter):
         }
         self.annotation_metadata = AnnotationMetadata(self.config.fs, self.get_deposition().name, self.metadata)
 
+    @classmethod
+    def pre_import(cls, config: DepositionImportConfig, parents: dict[str, Any]) -> None:
+        """Remove stray (incomplete) annotation folders before importing.
+
+        A completed annotation always writes its `<name>-<version>.json` metadata file last,
+        after the zarr and mrc (see import_item -> convert, then import_metadata). So any
+        annotation_id folder that has content but no `*[0-9].json` is a partial/orphaned write
+        left behind by an interrupted run: it is invisible to id-seeding (which globs the same
+        `*[0-9].json`), lingers forever as a dead folder, and can push the live annotation onto
+        a different id. Delete these before anything is written. Removals are recoverable on
+        versioned buckets. Complete folders (those with a metadata json) are never touched.
+        """
+        voxel_spacing = parents.get("voxel_spacing")
+        if voxel_spacing is None:
+            return
+        anno_glob = config.resolve_output_path("annotation", voxel_spacing, {"annotation_id": "*"})
+        all_folders = set(config.fs.glob(anno_glob))
+        if not all_folders:
+            return
+        complete = {
+            os.path.dirname(path) for path in config.fs.glob(os.path.join(anno_glob, "*[0-9].json"))
+        }
+        for folder in sorted(all_folders - complete):
+            # Only ever touch numeric annotation_id folders.
+            if not os.path.basename(folder).isdigit():
+                continue
+            print(f"Deleting stray annotation folder (no metadata json): {folder}")
+            config.fs.rm(folder, recursive=True)
+
     # Functions to support writing annotation data
     def import_item(self):
         if not self.is_import_allowed():

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -164,15 +164,13 @@ class AnnotationImporter(BaseImporter):
 
     @classmethod
     def pre_import(cls, config: DepositionImportConfig, parents: dict[str, Any]) -> None:
-        """Remove stray (incomplete) annotation folders before importing.
+        """Remove incomplete annotation folders before importing.
 
-        A completed annotation always writes its `<name>-<version>.json` metadata file last,
-        after the zarr and mrc (see import_item -> convert, then import_metadata). So any
-        annotation_id folder that has content but no `*[0-9].json` is a partial/orphaned write
-        left behind by an interrupted run: it is invisible to id-seeding (which globs the same
-        `*[0-9].json`), lingers forever as a dead folder, and can push the live annotation onto
-        a different id. Delete these before anything is written. Removals are recoverable on
-        versioned buckets. Complete folders (those with a metadata json) are never touched.
+        A completed annotation always writes its `<name>-<version>.json` metadata file last
+        (see import_item -> convert, then import_metadata). So any annotation_id folder that
+        has content but no `*[0-9].json` is a partial write left behind by an interrupted run:
+        it is invisible to id-seeding (which globs the same `*[0-9].json`). Delete these before
+        anything is written.
         """
         voxel_spacing = parents.get("voxel_spacing")
         if voxel_spacing is None:
@@ -226,9 +224,7 @@ class AnnotationImporter(BaseImporter):
         path = os.path.relpath(dest_prefix, self.config.output_prefix)
 
         # Several sources can belong to the same logical annotation (same identifier -> same output
-        # path); accumulate their files into one metadata doc as each source is imported, instead of
-        # re-discovering siblings via the finder. Re-running the finder here re-globbed and re-read
-        # every annotation source once per annotation -- O(annotations x sources).
+        # path); accumulate their files into one metadata doc as each source is imported.
         meta = self.identifier_metadata_map.setdefault(
             filename,
             {
@@ -237,7 +233,6 @@ class AnnotationImporter(BaseImporter):
                 "alignment_metadata_path": self.local_metadata["alignment_metadata_path"],
             },
         )
-        # Point this instance at the shared accumulator so local_metadata reflects the written doc.
         self.local_metadata = meta
         meta["files"].extend(self.get_metadata(path))
 

--- a/ingestion_tools/scripts/importers/annotation.py
+++ b/ingestion_tools/scripts/importers/annotation.py
@@ -138,7 +138,13 @@ class AnnotationImporter(BaseImporter):
     has_metadata = True
     dir_path = "{dataset_name}/{run_name}/Reconstructions/VoxelSpacing{voxel_spacing_name}/Annotations/{annotation_id}"
     metadata_path = dir_path
-    written_metadata_files = []  # This is a *class* variable that helps us avoid writing metadata files multiple times.
+
+    # Multiple annotation sources can map to one logical annotation (same identifier -> same output
+    # path) and thus one metadata.json. We accumulate each source's metadata here, keyed by the
+    # fully-qualified output path. Keying by output path -- not the bare identifier, which only counts
+    # up from 100 *per run/voxel-spacing* -- groups sibling sources without colliding across runs or
+    # voxel spacings.
+    identifier_metadata_map: dict[str, dict[str, Any]] = {}
 
     def __init__(
         self,
@@ -170,39 +176,49 @@ class AnnotationImporter(BaseImporter):
         self.config.fs.makedirs(output_dir)
         return self.annotation_metadata.get_filename_prefix(output_dir)
 
+    def get_object_count(self, output_prefix: str) -> int:
+        # To be overridden by subclasses where necessary to return the number of objects in the annotation.
+        return 0
+
+    @abstractmethod
+    def get_metadata(self, output_prefix: str) -> list[dict[str, Any]]:
+        # To be overridden by subclasses to return the metadata for the "files" property of the
+        # annotation metadata, e.g.:
+        # [{"format": FORMAT, "path": OUTPUT_PATH, "shape": SHAPE, "is_visualization_default": BOOL}]
+        pass
+
     def import_metadata(self):
         if not self.is_import_allowed():
             print(f"Skipping import of {self.name} metadata")
             return
+
         dest_prefix = self.get_output_path()
         filename = f"{dest_prefix}.json"
-        if filename in self.written_metadata_files:
-            return  # We've already written this metadata file
+        path = os.path.relpath(dest_prefix, self.config.output_prefix)
 
-        anno_files = [
-            item
-            for item in AnnotationImporter.finder(self.config, **self.parents)
-            if item.identifier == self.identifier
-        ]
-
-        output_dir = self.get_output_path()
-        path = os.path.relpath(output_dir, self.config.output_prefix)
-        files = []
-        for source in anno_files:
-            files.extend(source.get_metadata(path))
+        # Several sources can belong to the same logical annotation (same identifier -> same output
+        # path); accumulate their files into one metadata doc as each source is imported, instead of
+        # re-discovering siblings via the finder. Re-running the finder here re-globbed and re-read
+        # every annotation source once per annotation -- O(annotations x sources).
+        meta = self.identifier_metadata_map.setdefault(
+            filename,
+            {
+                "object_count": 0,
+                "files": [],
+                "alignment_metadata_path": self.local_metadata["alignment_metadata_path"],
+            },
+        )
+        # Point this instance at the shared accumulator so local_metadata reflects the written doc.
+        self.local_metadata = meta
+        meta["files"].extend(self.get_metadata(path))
 
         try:
-            self.local_metadata["object_count"] = max(
-                [anno.get_object_count(output_dir) for anno in anno_files],
-                default=0,
-            )
-            self.local_metadata["files"] = files
+            object_count = self.get_object_count(dest_prefix)
         except FileNotFoundError:
-            print("Skipping metadata write since not all files have been written yet")
-            return
+            object_count = 0
+        meta["object_count"] = max(meta["object_count"], object_count)
 
-        self.written_metadata_files.append(filename)
-        self.annotation_metadata.write_metadata(filename, self.local_metadata)
+        self.annotation_metadata.write_metadata(filename, meta)
 
 
 class BaseAnnotationSource(AnnotationImporter):
@@ -232,19 +248,10 @@ class BaseAnnotationSource(AnnotationImporter):
         # To be overridden by subclasses to handle the import of the annotation.
         pass
 
-    def get_object_count(self, output_prefix: str) -> int:
-        # To be overridden by subclasses where necessary to return the number of objects in the annotation.
-        return 0
-
     def is_valid(self, *args, **kwargs) -> bool:
         # To be overridden by subclasses when additional check needed to validate if a source contains valid information
         # for this run.
         return True
-
-    @abstractmethod
-    def get_metadata(self, output_prefix: str) -> list[dict[str, Any]]:
-        # To be overridden by subclasses to return the metadata for the files property of the metadata.
-        pass
 
     def get_output_filename(self, output_prefix: str, extension: str | None = None) -> str:
         filename = f"{output_prefix}_{self.shape.lower()}"

--- a/ingestion_tools/scripts/importers/base_importer.py
+++ b/ingestion_tools/scripts/importers/base_importer.py
@@ -161,6 +161,14 @@ class BaseImporter:
         return self.allow_imports
 
     @classmethod
+    def pre_import(cls, config: DepositionImportConfig, parents: dict[str, "BaseImporter"]) -> None:
+        """Hook invoked once, before this importer's items are discovered or written for the
+        given parents -- i.e. before the finder runs and before any identifiers are assigned.
+        No-op by default; override to perform pre-import cleanup.
+        """
+        return None
+
+    @classmethod
     def finder(cls, config: DepositionImportConfig, **parents: dict[str, "BaseImporter"]) -> Iterator["BaseImporter"]:
         """
         Finds the importer entities based on the configuration source specified. If no items are found, but a default

--- a/ingestion_tools/scripts/importers/base_importer.py
+++ b/ingestion_tools/scripts/importers/base_importer.py
@@ -163,8 +163,7 @@ class BaseImporter:
     @classmethod
     def pre_import(cls, config: DepositionImportConfig, parents: dict[str, "BaseImporter"]) -> None:
         """Hook invoked once, before this importer's items are discovered or written for the
-        given parents -- i.e. before the finder runs and before any identifiers are assigned.
-        No-op by default; override to perform pre-import cleanup.
+        given parents. No-op by default; override to perform pre-import work.
         """
         return None
 

--- a/ingestion_tools/scripts/standardize_dirs.py
+++ b/ingestion_tools/scripts/standardize_dirs.py
@@ -55,6 +55,12 @@ def do_import(config, tree, to_import, metadata_import, to_iterate, kwargs, pare
         # all ancestors
         parent_args = dict(parents)
 
+        # Pre-import cleanup (e.g. remove stray/incomplete annotation folders left by an
+        # interrupted run) before any items are discovered or identifiers assigned. No-op for
+        # most importers. Only when we're actually (re)writing this entity's data.
+        if import_class in to_import:
+            import_class.pre_import(config, parent_args)
+
         items = import_class.finder(config, **parent_args)
         for item in items:
             print(f"Iterating {item.type_key}: {item.name}")

--- a/ingestion_tools/scripts/standardize_dirs.py
+++ b/ingestion_tools/scripts/standardize_dirs.py
@@ -55,9 +55,6 @@ def do_import(config, tree, to_import, metadata_import, to_iterate, kwargs, pare
         # all ancestors
         parent_args = dict(parents)
 
-        # Pre-import cleanup (e.g. remove stray/incomplete annotation folders left by an
-        # interrupted run) before any items are discovered or identifiers assigned. No-op for
-        # most importers. Only when we're actually (re)writing this entity's data.
         if import_class in to_import:
             import_class.pre_import(config, parent_args)
 

--- a/ingestion_tools/scripts/tests/s3_import/test_annotations.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_annotations.py
@@ -9,6 +9,7 @@ import pytest
 import trimesh
 from importers.annotation import (
     AnnotationCaptionAnnotation,
+    AnnotationImporter,
     GlobalCaptionAnnotation,
     InstanceSegmentationAnnotation,
     InstanceSegmentationMaskAnnotation,
@@ -1911,3 +1912,94 @@ def test_ingest_annotation_caption(
         input_data = json.load(fh)
     assert output_data == input_data
     assert len(output_data["objects"]) == 5
+
+
+# ---------------------------------------------------------------------------
+# AnnotationImporter.pre_import: stray-folder cleanup
+# ---------------------------------------------------------------------------
+
+
+def _anno_key_base(config: DepositionImportConfig, voxel_spacing: VoxelSpacingImporter) -> str:
+    """The `.../Annotations` key prefix (no bucket, no trailing `/*`), derived the same way
+    pre_import does so the test tracks the real (formatted) voxel-spacing path."""
+    anno_glob = config.resolve_output_path("annotation", voxel_spacing, {"annotation_id": "*"})
+    base = anno_glob[:-2] if anno_glob.endswith("/*") else anno_glob
+    return base.split("/", 1)[1]  # drop the bucket component
+
+
+def _put(s3_client: S3Client, bucket: str, key: str, body: bytes = b"x") -> None:
+    s3_client.put_object(Bucket=bucket, Key=key, Body=body)
+
+
+def _remaining_keys(s3_client: S3Client, bucket: str, base: str) -> set[str]:
+    resp = s3_client.list_objects_v2(Bucket=bucket, Prefix=base)
+    return {o["Key"] for o in resp.get("Contents", [])}
+
+
+def test_pre_import_deletes_stray_annotation_folders(
+    deposition_config_s3: DepositionImportConfig,
+    voxel_spacing_importer_s3: VoxelSpacingImporter,
+    s3_client: S3Client,
+    test_output_bucket: str,
+) -> None:
+    base = _anno_key_base(deposition_config_s3, voxel_spacing_importer_s3)
+    # complete folder (has metadata json) -- must survive
+    _put(s3_client, test_output_bucket, f"{base}/100/membrane-1.0.json")
+    _put(s3_client, test_output_bucket, f"{base}/100/membrane-1.0_segmentationmask.mrc")
+    _put(s3_client, test_output_bucket, f"{base}/100/membrane-1.0_segmentationmask.zarr/.zattrs")
+    # stray folder (zarr + mrc, NO metadata json) -- the interrupted-write signature -- must be deleted
+    _put(s3_client, test_output_bucket, f"{base}/123/fen1-1.0_instancesegmentationmask.zarr/.zgroup")
+    _put(s3_client, test_output_bucket, f"{base}/123/fen1-1.0_instancesegmentationmask.mrc")
+    # complete folder whose json happens to sort/glob next to the stray -- must survive
+    _put(s3_client, test_output_bucket, f"{base}/125/fen1-1.0.json")
+    # non-numeric child under Annotations/ -- never touched
+    _put(s3_client, test_output_bucket, f"{base}/notanid/something.json")
+
+    parents = {"voxel_spacing": voxel_spacing_importer_s3, **voxel_spacing_importer_s3.parents}
+    AnnotationImporter.pre_import(deposition_config_s3, parents)
+
+    remaining = _remaining_keys(s3_client, test_output_bucket, base)
+    assert f"{base}/100/membrane-1.0.json" in remaining
+    assert f"{base}/100/membrane-1.0_segmentationmask.mrc" in remaining
+    assert f"{base}/125/fen1-1.0.json" in remaining
+    assert f"{base}/notanid/something.json" in remaining
+    # the entire stray folder is gone
+    assert not any(k.startswith(f"{base}/123/") for k in remaining)
+
+
+def test_pre_import_keeps_complete_folder_with_broken_zarr(
+    deposition_config_s3: DepositionImportConfig,
+    voxel_spacing_importer_s3: VoxelSpacingImporter,
+    s3_client: S3Client,
+    test_output_bucket: str,
+) -> None:
+    base = _anno_key_base(deposition_config_s3, voxel_spacing_importer_s3)
+    # A folder with a metadata json but a zarr missing .zattrs is "complete" by our rule
+    # (json present) and must NOT be deleted -- it will be overwritten on re-import instead.
+    _put(s3_client, test_output_bucket, f"{base}/100/membrane-1.0.json")
+    _put(s3_client, test_output_bucket, f"{base}/100/membrane-1.0_segmentationmask.zarr/.zgroup")
+
+    parents = {"voxel_spacing": voxel_spacing_importer_s3, **voxel_spacing_importer_s3.parents}
+    AnnotationImporter.pre_import(deposition_config_s3, parents)
+
+    remaining = _remaining_keys(s3_client, test_output_bucket, base)
+    assert f"{base}/100/membrane-1.0.json" in remaining
+    assert f"{base}/100/membrane-1.0_segmentationmask.zarr/.zgroup" in remaining
+
+
+def test_pre_import_noop_when_all_complete(
+    deposition_config_s3: DepositionImportConfig,
+    voxel_spacing_importer_s3: VoxelSpacingImporter,
+    s3_client: S3Client,
+    test_output_bucket: str,
+) -> None:
+    base = _anno_key_base(deposition_config_s3, voxel_spacing_importer_s3)
+    for i in (100, 101, 102):
+        _put(s3_client, test_output_bucket, f"{base}/{i}/obj-1.0.json")
+        _put(s3_client, test_output_bucket, f"{base}/{i}/obj-1.0_segmentationmask.mrc")
+    before = _remaining_keys(s3_client, test_output_bucket, base)
+
+    parents = {"voxel_spacing": voxel_spacing_importer_s3, **voxel_spacing_importer_s3.parents}
+    AnnotationImporter.pre_import(deposition_config_s3, parents)
+
+    assert _remaining_keys(s3_client, test_output_bucket, base) == before

--- a/ingestion_tools/scripts/tests/s3_import/test_fs.py
+++ b/ingestion_tools/scripts/tests/s3_import/test_fs.py
@@ -1,0 +1,58 @@
+from common.fs import FileSystemApi
+
+
+def _keys(s3_client, bucket: str) -> set[str]:
+    resp = s3_client.list_objects_v2(Bucket=bucket)
+    return {o["Key"] for o in resp.get("Contents", [])}
+
+
+def test_rm_s3_recursive_deletes_only_the_prefix(s3_fs: FileSystemApi, s3_client, test_output_bucket: str) -> None:
+    keys = [
+        "ds/Annotations/123/a.zarr/.zgroup",
+        "ds/Annotations/123/a.zarr/0/0/0",
+        "ds/Annotations/123/foo[1].mrc",  # glob metachars must be deleted as a literal
+        "ds/Annotations/124/keep.json",  # sibling -- must survive
+        "ds/Annotations/1234/keep.json",  # prefix-overlap -- must survive (trailing-slash guard)
+    ]
+    for k in keys:
+        s3_client.put_object(Bucket=test_output_bucket, Key=k, Body=b"x")
+
+    s3_fs.rm(f"{test_output_bucket}/ds/Annotations/123", recursive=True)
+
+    assert _keys(s3_client, test_output_bucket) == {
+        "ds/Annotations/124/keep.json",
+        "ds/Annotations/1234/keep.json",
+    }
+
+
+def test_rm_s3_single_object(s3_fs: FileSystemApi, s3_client, test_output_bucket: str) -> None:
+    s3_client.put_object(Bucket=test_output_bucket, Key="ds/x.json", Body=b"x")
+    s3_client.put_object(Bucket=test_output_bucket, Key="ds/y.json", Body=b"y")
+
+    s3_fs.rm(f"{test_output_bucket}/ds/x.json")
+
+    assert _keys(s3_client, test_output_bucket) == {"ds/y.json"}
+
+
+def test_rm_local_recursive(local_fs: FileSystemApi, tmp_path) -> None:
+    folder = tmp_path / "123"
+    (folder / "a.zarr" / "0").mkdir(parents=True)
+    (folder / "a.zarr" / ".zgroup").write_text("{}")
+    (folder / "a.zarr" / "0" / "0").write_text("x")
+    sibling = tmp_path / "124"
+    sibling.mkdir()
+    (sibling / "keep.json").write_text("{}")
+
+    local_fs.rm(str(folder), recursive=True)
+
+    assert not folder.exists()
+    assert (sibling / "keep.json").exists()
+
+
+def test_rm_local_single_file(local_fs: FileSystemApi, tmp_path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text("{}")
+
+    local_fs.rm(str(f))
+
+    assert not f.exists()


### PR DESCRIPTION
To be merged in after #719, before #676.

When an ingestion run is interrupted mid-write (most commonly an AWS spot instance being reclaimed), it can leave a partially-written annotation folder behind. The Step Functions/Batch retry then re-runs the whole standardization, but the orphaned folder is never cleaned up — the ingestion pipeline is append/overwrite-only and has no delete capability at all today.

This shows up in two ways:
- Interrupted zarr write (e.g. `10490/sample_300/.../Annotations/123`): the folder has zarr chunks + `.zgroup` but no `.zattrs`, no `.mrc`, and no metadata `.json`.
- Interrupted later in the per-annotation sequence (e.g. `10492/.../Annotations/129`): the folder has a complete zarr + `.zattrs` + `.mrc` but still no metadata `.json` (the crash landed during the Neuroglancer step, before `import_metadata`).

### Why the orphan gets stranded (and renumbers the live annotation)

Annotation folder numbers come from `AnnotationIdentifierHelper`, which seeds itself by globbing existing `*[0-9].json` files (`id_helper.py:_load_ids_for_container`). A folder written by the killed attempt has no `.json`, so it is invisible to the retry's id-seeding. The retry therefore: (1) cannot see the partial folder, so it never reuses or overwrites it, and (2) assigns the re-discovered annotation a fresh id, writing a complete copy at a new number — leaving the partial folder behind as permanent dead weight. The overall execution reports SUCCEEDED, so this is silent. The orphaned folders are never picked up by the DB loader (it keys off the `.json`), but they pollute the bucket and fail annotation-integrity checks.

## What this PR does

Adds a pre-import cleanup step to the annotation importer: before anything is written (before the finder runs and before any identifiers are assigned), it removes stray annotation folders. A folder is considered stray iff it is a numeric `annotation_id` folder with no `*[0-9].json` metadata file. Because a completed annotation always writes its `<name>-<version>.json` last (after zarr + mrc), the absence of that json is a reliable signal of a partial/orphaned write. This makes orphans transient: each attempt removes the previous attempt's partial folder, and the final successful attempt cleans up and writes nothing partial — so the end state is always clean.

### Scope / safety
- Only ever deletes incomplete folders. Complete folders (those with a metadata json) are never touched — even ones the current run wouldn't re-create — so this is safe under `--filter-*` runs and multi-deposition buckets.
- Numbering-neutral. Incomplete folders have no json, so they were already invisible to id-seeding; removing them does not change id assignment for any run.
- Delete, not quarantine. The target buckets are versioned, so deletes write recoverable delete-markers — S3 versioning is the safety net, with no `_quarantine/` prefix to manage.
- Bracket-safe deletes. The S3 delete uses boto3 `delete_objects` over keys listed by a literal prefix, avoiding fsspec's glob-expansion path that breaks on filenames containing `[]` (the same reason `S3Filesystem.copy` already bypasses fsspec).
- Always on. Runs whenever annotation data is being imported; no flag.

## Changes
- `common/fs.py`: new `rm(path, recursive=False)` on `FileSystemApi` (abstract). `S3Filesystem.rm` uses boto3 `delete_objects` in batches of 1000 over a literal prefix, then invalidates the s3fs listing cache. `LocalFilesystem.rm` uses `shutil.rmtree` / `os.remove`.
- `importers/base_importer.py`: new `pre_import(config, parents)` classmethod hook (no-op by default), documented to run before discovery/id-assignment.
- `importers/annotation.py`: `AnnotationImporter.pre_import` globs `Annotations/*`, deletes numeric id-folders that lack a `*[0-9].json`, logging each deletion.
- `standardize_dirs.py`: `do_import` calls `import_class.pre_import(config, parent_args)` before consuming the finder, guarded by `if import_class in to_import`.

## Out of scope (intentionally)
- The +N folder-number shift. A phantom annotation (one that fails `is_valid()`, e.g. an empty mask) consumes an id without writing a folder; on a retry this can shift the live annotation's number. The resulting gaps are harmless, and fixing the shift is a separate change (assign the id only after `is_valid()`). This PR removes the orphan; it does not re-align numbering.
- Stale-mix where a stale `.json` is present next to a newly-rewritten zarr (only on a re-run that overwrites in place). That folder looks complete, so it is left alone here; it self-heals on the next successful re-import and would otherwise need a content/consistency check.
- Complete folders that no current annotation maps to (only arise from a source-data / config change that alters an annotation's identity hash) — deliberately never deleted.

## Testing
- `tests/s3_import/test_fs.py` (new): S3 recursive delete (including a `foo[1].mrc` bracket key and a `1234/` prefix-overlap sibling that must survive), S3 single-object delete, local recursive delete, local single-file delete.
- `tests/s3_import/test_annotations.py` (added): `pre_import` deletes a stray folder while keeping complete and non-numeric siblings; keeps a complete folder whose zarr is broken (json present); is a no-op when everything is complete.
- All new tests pass against the moto-backed harness.
