### PR TITLE
feat: add 'simulated' to alignment method type enum

### DIFF
--- a/apiv2/graphql_api/schema.graphql
+++ b/apiv2/graphql_api/schema.graphql
@@ -7120,6 +7120,7 @@ enum alignment_method_type_enum {
   projection_matching
   patch_tracking
   fiducial_based
+  simulated
 }
 
 enum alignment_type_enum {

--- a/apiv2/schema/schema.yaml
+++ b/apiv2/schema/schema.yaml
@@ -245,6 +245,8 @@ enums:
         description: Alignment was generated via IMOD without fiducials
       fiducial_based:
         description: Alignment was generated based on fiducials
+      simulated:
+        description: Alignment is derived from the known geometry of a simulated tilt series
   annotation_method_type_enum:
     name: annotation_method_type_enum
     description: Describes how the annotations were generated.

--- a/apiv2/support/enums.py
+++ b/apiv2/support/enums.py
@@ -22,6 +22,7 @@ class alignment_method_type_enum(enum.StrEnum):
     projection_matching = "projection_matching"
     patch_tracking = "patch_tracking"
     fiducial_based = "fiducial_based"
+    simulated = "simulated"
 
 
 @strawberry.enum

--- a/apiv2/test_infra/factories/alignment.py
+++ b/apiv2/test_infra/factories/alignment.py
@@ -41,7 +41,7 @@ class AlignmentFactory(CommonFactory):
         RunFactory,
     )
     alignment_type = fuzzy.FuzzyChoice(["LOCAL", "GLOBAL"])
-    alignment_method = fuzzy.FuzzyChoice(["projection_matching", "patch_tracking", "fiducial_based"])
+    alignment_method = fuzzy.FuzzyChoice(["projection_matching", "patch_tracking", "fiducial_based", "simulated"])
     volume_x_dimension = fuzzy.FuzzyFloat(1, 100)
     volume_y_dimension = fuzzy.FuzzyFloat(1, 100)
     volume_z_dimension = fuzzy.FuzzyFloat(1, 100)

--- a/schema/core/v2.0.0/codegen/metadata_materialized.yaml
+++ b/schema/core/v2.0.0/codegen/metadata_materialized.yaml
@@ -517,6 +517,10 @@ enums:
       projection_matching:
         text: projection_matching
         description: alignment was done based on image projection
+      simulated:
+        text: simulated
+        description: alignment is derived from the known geometry of a simulated tilt
+          series
       undefined:
         text: undefined
         description: how alignment was done is unknown
@@ -5751,7 +5755,7 @@ classes:
         range: alignment_method_type_enum
         inlined: true
         inlined_as_list: true
-        pattern: (^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^undefined$)
+        pattern: (^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^simulated$)|(^undefined$)
   Frame:
     name: Frame
     description: A frame entity.

--- a/schema/core/v2.0.0/codegen/metadata_models.py
+++ b/schema/core/v2.0.0/codegen/metadata_models.py
@@ -687,6 +687,10 @@ class AlignmentMethodTypeEnum(str, Enum):
     """
     alignment was done based on image projection
     """
+    simulated = "simulated"
+    """
+    alignment is derived from the known geometry of a simulated tilt series
+    """
     undefined = "undefined"
     """
     how alignment was done is unknown
@@ -5922,7 +5926,9 @@ class Alignment(ConfiguredBaseModel):
 
     @field_validator("method_type")
     def pattern_method_type(cls, v):
-        pattern = re.compile(r"(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^undefined$)")
+        pattern = re.compile(
+            r"(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^simulated$)|(^undefined$)"
+        )
         if isinstance(v, list):
             for element in v:
                 if isinstance(element, str) and not pattern.match(element):

--- a/schema/core/v2.0.0/common.yaml
+++ b/schema/core/v2.0.0/common.yaml
@@ -1296,6 +1296,8 @@ enums:
         description: alignment was done based on patch tracking
       projection_matching:
         description: alignment was done based on image projection
+      simulated:
+        description: alignment is derived from the known geometry of a simulated tilt series
       undefined:
         description: how alignment was done is unknown
 

--- a/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.py
+++ b/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.py
@@ -568,6 +568,10 @@ class AlignmentMethodTypeEnum(str, Enum):
     """
     alignment was done based on image projection
     """
+    simulated = "simulated"
+    """
+    alignment is derived from the known geometry of a simulated tilt series
+    """
     undefined = "undefined"
     """
     how alignment was done is unknown
@@ -3696,7 +3700,7 @@ class Alignment(ConfiguredBaseModel):
 
     @field_validator('method_type')
     def pattern_method_type(cls, v):
-        pattern=re.compile(r"(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^undefined$)")
+        pattern=re.compile(r"(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^simulated$)|(^undefined$)")
         if isinstance(v, list):
             for element in v:
                 if isinstance(element, str) and not pattern.match(element):

