### PR TITLE
fix: make angle validation mod 360

### DIFF
--- a/ingestion_tools/scripts/data_validation/shared/helper/tiltseries_helper.py
+++ b/ingestion_tools/scripts/data_validation/shared/helper/tiltseries_helper.py
@@ -9,6 +9,16 @@ from data_validation.shared.helper.helper_mrc_zarr import HelperTestMRCZarrHeade
 
 TILT_AXIS_ANGLE_REGEX = re.compile(r".*tilt\s*axis\s*angle\s*=\s*([-+]?(?:\d*\.*\d+))")
 
+
+def assert_angle_in_valid_range(angle: float, label: str) -> None:
+    assert -360 <= angle <= 360, f"{label} {angle} is outside the valid range [-360, 360]."
+
+
+def angular_difference(a: float, b: float) -> float:
+    """Smallest absolute difference between two angles (degrees), wrapping around 360. Result in [0, 180]."""
+    diff = abs(a - b) % 360
+    return min(diff, 360 - diff)
+
 class TiltSeriesHelper(HelperTestMRCZarrHeader):
     @pytest.fixture
     def mdoc_tilt_axis_angle(self, mdoc_data: pd.DataFrame) -> float:
@@ -35,6 +45,8 @@ class TiltSeriesHelper(HelperTestMRCZarrHeader):
     @allure.title("Tiltseries: tilt axis angle in mdoc file matches that in tilt series metadata (+/- 10 deg).")
     def test_tilt_axis_angle(self, mdoc_tilt_axis_angle: float, tiltseries_metadata: dict[str, Any]):
         metadata_tilt_axis = tiltseries_metadata["tilt_axis"]
-        assert abs(metadata_tilt_axis - mdoc_tilt_axis_angle) <= 10, (
+        assert_angle_in_valid_range(mdoc_tilt_axis_angle, "Mdoc tilt axis angle")
+        assert_angle_in_valid_range(metadata_tilt_axis, "Metadata tilt axis angle")
+        assert angular_difference(metadata_tilt_axis, mdoc_tilt_axis_angle) <= 10, (
             f"Tilt axis angle mismatch: MDOC: {mdoc_tilt_axis_angle} vs Metadata: {metadata_tilt_axis}"
         )

--- a/ingestion_tools/scripts/data_validation/standardized/tests/test_alignments.py
+++ b/ingestion_tools/scripts/data_validation/standardized/tests/test_alignments.py
@@ -5,7 +5,11 @@ import allure
 import numpy as np
 import pandas as pd
 import pytest
-from data_validation.shared.helper.tiltseries_helper import TILT_AXIS_ANGLE_REGEX
+from data_validation.shared.helper.tiltseries_helper import (
+    TILT_AXIS_ANGLE_REGEX,
+    angular_difference,
+    assert_angle_in_valid_range,
+)
 
 
 def matrix_to_angle(matrix: list[list[float]]) -> float:
@@ -100,8 +104,12 @@ class TestAlignments:
         per_section_alignment_parameters = alignment_metadata.get("per_section_alignment_parameters")
         if not per_section_alignment_parameters:
             pytest.skip("Alignment metadata missing per_section_alignment_parameters.")
-        # convert all in_plane_rotation matrices to angles and check against mdoc_tilt_axis_angle
+        # convert all in_plane_rotation matrices to angles and check against mdoc_tilt_axis_angle.
+        # Angles wrap around 360 (e.g. mdoc -184 deg == in_plane 175 deg), so compare circularly.
         in_plane_rotations = [matrix_to_angle(psap["in_plane_rotation"]) for psap in per_section_alignment_parameters]
-        assert all(in_plane_rotation == pytest.approx(mdoc_tilt_axis_angle, abs=10) for in_plane_rotation in in_plane_rotations), f"Mdoc tilt axis angle {mdoc_tilt_axis_angle} does not match all alignment metadata in_plane_rotation angles within +/- 10 degrees: {in_plane_rotations}"
+        assert_angle_in_valid_range(mdoc_tilt_axis_angle, "Mdoc tilt axis angle")
+        for in_plane_rotation in in_plane_rotations:
+            assert_angle_in_valid_range(in_plane_rotation, "Alignment in_plane_rotation angle")
+        assert all(angular_difference(in_plane_rotation, mdoc_tilt_axis_angle) <= 10 for in_plane_rotation in in_plane_rotations), f"Mdoc tilt axis angle {mdoc_tilt_axis_angle} does not match all alignment metadata in_plane_rotation angles within +/- 10 degrees: {in_plane_rotations}"
 
     ### END Tiltseries consistency tests ###


### PR DESCRIPTION
when validating angles correspond between mdoc files, alignment metadata, tiltseries metadata, allow for angles to match if off by 360 deg (only allow them to be [-360, 360] though).
