### PR TITLE
fix: revert 10430 ingestion config to original pre-reprocessing data

### DIFF
--- a/ingestion_tools/dataset_configs/10430.yaml
+++ b/ingestion_tools/dataset_configs/10430.yaml
@@ -1,22 +1,17 @@
 alignments:
 - metadata:
-    format: ARETOMO3
-    is_portal_standard: true
+    format: IMOD
     method_type: fiducial_based
   sources:
-  - source_glob:
-      list_glob: reprocessed/{run_name}_*/{run_name}_*.aln
+  - source_multi_glob:
+      list_globs:
+      - alignmentfiles/{run_name}_fid.tlt
+      - alignmentfiles/{run_name}_fid.xf
 annotations: []
 collection_metadata:
 - sources:
   - source_glob:
       list_glob: mdocs/{mdoc_name}
-ctfs:
-- metadata:
-    format: CTFFIND
-  sources:
-  - source_glob:
-      list_glob: reprocessed/{run_name}_*/{run_name}_*_CTF.txt
 datasets:
 - metadata:
     assay:
@@ -122,7 +117,7 @@ standardization_config:
 tiltseries:
 - metadata:
     acceleration_voltage: 300000
-    binning_from_frames: 2
+    binning_from_frames: 1
     camera:
       manufacturer: Gatan
       model: K3
@@ -133,7 +128,7 @@ tiltseries:
       model: TITAN KRIOS
     microscope_optical_setup:
       energy_filter: Gatan Bioquantum
-    pixel_spacing: 2.165
+    pixel_spacing: 1.0825
     spherical_aberration_constant: 2.7
     tilt_axis: 176.0
     tilt_range:
@@ -145,8 +140,8 @@ tiltseries:
     total_flux: float {tilt_series_total_flux}
   sources:
   - source_glob:
-      list_glob: reprocessed/{run_name}_*/{run_name}_*.mrc
-      match_regex: ^.*_[0-9]+\.mrc$
+      list_glob: tiltseries/{run_name}.mrc
+      match_regex: ^.*\.mrc$
 tomograms:
 - metadata:
     affine_transformation_matrix:
@@ -166,12 +161,8 @@ tomograms:
       - 0
       - 0
       - 1
-    authors:
-    - ORCID: 0000-0002-8063-6951
-      corresponding_author_status: true
-      name: Jonathan Schwartz
-      primary_author_status: true
-    ctf_corrected: true
+    authors: *id001
+    ctf_corrected: false
     dates: *id002
     fiducial_alignment_status: FIDUCIAL
     is_visualization_default: true
@@ -179,98 +170,18 @@ tomograms:
       x: 0
       y: 0
       z: 0
-    processing: filtered
-    reconstruction_method: WBP
-    reconstruction_software: AreTomo3 v2.1.10
-    tomogram_version: 1
-    voxel_spacing: 8.66
-  sources:
-  - source_glob:
-      list_glob: reprocessed/{run_name}_*/{run_name}_*_ts_Vol.mrc
-      match_regex: (.*)\.mrc
-- metadata:
-    affine_transformation_matrix:
-    - - 1
-      - 0
-      - 0
-      - 0
-    - - 0
-      - 1
-      - 0
-      - 0
-    - - 0
-      - 0
-      - 1
-      - 0
-    - - 0
-      - 0
-      - 0
-      - 1
-    authors:
-    - ORCID: 0000-0002-8063-6951
-      corresponding_author_status: true
-      name: Jonathan Schwartz
-      primary_author_status: true
-    ctf_corrected: false
-    dates: *id002
-    fiducial_alignment_status: FIDUCIAL
-    is_visualization_default: false
-    offset:
-      x: 0
-      y: 0
-      z: 0
     processing: raw
-    reconstruction_method: WBP
-    reconstruction_software: AreTomo3 v2.1.10
+    reconstruction_method: SIRT
+    reconstruction_software: IMOD
     tomogram_version: 1
-    voxel_spacing: 8.66
+    voxel_spacing: 10.825
   sources:
   - source_glob:
-      list_glob: reprocessed/{run_name}_*/{run_name}_*_ts_2ND_Vol.mrc
-      match_regex: (.*)\.mrc
-- metadata:
-    affine_transformation_matrix:
-    - - 1
-      - 0
-      - 0
-      - 0
-    - - 0
-      - 1
-      - 0
-      - 0
-    - - 0
-      - 0
-      - 1
-      - 0
-    - - 0
-      - 0
-      - 0
-      - 1
-    authors:
-    - ORCID: 0000-0002-8063-6951
-      corresponding_author_status: true
-      name: Jonathan Schwartz
-      primary_author_status: true
-    ctf_corrected: false
-    dates: *id002
-    fiducial_alignment_status: FIDUCIAL
-    is_visualization_default: false
-    offset:
-      x: 0
-      y: 0
-      z: 0
-    processing: raw
-    reconstruction_method: SART
-    reconstruction_software: AreTomo3 v2.1.10
-    tomogram_version: 1
-    voxel_spacing: 8.66
-  sources:
-  - source_glob:
-      list_glob: reprocessed/{run_name}_*/{run_name}_*_ts_3RD_Vol.mrc
+      list_glob: tomograms_bin10/{run_name}_b10_rec.mrc
       match_regex: (.*)\.mrc
 version: 1.3.0
 voxel_spacings:
 - sources:
   - literal:
       value:
-      - 8.66
+      - 10.825


### PR DESCRIPTION
Reverts the `10430.yaml` ingestion config to its pre-#727 (pre-AreTomo3-reprocessing) state.
The reprocessed tomograms were bad; staging + prod data have been reverted and reingested.

https://github.com/chanzuckerberg/cryoet-data-portal-backend/compare/a89c46d4931bf38b651c4e0797ca46c7520eb2b5...daniel-ji/revert-10430