### PR TITLE
fix: correct AreTomo3 alignment_type LOCAL -> GLOBAL (19 configs)

### DIFF
--- a/ingestion_tools/dataset_configs/10311_draft.yaml
+++ b/ingestion_tools/dataset_configs/10311_draft.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10444.yaml
+++ b/ingestion_tools/dataset_configs/10444.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10448.yaml
+++ b/ingestion_tools/dataset_configs/10448.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10449.yaml
+++ b/ingestion_tools/dataset_configs/10449.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10450.yaml
+++ b/ingestion_tools/dataset_configs/10450.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10451.yaml
+++ b/ingestion_tools/dataset_configs/10451.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10457.yaml
+++ b/ingestion_tools/dataset_configs/10457.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10458.yaml
+++ b/ingestion_tools/dataset_configs/10458.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10459.yaml
+++ b/ingestion_tools/dataset_configs/10459.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10460.yaml
+++ b/ingestion_tools/dataset_configs/10460.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10461.yaml
+++ b/ingestion_tools/dataset_configs/10461.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10462.yaml
+++ b/ingestion_tools/dataset_configs/10462.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10463.yaml
+++ b/ingestion_tools/dataset_configs/10463.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10464.yaml
+++ b/ingestion_tools/dataset_configs/10464.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10465.yaml
+++ b/ingestion_tools/dataset_configs/10465.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10466.yaml
+++ b/ingestion_tools/dataset_configs/10466.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10467.yaml
+++ b/ingestion_tools/dataset_configs/10467.yaml
@@ -1,6 +1,6 @@
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10475.yaml
+++ b/ingestion_tools/dataset_configs/10475.yaml
@@ -305,7 +305,7 @@ annotations:
 
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching

--- a/ingestion_tools/dataset_configs/10476.yaml
+++ b/ingestion_tools/dataset_configs/10476.yaml
@@ -275,7 +275,7 @@ annotations:
 
 alignments:
 - metadata:
-    alignment_type: LOCAL
+    alignment_type: GLOBAL
     format: ARETOMO3
     is_portal_standard: true
     method_type: projection_matching


### PR DESCRIPTION
## Description

Corrects `alignments.metadata.alignment_type` from `LOCAL` to `GLOBAL` for 19 AreTomo3-based dataset configs whose alignments are actually global-only.

### Why

These configs declare `alignment_type: LOCAL` with `format: ARETOMO3`, but the AreTomo3 `.aln` files for every affected dataset have `NumPatches = 0` - meaning no local (patch) alignment was performed.

Per the AreTomo3 manual (section 5.5, "Alignment file"):
- "When the local alignment is enabled with `-AtPatch`, the aln file has two sections, one for global and one for local alignment. Otherwise, only global section is present."
- "`# NumPatch` indicates number of patches used in local alignment."
- "`-AtPatch 4 4` invokes 4x4 patch-based local alignment after global tilt series alignment."

So `NumPatches = 0` = no `-AtPatch` = global-only alignment, which should be recorded as `GLOBAL`. The importer's own default for `alignment_type` is `GLOBAL`.

### Scope / verification

Scanned all merged configs: 49 use AreTomo alignments, 33 declared `LOCAL`. Each `LOCAL` candidate was verified by reading `# NumPatches` from sampled `.aln` files:
- 19 read `NumPatches = 0` -> mislabeled, fixed here.
- 14 read `NumPatches > 0` (mostly 16 = `-AtPatch 4 4`, one 9) -> legitimately LOCAL, left unchanged.

The split is clean per dataset (0 vs 16), consistent with a per-dataset AreTomo3 patch setting.

Affected datasets: 10444, 10448, 10449, 10450, 10451, 10457, 10458, 10459, 10460, 10461, 10462, 10463, 10464, 10465, 10466, 10467, 10475, 10476, and 10311_draft.

Note: 18 of these are already ingested on production; they will need an alignment metadata re-ingest to reflect the corrected value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