--- a/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.schema.json
+++ b/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models.schema.json
@@ -41,7 +41,7 @@
                 "method_type": {
                     "$ref": "#/$defs/AlignmentMethodTypeEnum",
                     "description": "The alignment method type.",
-                    "pattern": "(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^undefined$)"
+                    "pattern": "(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^simulated$)|(^undefined$)"
                 },
                 "tilt_offset": {
                     "description": "The tilt offset relative to the tomogram.",
@@ -139,6 +139,7 @@
                 "fiducial_based",
                 "patch_tracking",
                 "projection_matching",
+                "simulated",
                 "undefined"
             ],
             "title": "AlignmentMethodTypeEnum",

--- a/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models_materialized.yaml
+++ b/schema/ingestion_config/v1.0.0/codegen/ingestion_config_models_materialized.yaml
@@ -501,6 +501,10 @@ enums:
       projection_matching:
         text: projection_matching
         description: alignment was done based on image projection
+      simulated:
+        text: simulated
+        description: alignment is derived from the known geometry of a simulated tilt
+          series
       undefined:
         text: undefined
         description: how alignment was done is unknown

--- a/schema/metadata_files/v2.0.0/codegen/metadata_files.py
+++ b/schema/metadata_files/v2.0.0/codegen/metadata_files.py
@@ -578,6 +578,10 @@ class AlignmentMethodTypeEnum(str, Enum):
     """
     alignment was done based on image projection
     """
+    simulated = "simulated"
+    """
+    alignment is derived from the known geometry of a simulated tilt series
+    """
     undefined = "undefined"
     """
     how alignment was done is unknown
@@ -3832,7 +3836,7 @@ class Alignment(ConfiguredBaseModel):
 
     @field_validator('method_type')
     def pattern_method_type(cls, v):
-        pattern=re.compile(r"(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^undefined$)")
+        pattern=re.compile(r"(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^simulated$)|(^undefined$)")
         if isinstance(v, list):
             for element in v:
                 if isinstance(element, str) and not pattern.match(element):
@@ -4230,7 +4234,7 @@ class AlignmentMetadata(DefaultMetadata, Alignment):
 
     @field_validator('method_type')
     def pattern_method_type(cls, v):
-        pattern=re.compile(r"(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^undefined$)")
+        pattern=re.compile(r"(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^simulated$)|(^undefined$)")
         if isinstance(v, list):
             for element in v:
                 if isinstance(element, str) and not pattern.match(element):

--- a/schema/metadata_files/v2.0.0/codegen/metadata_files.schema.json
+++ b/schema/metadata_files/v2.0.0/codegen/metadata_files.schema.json
@@ -41,7 +41,7 @@
                 "method_type": {
                     "$ref": "#/$defs/AlignmentMethodTypeEnum",
                     "description": "The alignment method type.",
-                    "pattern": "(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^undefined$)"
+                    "pattern": "(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^simulated$)|(^undefined$)"
                 },
                 "tilt_offset": {
                     "description": "The tilt offset relative to the tomogram.",
@@ -170,7 +170,7 @@
                 "method_type": {
                     "$ref": "#/$defs/AlignmentMethodTypeEnum",
                     "description": "The alignment method type.",
-                    "pattern": "(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^undefined$)"
+                    "pattern": "(^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^simulated$)|(^undefined$)"
                 },
                 "per_section_alignment_parameters": {
                     "description": "Alignment parameters for one section of a tilt series.",
@@ -262,6 +262,7 @@
                 "fiducial_based",
                 "patch_tracking",
                 "projection_matching",
+                "simulated",
                 "undefined"
             ],
             "title": "AlignmentMethodTypeEnum",

--- a/schema/metadata_files/v2.0.0/codegen/metadata_files_materialized.yaml
+++ b/schema/metadata_files/v2.0.0/codegen/metadata_files_materialized.yaml
@@ -516,6 +516,10 @@ enums:
       projection_matching:
         text: projection_matching
         description: alignment was done based on image projection
+      simulated:
+        text: simulated
+        description: alignment is derived from the known geometry of a simulated tilt
+          series
       undefined:
         text: undefined
         description: how alignment was done is unknown
@@ -1187,7 +1191,7 @@ classes:
         range: alignment_method_type_enum
         inlined: true
         inlined_as_list: true
-        pattern: (^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^undefined$)
+        pattern: (^fiducial_based$)|(^patch_tracking$)|(^projection_matching$)|(^simulated$)|(^undefined$)
   AnnotationFileMetadata:
     name: AnnotationFileMetadata
     description: Metadata relating to an annotation file.


### PR DESCRIPTION
Add `simulated` as a permissible value of `alignment_method_type_enum`.